### PR TITLE
Fix play/pause on audio played first time

### DIFF
--- a/Quran/QueuePlayer.swift
+++ b/Quran/QueuePlayer.swift
@@ -120,7 +120,6 @@ class QueuePlayer: NSObject {
 
         rateObserver = observe(retainedObservable: player, keyPath: "rate", options: [.New]) { [weak self] (observable, change: ChangeData<Float>) in
             self?.updatePlayNowInfo()
-            self?.onPlaybackRateChanged?(playing: change.newValue != 0)
         }
 
         // enqueue new items


### PR DESCRIPTION
https://github.com/quran/quran-ios/issues/41

I am not for removing the line of code, however I did see removing it.
1. Doesn't change existing functionality 
2. Fixes the issue

onPlaybackPaused was getting called right after onPlaybackResumed because the deleted line of code.
