### PR TITLE
Fastlane Integration + Incrementing version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,6 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
-
+fastlane/Appfile
+fastlane/report.xml
+fastlane/README.md

--- a/Quran.xcodeproj/project.pbxproj
+++ b/Quran.xcodeproj/project.pbxproj
@@ -1787,6 +1787,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = MKP73M5X4A;
 				INFOPLIST_FILE = Quran/Info.plist;
@@ -1811,6 +1812,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = MKP73M5X4A;
 				INFOPLIST_FILE = Quran/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;

--- a/Quran.xcodeproj/project.pbxproj
+++ b/Quran.xcodeproj/project.pbxproj
@@ -1789,7 +1789,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = MKP73M5X4A;
 				INFOPLIST_FILE = Quran/Info.plist;
@@ -1814,7 +1814,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = MKP73M5X4A;
 				INFOPLIST_FILE = Quran/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.1;

--- a/Quran.xcodeproj/project.pbxproj
+++ b/Quran.xcodeproj/project.pbxproj
@@ -1220,8 +1220,8 @@
 				54B265DF1CC57D8E00D3AEF8 /* Sources */,
 				54B265E01CC57D8E00D3AEF8 /* Frameworks */,
 				54B265E11CC57D8E00D3AEF8 /* Resources */,
-				54B266481CC81D6500D3AEF8 /* ShellScript */,
-				54A99CB41CF7BDF2003995AE /* ShellScript */,
+				54B266481CC81D6500D3AEF8 /* Swiftlint Run Script */,
+				54A99CB41CF7BDF2003995AE /* Fabric Run Script */,
 				A7C0CB29E29693C884F7AE27 /* [CP] Embed Pods Frameworks */,
 				B40DC3187BCD4205782A7E54 /* [CP] Copy Pods Resources */,
 			);
@@ -1320,26 +1320,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		54A99CB41CF7BDF2003995AE /* ShellScript */ = {
+		54A99CB41CF7BDF2003995AE /* Fabric Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Fabric Run Script";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Fabric/run\" 9d14e32641d4697dc9516655505b19a7b3d91747 2c77b30cb2574beb030dae483b3b4effcff2475154a8d503c86728fa9ab13393";
 		};
-		54B266481CC81D6500D3AEF8 /* ShellScript */ = {
+		54B266481CC81D6500D3AEF8 /* Swiftlint Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Swiftlint Run Script";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Quran.xcworkspace/contents.xcworkspacedata
+++ b/Quran.xcworkspace/contents.xcworkspacedata
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
+   <Group
+      location = "group:fastlane"
+      name = "fastlane">
+      <FileRef
+         location = "group:Fastfile"
+         assignedFileDataType = "public.ruby-script">
+      </FileRef>
+   </Group>
    <FileRef
       location = "group:Quran.xcodeproj">
    </FileRef>

--- a/Quran/Info.plist
+++ b/Quran/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/Quran/Info.plist
+++ b/Quran/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.3</string>
+	<string>1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,49 +29,34 @@ platform :ios do
         increment_build_number(build_number: 0)
 
         # Commit the change
-        # commit_version_bump
-    end
-
-    desc 'Runs all the tests'
-    lane :test do
-        scan
+        commit_version_bump
     end
 
     desc 'Submit a new Beta Build to Apple TestFlight'
     desc 'This will also make sure the profile is up to date'
     lane :beta do
-        # match(type: "appstore") # more information: https://codesigning.guide
-        gym(scheme: 'Quran') # Build your app - more options available
-        pilot
+      # Increase build number & commit it
+      increment_build_number
+      #commit_version_bump
+      #push_to_git_remote
 
-        # sh "your_script.sh"
-        # You can also use other beta testing services here (run `fastlane actions`)
-    end
+      # Build the app
+      gym(
+        scheme: "Quran",
+        clean: true,
+        output_directory: "./build/",
+      )
 
-    desc 'Deploy a new version to the App Store'
-    lane :release do
-        # match(type: "appstore")
-        # snapshot
-        gym(scheme: 'Quran') # Build your app - more options available
-        deliver(force: true)
-        # frameit
-    end
+      # Upload to test flight
+      pilot(ipa: "./build/Quran.ipa", skip_waiting_for_build_processing: true)
 
-    # You can define as many lanes as you want
+      successMessage = "New app version uploaded to TestFlight! Please wait while itunes connect process it. Success!"
+      say successMessage
 
-    after_all do |lane|
-        # This block is called, only if the executed lane was successful
-
-        # slack(
-        #   message: "Successfully deployed new App Update."
-        # )
     end
 
     error do |lane, exception|
-        # slack(
-        #   message: exception.message,
-        #   success: false
-        # )
+      say "Error while trying to execute fastlane command. Error!"
     end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -68,7 +68,9 @@ platform :ios do
         pilot(ipa: './build/Quran.ipa', skip_waiting_for_build_processing: true)
 
         # Reset fabric keys changes
-        reset_git_repo(force: true)
+        # reset_git_repo(force: true)
+        sh "git reset --hard HEAD"
+        sh "git clean -fd"
 
         # Say it succeeded
         successMessage = 'New app version uploaded to TestFlight! Please wait while itunes connect process it. Success!'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -75,8 +75,8 @@ platform :ios do
         say successMessage
     end
 
-    error do |_lane, _exception|
-        say 'Error while trying to execute fastlane command. Error!'
+    error do |lane, exception|
+        say "Error while trying to execute fastlane command. #{exception.message}"
     end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,82 @@
+# Customise this file, documentation can be found here:
+# https://github.com/fastlane/fastlane/tree/master/fastlane/docs
+# All available actions: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Actions.md
+# can also be listed using the `fastlane actions` command
+
+# Change the syntax highlighting to Ruby
+# All lines starting with a # are ignored when running `fastlane`
+
+# If you want to automatically update fastlane if a new version is available:
+# update_fastlane
+
+# This is the minimum version number required.
+# Update this, if you use features of a newer version
+fastlane_version '1.107.0'
+
+default_platform :ios
+
+platform :ios do
+    before_all do
+        # ENV["SLACK_URL"] = "https://hooks.slack.com/services/..."
+    end
+
+    desc 'Resets the build to 0 and version to passed version value and push it to the origin.'
+    lane :version_reset do |options|
+        # Set a specific version number
+        increment_version_number(version_number: options[:version])
+
+        # Set build number to 0
+        increment_build_number(build_number: 0)
+
+        # Commit the change
+        # commit_version_bump
+    end
+
+    desc 'Runs all the tests'
+    lane :test do
+        scan
+    end
+
+    desc 'Submit a new Beta Build to Apple TestFlight'
+    desc 'This will also make sure the profile is up to date'
+    lane :beta do
+        # match(type: "appstore") # more information: https://codesigning.guide
+        gym(scheme: 'Quran') # Build your app - more options available
+        pilot
+
+        # sh "your_script.sh"
+        # You can also use other beta testing services here (run `fastlane actions`)
+    end
+
+    desc 'Deploy a new version to the App Store'
+    lane :release do
+        # match(type: "appstore")
+        # snapshot
+        gym(scheme: 'Quran') # Build your app - more options available
+        deliver(force: true)
+        # frameit
+    end
+
+    # You can define as many lanes as you want
+
+    after_all do |lane|
+        # This block is called, only if the executed lane was successful
+
+        # slack(
+        #   message: "Successfully deployed new App Update."
+        # )
+    end
+
+    error do |lane, exception|
+        # slack(
+        #   message: exception.message,
+        #   success: false
+        # )
+    end
+end
+
+# More information about multiple platforms in fastlane: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Platforms.md
+# All available actions: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Actions.md
+
+# fastlane reports which actions are used
+# No personal data is recorded. Learn more at https://github.com/fastlane/enhancer

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,28 +35,48 @@ platform :ios do
     desc 'Submit a new Beta Build to Apple TestFlight'
     desc 'This will also make sure the profile is up to date'
     lane :beta do
-      # Increase build number & commit it
-      increment_build_number
-      #commit_version_bump
-      #push_to_git_remote
+        # Increase build number & commit it
+        increment_build_number
+        commit_version_bump
+        push_to_git_remote
 
-      # Build the app
-      gym(
-        scheme: "Quran",
-        clean: true,
-        output_directory: "./build/",
-      )
+        # Update fabric keys
+        fabric_keys = ENV['fabric_keys'].split(',')
+        puts 'before'.color(:yellow)
+        file_names = ['../Quran.xcodeproj/project.pbxproj', '../Quran/Info.plist']
+        file_names.each do |file_name|
+            text = File.read(file_name)
 
-      # Upload to test flight
-      pilot(ipa: "./build/Quran.ipa", skip_waiting_for_build_processing: true)
+            fabric_keys.each do |key|
+                values = key.split('|')
+                puts " Replacing #{values[0]} => #{values[1]} in #{file_name}"
+                text = text.gsub(values[0], values[1])
+            end
 
-      successMessage = "New app version uploaded to TestFlight! Please wait while itunes connect process it. Success!"
-      say successMessage
+            # To write changes to the file, use:
+            File.open(file_name, 'w') { |file| file.puts text }
+        end
 
+        # Build the app
+        gym(
+            scheme: 'Quran',
+            clean: true,
+            output_directory: './build/'
+        )
+
+        # Upload to test flight
+        pilot(ipa: './build/Quran.ipa', skip_waiting_for_build_processing: true)
+
+        # Reset fabric keys changes
+        reset_git_repo(force: true)
+
+        # Say it succeeded
+        successMessage = 'New app version uploaded to TestFlight! Please wait while itunes connect process it. Success!'
+        say successMessage
     end
 
-    error do |lane, exception|
-      say "Error while trying to execute fastlane command. Error!"
+    error do |_lane, _exception|
+        say 'Error while trying to execute fastlane command. Error!'
     end
 end
 


### PR DESCRIPTION
Fastlane integration to automate build uploads to TestFlight and replacing fabric keys. It also automates version changes.

When working on a new version we should execute:
```shell
fastlane version_reset verstion:1.1
```

When uploading a new version to test flight we should execute:
```shell
fastlane beta
```

we can execute once and then if there are some bug fixes, we do it and execute it again, it automatically increases the build number as long as we didn't submit the version to the app store.

There is an `Appfile` that should be placed next to `Fastfile` for the `beta` command to run, it shouldn't be shared in the repo. I'll e-mail it to you @ahmedre.