### PR TITLE
Better Error handling

### DIFF
--- a/Pods/GenericDataSources/Sources/DataSourceSelector.swift
+++ b/Pods/GenericDataSources/Sources/DataSourceSelector.swift
@@ -29,12 +29,14 @@ import Foundation
     case move
     case willDisplayCell
     case didEndDisplayingCell
-    case shouldShowMenuForItemAt
     case canPerformAction
     case performAction
     case canFocusItemAt
     case shouldUpdateFocusIn
     case didUpdateFocusIn*/
+
+    /// Represents the should show menu for item selector.
+    case shouldShowMenuForItemAt
 
     /// Represents the can edit selector.
     case canEdit
@@ -78,6 +80,7 @@ extension DataSourceSelector {
         case .shouldIndentWhileEditing: return false
         case .willBeginEditing: return false
         case .didEndEditing: return false
+        case .shouldShowMenuForItemAt: return false
         }
     }
 }
@@ -121,6 +124,11 @@ let dataSourceSelectorToSelectorMapping: [DataSourceSelector: [Selector]] = {
          .didEndEditing: [
             #selector(UITableViewDelegate.tableView(_:didEndEditingRowAt:)),
             #selector(DataSource.ds_collectionView(_:didEndEditingItemAt:))
+            ],
+         .shouldShowMenuForItemAt: [
+            #selector(UITableViewDelegate.tableView(_:shouldShowMenuForRowAt:)),
+            #selector(UICollectionViewDelegateFlowLayout.collectionView(_:shouldShowMenuForItemAt:)),
+            #selector(DataSource.ds_collectionView(_:shouldShowMenuForItemAt:))
             ]
     ]
     return mapping

--- a/Quran/AppDelegate.swift
+++ b/Quran/AppDelegate.swift
@@ -21,13 +21,20 @@
 import UIKit
 import Fabric
 import Crashlytics
+import PromiseKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    let container = Container()
+    let container: Container
+
+    override init() {
+        DispatchQueue.default = .global()
+        container = Container()
+        super.init()
+    }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         Fabric.with([Crashlytics.self, Answers.self])

--- a/Quran/AyahBookmarkDataSource.swift
+++ b/Quran/AyahBookmarkDataSource.swift
@@ -61,8 +61,8 @@ class AyahBookmarkDataSource: BasicDataSource<AyahBookmark, BookmarkTableViewCel
 
         } else {
             cell.name.text = item.ayah.localizedName
-            DispatchQueue.global()
-                .promise { try self.ayahPersistence.getAyahTextForNumber(item.ayah) }
+            DispatchQueue.default
+                .promise2 { try self.ayahPersistence.getAyahTextForNumber(item.ayah) }
                 .then(on: .main) { text -> Void in
                     guard self.ds_reusableViewDelegate?.ds_indexPath(for: cell) == indexPath else { return }
 
@@ -76,8 +76,8 @@ class AyahBookmarkDataSource: BasicDataSource<AyahBookmark, BookmarkTableViewCel
     }
 
     func reloadData() {
-        DispatchQueue.global()
-        .promise(execute: self.persistence.retrieveAyahBookmarks)
+       DispatchQueue.default
+        .promise2(execute: self.persistence.retrieveAyahBookmarks)
             .then(on: .main) { items -> Void in
                 self.items = items
                 self.ds_reusableViewDelegate?.ds_reloadSections(IndexSet(integer: 0), with: .automatic)

--- a/Quran/BookmarksManager.swift
+++ b/Quran/BookmarksManager.swift
@@ -30,8 +30,8 @@ class BookmarksManager {
     private(set) var isBookmarked: Bool = false
 
     func calculateIsBookmarked(pageNumber: Int) -> Promise<Bool> {
-        return DispatchQueue.global()
-            .promise { self.bookmarksPersistence.isPageBookmarked(pageNumber) }
+        return DispatchQueue.default
+            .promise2 { self.bookmarksPersistence.isPageBookmarked(pageNumber) }
             .then(on: .main) { bookmarked -> Bool in
                 self.isBookmarked = bookmarked
                 return bookmarked
@@ -43,12 +43,12 @@ class BookmarksManager {
 
         if isBookmarked {
             Analytics.shared.bookmark(quranPage: pageNumber)
-            return DispatchQueue.global() .promise {
+            return DispatchQueue.default.promise2 {
                 try self.bookmarksPersistence.insertPageBookmark(forPage: pageNumber)
             }
         } else {
             Analytics.shared.unbookmark(quranPage: pageNumber)
-            return DispatchQueue.global() .promise {
+            return DispatchQueue.default.promise2 {
                 try self.bookmarksPersistence.removePageBookmark(atPage: pageNumber)
             }
         }

--- a/Quran/ConnectionsPool.swift
+++ b/Quran/ConnectionsPool.swift
@@ -34,7 +34,7 @@ final class ConnectionsPool {
             let connection = try Connection(filePath, readonly: false)
             // wait for max of 3 seconds if the db is locked.
             // should be enough for most of the cases.
-            connection.busyTimeout = 3
+            connection.busyTimeout = 5
             return connection
         } catch {
             Crash.recordError(error, reason: "Cannot open connection to sqlite file '\(filePath)'.")

--- a/Quran/Container.swift
+++ b/Quran/Container.swift
@@ -334,6 +334,7 @@ class Container {
 
     func createTranslationsVersionUpdaterInteractor() -> AnyInteractor<[Translation], [TranslationFull]> {
         return TranslationsVersionUpdaterInteractor(
+            simplePersistence: createSimplePersistence(),
             persistence: createActiveTranslationsPersistence(),
             downloader: createDownloadManager(),
             versionPersistenceCreator: createCreator(createSQLiteDatabaseVersionPersistence)).erasedType()

--- a/Quran/DefaultAyahInfoRetriever.swift
+++ b/Quran/DefaultAyahInfoRetriever.swift
@@ -26,9 +26,9 @@ struct DefaultAyahInfoRetriever: AyahInfoRetriever {
 
     func retrieveAyahs(in page: Int) -> Promise<[AyahNumber: [AyahInfo]]> {
 
-        return DispatchQueue.global()
-            .promise { try self.persistence.getAyahInfoForPage(page) }
-            .then(on: .global()) { self.processAyahInfo($0) }
+        return DispatchQueue.default
+            .promise2 { try self.persistence.getAyahInfoForPage(page) }
+            .then { self.processAyahInfo($0) }
     }
 
     fileprivate func processAyahInfo(_ info: [AyahNumber: [AyahInfo]]) -> [AyahNumber: [AyahInfo]] {

--- a/Quran/FileSystemError.swift
+++ b/Quran/FileSystemError.swift
@@ -23,17 +23,17 @@ import Foundation
 enum FileSystemError: QuranError {
 
     case noDiskSpace
-    case unknown
+    case unknown(Error)
 
     init(error: Error) {
         if let error = error as? CocoaError {
             if error.code == .fileWriteOutOfSpace {
                 self = .noDiskSpace
             } else {
-                self = .unknown
+                self = .unknown(error)
             }
         } else {
-            self = .unknown
+            self = .unknown(error)
         }
     }
 

--- a/Quran/ImageVerseTextRetrieval.swift
+++ b/Quran/ImageVerseTextRetrieval.swift
@@ -29,7 +29,7 @@ class ImageVerseTextRetrieval: Interactor {
     }
 
     func execute(_ input: QuranShareData) -> Promise<String> {
-        return DispatchQueue.global().promise {
+        return DispatchQueue.default.promise2 {
             try self.arabicAyahPersistence.getAyahTextForNumber(input.ayah)
         }
     }

--- a/Quran/LastPageBookmarkDataSource.swift
+++ b/Quran/LastPageBookmarkDataSource.swift
@@ -47,8 +47,8 @@ class LastPageBookmarkDataSource: BasicDataSource<LastPage, BookmarkTableViewCel
     }
 
     func reloadData() {
-        DispatchQueue.global()
-            .promise(execute: self.persistence.retrieveAll)
+        DispatchQueue.default
+            .promise2(execute: self.persistence.retrieveAll)
             .then(on: .main) { items -> Void in
                 self.items = items
                 self.ds_reusableViewDelegate?.ds_reloadSections(IndexSet(integer: 0), with: .automatic)

--- a/Quran/LastPageUpdater.swift
+++ b/Quran/LastPageUpdater.swift
@@ -47,15 +47,15 @@ class LastPageUpdater {
 
     private func forceUpdateTo(page: Int) {
         guard let lastPage = lastPage else { return }
-        DispatchQueue.global()
-            .promise { try self.persistence.update(page: lastPage, toPage: page) }
+        DispatchQueue.default
+            .promise2 { try self.persistence.update(page: lastPage, toPage: page) }
             .then (on: .main) { self.lastPage = $0 }
             .cauterize(tag: "LastPagesPersistence.update(page:toPage:)")
     }
 
     private func create(page: Int) {
-        DispatchQueue.global()
-            .promise { try self.persistence.add(page: page) }
+        DispatchQueue.default
+            .promise2 { try self.persistence.add(page: page) }
             .then (on: .main) { self.lastPage = $0 }
             .cauterize(tag: "LastPagesPersistence.update(page:toPage:)")
     }

--- a/Quran/LocalTranslationsRetrievalInteractor.swift
+++ b/Quran/LocalTranslationsRetrievalInteractor.swift
@@ -33,8 +33,8 @@ class LocalTranslationsRetrievalInteractor: Interactor {
     }
 
     func execute(_ input: Void) -> Promise<[TranslationFull]> {
-        return DispatchQueue.global()
-            .promise(execute: persistence.retrieveAll)
-            .then(on: .global(), execute: versionUpdater.execute)
+        return DispatchQueue.default
+            .promise2(execute: persistence.retrieveAll)
+            .then(execute: versionUpdater.execute)
     }
 }

--- a/Quran/MoyaNetworkManager.swift
+++ b/Quran/MoyaNetworkManager.swift
@@ -61,7 +61,7 @@ class MoyaNetworkManager<Target>: NetworkManager {
                         case .underlying(let underlyingError):
                             finalError = NetworkError(error: underlyingError)
                         default:
-                            finalError = NetworkError.unknown
+                            finalError = NetworkError.unknown(error)
                         }
                     } else {
                         finalError = error

--- a/Quran/NetworkError.swift
+++ b/Quran/NetworkError.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public enum NetworkError: QuranError {
     /// Unknown or not supported error.
-    case unknown
+    case unknown(Error)
 
     /// Not connected to the internet.
     case notConnectedToInternet
@@ -23,6 +23,8 @@ public enum NetworkError: QuranError {
 
     /// Cannot reach the server.
     case serverNotReachable
+
+    case serverError(String)
 
     case parsing(String)
 
@@ -40,10 +42,10 @@ public enum NetworkError: QuranError {
             case .internationalRoamingOff:
                 self = .internationalRoamingOff
             default:
-                self = .unknown
+                self = .unknown(error)
             }
         } else {
-            self = .unknown
+            self = .unknown(error)
         }
     }
 
@@ -51,6 +53,8 @@ public enum NetworkError: QuranError {
         let text: String
         switch self {
         case .unknown:
+            text = NSLocalizedString("NetworkError_Unknown", comment: "Error description")
+        case .serverError:
             text = NSLocalizedString("NetworkError_Unknown", comment: "Error description")
         case .notConnectedToInternet:
             text = NSLocalizedString("NetworkError_NotConnectedToInternet", comment: "Error description")

--- a/Quran/NetworkError.swift
+++ b/Quran/NetworkError.swift
@@ -29,7 +29,9 @@ public enum NetworkError: QuranError {
     case parsing(String)
 
     internal init(error: Error) {
-        if let error = error as? URLError {
+        if let error = error as? NetworkError {
+            self = error
+        } else if let error = error as? URLError {
             switch error.code {
             case .timedOut, .cannotFindHost, .cannotConnectToHost:
                 self = .serverNotReachable

--- a/Quran/NetworkError.swift
+++ b/Quran/NetworkError.swift
@@ -24,9 +24,9 @@ public enum NetworkError: QuranError {
     /// Cannot reach the server.
     case serverNotReachable
 
-    case serverError(String)
-
     case parsing(String)
+
+    case serverError(String)
 
     internal init(error: Error) {
         if let error = error as? NetworkError {

--- a/Quran/OperationCacheableService.swift
+++ b/Quran/OperationCacheableService.swift
@@ -70,7 +70,7 @@ class OperationCacheableService<Input: Hashable, Output>: CacheableService {
 
                 // cache the result
                 let promise = operation.promise
-                    .then(on: .global()) { result -> Output in
+                    .then { result -> Output in
                         self.lock.execute {
                             self.cache.setObject(result, forKey: input)
                             // remove from in progress

--- a/Quran/PageBookmarkDataSource.swift
+++ b/Quran/PageBookmarkDataSource.swift
@@ -50,8 +50,8 @@ class PageBookmarkDataSource: BasicDataSource<PageBookmark, BookmarkTableViewCel
     }
 
     func reloadData() {
-        DispatchQueue.global()
-            .promise(execute: self.persistence.retrievePageBookmarks)
+        DispatchQueue.default
+            .promise2(execute: self.persistence.retrievePageBookmarks)
             .then(on: .main) { items -> Void in
                 self.items = items
                 self.ds_reusableViewDelegate?.ds_reloadSections(IndexSet(integer: 0), with: .automatic)

--- a/Quran/PersistenceError.swift
+++ b/Quran/PersistenceError.swift
@@ -30,4 +30,8 @@ enum PersistenceError: QuranError {
     var localizedDescriptionv2: String {
         return NSLocalizedString("NetworkError_Unknown", comment: "")
     }
+
+    static func generalError(_ error: Error, info: String) -> PersistenceError {
+        return .general("error: \(error), info: \(info)")
+    }
 }

--- a/Quran/PersistenceError.swift
+++ b/Quran/PersistenceError.swift
@@ -24,7 +24,8 @@ enum PersistenceError: QuranError {
     case general(String)
     case openDatabase(Error)
     case query(Error)
-    case unknown
+    case badFile(Error?)
+    case unknown(Error)
 
     var localizedDescriptionv2: String {
         return NSLocalizedString("NetworkError_Unknown", comment: "")

--- a/Quran/PersistenceError.swift
+++ b/Quran/PersistenceError.swift
@@ -24,8 +24,8 @@ enum PersistenceError: QuranError {
     case general(String)
     case openDatabase(Error)
     case query(Error)
-    case badFile(Error?)
     case unknown(Error)
+    case badFile(Error?)
 
     var localizedDescriptionv2: String {
         return NSLocalizedString("NetworkError_Unknown", comment: "")

--- a/Quran/PromiseKit+Extension.swift
+++ b/Quran/PromiseKit+Extension.swift
@@ -74,3 +74,21 @@ extension OperationQueue {
         })
     }
 }
+
+extension DispatchQueue {
+    public final func promise2<T>(execute body: @escaping () throws -> T) -> Promise<T> {
+        return Promise(resolvers: { (fulfill, reject) in
+            if self === zalgo || self === waldo && !Thread.isMainThread {
+                fulfill(try body())
+            } else {
+                async {
+                    do {
+                        fulfill(try body())
+                    } catch {
+                        reject(error)
+                    }
+                }
+            }
+        })
+    }
+}

--- a/Quran/QuranBaseBasicDataSource.swift
+++ b/Quran/QuranBaseBasicDataSource.swift
@@ -47,8 +47,8 @@ class QuranBaseBasicDataSource<CellType: QuranBasePageCollectionViewCell>: Basic
         cell.setHighlightedVerses(highlightedAyat, forType: .reading)
 
         // set bookmarked ayat
-        DispatchQueue.global()
-            .promise { try self.bookmarkPersistence.retrieve(inPage: item.pageNumber) }
+        DispatchQueue.default
+            .promise2 { try self.bookmarkPersistence.retrieve(inPage: item.pageNumber) }
             .then(on: .main) { (_, ayahBookmarks) -> Void in
                 cell.setHighlightedVerses(Set(ayahBookmarks.map { $0.ayah }), forType: .bookmark)
             }.cauterize(tag: "bookmarkPersistence.retrieve(inPage:)")
@@ -84,8 +84,8 @@ class QuranBaseBasicDataSource<CellType: QuranBasePageCollectionViewCell>: Basic
     }
 
     private func scrollToHighlightedAyaIfNeeded(_ ayah: AyahNumber, ayaht: Set<AyahNumber>) {
-        DispatchQueue.global()
-            .promise(execute: ayah.getStartPage)
+        DispatchQueue.default
+            .promise2(execute: ayah.getStartPage)
             .then(on: .main) { self.scrollTo(page: $0) }
             .cauterize(tag: "Never.getStartPage")
     }

--- a/Quran/QuranShareData.swift
+++ b/Quran/QuranShareData.swift
@@ -21,6 +21,7 @@
 import UIKit
 
 struct QuranShareData {
+    let location: CGPoint
     let gestures: [UIGestureRecognizer]
     let cell: QuranBasePageCollectionViewCell
     let page: QuranPage

--- a/Quran/QuranView.swift
+++ b/Quran/QuranView.swift
@@ -246,8 +246,8 @@ class QuranView: UIView, UIGestureRecognizerDelegate {
     }
 
     private func removeAyahFromBookmarks(atPage page: Int, ayah: AyahNumber, cell: QuranBasePageCollectionViewCell) {
-        DispatchQueue.global()
-            .promise { try self.bookmarksPersistence.removeAyahBookmark(atPage: page, ayah: ayah) }
+        DispatchQueue.default
+            .promise2 { try self.bookmarksPersistence.removeAyahBookmark(atPage: page, ayah: ayah) }
             .then(on: .main) { _ -> Void in
                 // remove bookmark from model
                 var bookmarks = cell.highlightedVerse(forType: .bookmark) ?? Set()
@@ -257,8 +257,8 @@ class QuranView: UIView, UIGestureRecognizerDelegate {
     }
 
     private func addAyahToBookmarks(atPage page: Int, ayah: AyahNumber, cell: QuranBasePageCollectionViewCell) {
-        DispatchQueue.global()
-            .promise { try self.bookmarksPersistence.insertAyahBookmark(forPage: page, ayah: ayah) }
+        DispatchQueue.default
+            .promise2 { try self.bookmarksPersistence.insertAyahBookmark(forPage: page, ayah: ayah) }
             .then(on: .main) { _ -> Void in
                 // add a bookmark to the model
                 var bookmarks = cell.highlightedVerse(forType: .bookmark) ?? Set()
@@ -278,7 +278,7 @@ class QuranView: UIView, UIGestureRecognizerDelegate {
         verseTextRetrieval
             .execute(shareData)
             .then(on: .main, execute: completion)
-            .catch { (error) in
+            .catch(on: .main) { (error) in
                 self.delegate?.onErrorOccurred(error: error)
         }
     }

--- a/Quran/QuranViewController.swift
+++ b/Quran/QuranViewController.swift
@@ -244,8 +244,8 @@ class QuranViewController: BaseViewController, AudioBannerViewPresenterDelegate,
         setBarsHidden(navigationController?.isNavigationBarHidden == false)
     }
 
-    func quranView(_ quranView: QuranView, didSelectTextToShare text: String) {
-        ShareController.showShareActivityWithText(text, sourceViewController: self, handler: nil)
+    func quranView(_ quranView: QuranView, didSelectTextToShare text: String, sourceView: UIView, sourceRect: CGRect) {
+        ShareController.share(text: text, sourceView: sourceView, sourceRect: sourceRect, sourceViewController: self, handler: nil)
     }
 
     private func setBarsHidden(_ hidden: Bool) {

--- a/Quran/SQLite+Extension.swift
+++ b/Quran/SQLite+Extension.swift
@@ -21,23 +21,22 @@
 import SQLite
 
 extension Connection {
-    public var userVersion: Int {
-        get {
-            do {
-                let version: Int64 = cast(try scalar("PRAGMA user_version"))
-                return Int(version)
-            } catch {
-                Crash.recordError(error, reason: "Cannot get value for user_version")
-                fatalError("Cannot get user version from sqlite file. Error: '\(error)'")
-            }
+
+    func setUserVersion(_ newValue: Int) throws {
+        do {
+            let newValue: Int = cast(newValue)
+            try run("PRAGMA user_version = \(newValue)")
+        } catch {
+            throw PersistenceError.generalError(error, info: "Cannot set value for user_version to \(newValue)")
         }
-        set {
-            do {
-                try run("PRAGMA user_version = \(newValue)")
-            } catch {
-                Crash.recordError(error, reason: "Cannot set value for user_version")
-                fatalError("Cannot set user version to sqlite file. Error: '\(error)'")
-            }
+    }
+
+    func getUserVersion() throws -> Int {
+        do {
+            let version: Int64 = cast(try scalar("PRAGMA user_version"))
+            return Int(version)
+        } catch {
+            throw PersistenceError.generalError(error, info: "Cannot get value for user_version")
         }
     }
 }

--- a/Quran/SQLiteAyahTimingPersistence.swift
+++ b/Quran/SQLiteAyahTimingPersistence.swift
@@ -38,6 +38,8 @@ struct SQLiteAyahTimingPersistence: QariAyahTimingPersistence, ReadonlySQLitePer
     }
 
     func getTimingForSura(startAyah: AyahNumber) throws -> [AyahNumber: AyahTiming] {
+        try validateFileExists()
+
         return try run { connection in
             let query = timingsTable.filter(Column.sura == startAyah.sura && Column.ayah >= startAyah.ayah)
             do {
@@ -57,6 +59,8 @@ struct SQLiteAyahTimingPersistence: QariAyahTimingPersistence, ReadonlySQLitePer
     }
 
     func getOrderedTimingForSura(startAyah: AyahNumber) throws -> [AyahTiming] {
+        try validateFileExists()
+
         return try run { connection in
             let query = timingsTable.filter(Column.sura == startAyah.sura && Column.ayah >= startAyah.ayah).order(Column.ayah)
             do {

--- a/Quran/SQLitePersistence.swift
+++ b/Quran/SQLitePersistence.swift
@@ -26,6 +26,10 @@ protocol ReadonlySQLitePersistence {
     func openConnection() throws -> Connection
 }
 
+private var dbFileIssueCodes: Set<Int32> = {
+    return Set([SQLITE_PERM, SQLITE_NOTADB, SQLITE_CORRUPT, SQLITE_CANTOPEN])
+}()
+
 extension ReadonlySQLitePersistence {
 
     func openConnection() throws -> Connection {
@@ -44,9 +48,33 @@ extension ReadonlySQLitePersistence {
         } catch let error as PersistenceError {
             Crash.recordError(error, reason: "Error while executing sqlite statement")
             throw error
+
+        } catch let error as SQLite.Result {
+            switch error {
+            case .error(message: _, code: let code, statement: _):
+                if dbFileIssueCodes.contains(code) {
+                    // remove the db file as sometimes, the download is completed with error.
+                    if let url = URL(string: filePath) {
+                        try? FileManager.default.removeItem(at: url)
+                    }
+                    throw PersistenceError.badFile(error)
+                }
+            }
+            Crash.recordError(error, reason: "Error while executing sqlite statement")
+            throw PersistenceError.query(error)
         } catch {
             Crash.recordError(error, reason: "Error while executing sqlite statement")
             throw PersistenceError.query(error)
+        }
+    }
+}
+
+extension ReadonlySQLitePersistence {
+    func validateFileExists() throws {
+        if let url = URL(string: filePath) {
+            if !url.isReachable {
+                throw PersistenceError.badFile(nil)
+            }
         }
     }
 }

--- a/Quran/SQLiteQariTimingRetriever.swift
+++ b/Quran/SQLiteQariTimingRetriever.swift
@@ -30,7 +30,7 @@ struct SQLiteQariTimingRetriever: QariTimingRetriever {
             fatalError("Gapped qaris are not supported.")
         }
 
-        return DispatchQueue.global() .promise {
+        return DispatchQueue.default.promise2 {
                 let fileURL = qari.localFolder().appendingPathComponent(databaseName).appendingPathExtension(Files.databaseLocalFileExtension)
                 let persistence = self.persistenceCreator.create(fileURL)
                 let timings = try persistence.getTimingForSura(startAyah: startAyah)
@@ -42,7 +42,7 @@ struct SQLiteQariTimingRetriever: QariTimingRetriever {
         guard case .gapless(let databaseName) = qari.audioType else {
             fatalError("Gapped qaris are not supported.")
         }
-        return DispatchQueue.global() .promise {
+        return DispatchQueue.default.promise2 {
             let fileURL = qari.localFolder().appendingPathComponent(databaseName).appendingPathExtension(Files.databaseLocalFileExtension)
             let persistence = self.persistenceCreator.create(fileURL)
 

--- a/Quran/SQLiteTranslationTextPersistence.swift
+++ b/Quran/SQLiteTranslationTextPersistence.swift
@@ -36,6 +36,8 @@ class SQLiteTranslationTextPersistence: AyahTextPersistence, ReadonlySQLitePersi
     }
 
     func getAyahTextForNumber(_ number: AyahNumber) throws -> String {
+        try validateFileExists()
+
         return try run { connection in
 
             let query = Verses.table.filter(Verses.sura == number.sura && Verses.ayah == number.ayah)
@@ -48,6 +50,8 @@ class SQLiteTranslationTextPersistence: AyahTextPersistence, ReadonlySQLitePersi
     }
 
     func getOptionalAyahText(forNumber number: AyahNumber) throws -> String? {
+        try validateFileExists()
+
         return try run { connection in
 
             let query = Verses.table.filter(Verses.sura == number.sura && Verses.ayah == number.ayah)

--- a/Quran/ShareController/ShareController.swift
+++ b/Quran/ShareController/ShareController.swift
@@ -22,9 +22,13 @@ import UIKit
 
 class ShareController: NSObject {
 
-    class func showShareActivityWithText(_ text: String, image: UIImage? = nil, url: URL? = nil,
-                                         sourceViewController: UIViewController,
-                                         handler: UIActivityViewControllerCompletionWithItemsHandler?) {
+    class func share(text: String,
+                     image: UIImage? = nil,
+                     url: URL? = nil,
+                     sourceView: UIView,
+                     sourceRect: CGRect,
+                     sourceViewController: UIViewController,
+                     handler: UIActivityViewControllerCompletionWithItemsHandler?) {
         var itemsToShare = [AnyObject]()
         itemsToShare.append(text as AnyObject)
         if let shareImage = image {
@@ -36,6 +40,8 @@ class ShareController: NSObject {
 
         let activityViewController = UIActivityViewController(activityItems: itemsToShare, applicationActivities: nil)
         activityViewController.completionWithItemsHandler = handler
+        activityViewController.popoverPresentationController?.sourceView = sourceView
+        activityViewController.popoverPresentationController?.sourceRect = sourceRect
         sourceViewController.present(activityViewController, animated: true, completion: nil)
     }
 }

--- a/Quran/ThreadSafeDownloadSessionDelegate.swift
+++ b/Quran/ThreadSafeDownloadSessionDelegate.swift
@@ -50,9 +50,7 @@ class ThreadSafeDownloadSessionDelegate: NSObject, URLSessionDownloadDelegate {
                 self.queue.promise {
                     self.handler.populateOnGoingDownloads(from: downloadTasks)
                 }
-            }.catch { error in
-                Crash.recordError(error, reason: "While populateOnGoingDownloads")
-        }
+            }.cauterize()
     }
 
     func addOnGoingDownloads(_ downloads: [DownloadNetworkResponse]) {

--- a/Quran/TranslationDeletionInteractor.swift
+++ b/Quran/TranslationDeletionInteractor.swift
@@ -42,15 +42,15 @@ class TranslationDeletionInteractor: Interactor {
             simplePersistence.setValue(updatedTranslations, forKey: .selectedTranslations)
         }
 
-        return DispatchQueue.global()
-            .promise {
+        return DispatchQueue.default
+            .promise2 {
                 // delete from disk
                 item.translation.possibleFileNames.forEach { fileName in
                     let url = Files.translationsURL.appendingPathComponent(fileName)
                     try? FileManager.default.removeItem(at: url)
                 }
             }
-            .then(on: .global()) { () -> TranslationFull in
+            .then { () -> TranslationFull in
                 var translation = item.translation
                 translation.installedVersion = nil
                 try self.persistence.update(translation)

--- a/Quran/TranslationPreloadingOperation.swift
+++ b/Quran/TranslationPreloadingOperation.swift
@@ -57,7 +57,7 @@ class TranslationPreloadingOperation: AbstractPreloadingOperation<TranslationPag
         // get the translations text
         // merge them
         when(fulfilled: Promise(value: ayahs), translationsPromise(ayahs: ayahs), arabicPromise(ayahs: ayahs))
-            .then(on: .global(), execute: self.merge(ayahs:translations:arabic:))
+            .then(execute: self.merge(ayahs:translations:arabic:))
             .then(execute: self.fulfill)
             .catch(execute: self.reject)
     }
@@ -83,8 +83,8 @@ class TranslationPreloadingOperation: AbstractPreloadingOperation<TranslationPag
     private func translationsPromise(ayahs: [AyahNumber]) -> Promise<[(Translation, [AyahText])]> {
         return localTranslationInteractor
             .execute()
-            .then(on: .global(), execute: selectedTranslations(allTranslations:))
-            .then(on: .global()) { self.retrieveAllTranslations(ayahs: ayahs, translations: $0) }
+            .then(execute: selectedTranslations(allTranslations:))
+            .then { self.retrieveAllTranslations(ayahs: ayahs, translations: $0) }
     }
 
     private func selectedTranslations(allTranslations: [TranslationFull]) -> [Translation] {
@@ -94,7 +94,7 @@ class TranslationPreloadingOperation: AbstractPreloadingOperation<TranslationPag
     }
 
     private func arabicPromise(ayahs: [AyahNumber]) -> Promise<[AyahText]> {
-        return Promise(value: ayahs).then(on: .global(), execute: retrieveArabicText(ayahs:))
+        return Promise(value: ayahs).then(execute: retrieveArabicText(ayahs:))
     }
 
     private func retrieveArabicText(ayahs: [AyahNumber]) throws -> [AyahText] {

--- a/Quran/TranslationsDataSource.swift
+++ b/Quran/TranslationsDataSource.swift
@@ -178,25 +178,27 @@ class TranslationsDataSource: CompositeDataSource, TranslationsBasicDataSourceDe
     }
 
     func onDownloadCompleted(for translation: TranslationFull) {
-        guard let (ds, localIndexPath) = indexPathFor(translation: translation) else {
-            CLog("Cannot complete download for translation \(translation.translation.displayName)")
-            return
-        }
-        let globalIndexPath = globalIndexPathForLocalIndexPath(localIndexPath, dataSource: ds)
-
-        // remove old observer
-        let observer = downloadingObservers.removeValue(forKey: translation.translation.id)
-        observer?.stop()
-
-        // update the cell
-        let cell = ds_reusableViewDelegate?.ds_cellForItem(at: globalIndexPath) as? TranslationTableViewCell
-        cell?.downloadButton.state = .downloaded
-        cell?.checkbox.isHidden = !downloadedDS.isSelectable
-        cell?.setSelection(false)
 
         versionUpdater
             .execute([translation.translation])
             .then(on: .main) { newItems -> Void in
+
+                guard let (ds, localIndexPath) = self.indexPathFor(translation: translation) else {
+                    CLog("Cannot complete download for translation \(translation.translation.displayName)")
+                    return
+                }
+                let globalIndexPath = self.globalIndexPathForLocalIndexPath(localIndexPath, dataSource: ds)
+
+                // remove old observer
+                let observer = self.downloadingObservers.removeValue(forKey: translation.translation.id)
+                observer?.stop()
+
+                // update the cell
+                let cell = self.ds_reusableViewDelegate?.ds_cellForItem(at: globalIndexPath) as? TranslationTableViewCell
+                cell?.downloadButton.state = .downloaded
+                cell?.checkbox.isHidden = !self.downloadedDS.isSelectable
+                cell?.setSelection(false)
+
                 let newGlobalIndexPath = self.move(item: translation,
                                                    atLocalPath: localIndexPath,
                                                    newItem: newItems[0],

--- a/Quran/TranslationsRetrievalInteractor.swift
+++ b/Quran/TranslationsRetrievalInteractor.swift
@@ -37,13 +37,13 @@ class TranslationsRetrievalInteractor: Interactor {
 
     func execute(_ input: Void) -> Promise<[TranslationFull]> {
 
-        let local = DispatchQueue.global().promise(execute: persistence.retrieveAll)
+        let local = DispatchQueue.default.promise2(execute: persistence.retrieveAll)
         let remote = networkManager.execute(.translations)
 
         return when(fulfilled: local, remote)                       // get local and remote
-            .then(on: .global(), execute: combine)                  // combine local and remote
-            .then(on: .global(), execute: saveCombined)         // save combined list
-            .then(on: .global(), execute: localInteractor.execute)  // get local data
+            .then(execute: combine)                  // combine local and remote
+            .then(execute: saveCombined)         // save combined list
+            .then(execute: localInteractor.execute)  // get local data
     }
 
     private func combine(local: [Translation], remote: [Translation]) -> ([Translation], [Int: Translation]) {

--- a/Quran/TranslationsVersionUpdaterInteractor.swift
+++ b/Quran/TranslationsVersionUpdaterInteractor.swift
@@ -37,11 +37,11 @@ class TranslationsVersionUpdaterInteractor: Interactor {
 
     func execute(_ translations: [Translation]) -> Promise<[TranslationFull]> {
         let update = Promise(value: translations)
-            .then(on: .global(), execute: unzipIfNeeded)    // unzip if needed
-            .then(on: .global(), execute: updateInstalledVersions) // update versions
+            .then(execute: unzipIfNeeded)    // unzip if needed
+            .then(execute: updateInstalledVersions) // update versions
         let downloads = downloader.getOnGoingDownloads()
         return when(fulfilled: update, downloads)
-            .then(on: .global(), execute: createTranslations)
+            .then(execute: createTranslations)
     }
 
     private func createTranslations(translations: [Translation], downloadsBatches: [[DownloadNetworkResponse]]) -> [TranslationFull] {

--- a/Quran/TranslationsVersionUpdaterInteractor.swift
+++ b/Quran/TranslationsVersionUpdaterInteractor.swift
@@ -23,13 +23,16 @@ import Zip
 
 class TranslationsVersionUpdaterInteractor: Interactor {
 
+    private let simplePersistence: SimplePersistence
     private let persistence: ActiveTranslationsPersistence
     private let downloader: DownloadManager
     private let versionPersistenceCreator: AnyCreator<DatabaseVersionPersistence, String>
 
-    init(persistence: ActiveTranslationsPersistence,
+    init(simplePersistence: SimplePersistence,
+         persistence: ActiveTranslationsPersistence,
          downloader: DownloadManager,
          versionPersistenceCreator: AnyCreator<DatabaseVersionPersistence, String>) {
+        self.simplePersistence = simplePersistence
         self.persistence = persistence
         self.downloader = downloader
         self.versionPersistenceCreator = versionPersistenceCreator
@@ -76,14 +79,29 @@ class TranslationsVersionUpdaterInteractor: Interactor {
             // installed on the latest version & the db file exists
             if translation.version != translation.installedVersion && isReachable {
                 let versionPersistence = versionPersistenceCreator.create(fileURL.absoluteString)
-                let version = try versionPersistence.getTextVersion()
-                translation.installedVersion = version
+                do {
+                    let version = try versionPersistence.getTextVersion()
+                    translation.installedVersion = version
+                } catch {
+                    // if an error occurred while getting the version
+                    // that means the db file is corrupted.
+                    translation.installedVersion = nil
+                }
             } else if translation.installedVersion != nil && !isReachable {
                 translation.installedVersion = nil
             }
 
             if previousInstalledVersion != translation.installedVersion {
                 try persistence.update(translation)
+
+                // remove the translation from selected translations
+                if translation.installedVersion == nil {
+                    var selectedTranslations = simplePersistence.valueForKey(.selectedTranslations)
+                    if let index = selectedTranslations.index(of: translation.id) {
+                        selectedTranslations.remove(at: index)
+                        simplePersistence.setValue(selectedTranslations, forKey: .selectedTranslations)
+                    }
+                }
             }
             updatedTranslations.append(translation)
         }

--- a/Quran/TranslationsViewController.swift
+++ b/Quran/TranslationsViewController.swift
@@ -104,7 +104,7 @@ class TranslationsViewController: BaseTableBasedViewController, TranslationsData
                 self?.dataSource.setItems(items: translations)
                 self?.tableView.reloadData()
             }.catchToAlertView(viewController: self)
-            .always { [weak self] in
+            .always(on: .main) { [weak self] in
                 self?.refreshControl.endRefreshing()
                 self?.activityIndicator?.stopAnimating()
         }

--- a/Quran/TranslationsViewController.swift
+++ b/Quran/TranslationsViewController.swift
@@ -85,7 +85,9 @@ class TranslationsViewController: BaseTableBasedViewController, TranslationsData
         super.viewWillAppear(animated)
 
         activityIndicator?.startAnimating()
-        refreshData()
+        loadLocalData {
+            self.refreshData()
+        }
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -110,11 +112,13 @@ class TranslationsViewController: BaseTableBasedViewController, TranslationsData
         }
     }
 
-    private func loadLocalData() {
+    private func loadLocalData(completion: @escaping () -> Void = { }) {
         localTranslationsInteractor.execute()
             .then(on: .main) { [weak self] translations -> Void in
                 self?.dataSource.setItems(items: translations)
                 self?.tableView.reloadData()
+            } .always {
+                completion()
             }.catchToAlertView(viewController: self)
     }
 

--- a/Quran/UIViewController+Extension.swift
+++ b/Quran/UIViewController+Extension.swift
@@ -22,6 +22,16 @@ import UIKit
 
 extension UIViewController {
     func showErrorAlert(error: Error) {
+        if Thread.current.isMainThread {
+            _showErrorAlert(error: error)
+        } else {
+            DispatchQueue.main.async {
+                self._showErrorAlert(error: error)
+            }
+        }
+    }
+
+    private func _showErrorAlert(error: Error) {
         Crash.recordError(error, reason: "showErrorAlert", fatalErrorOnDebug: false)
         let message = error.getLocalizedDescription()
         let controller = UIAlertController(title: "Error", message: message, preferredStyle: .alert)


### PR DESCRIPTION
Fixes #121 
Fixes #123 by both preventing downloading the file if there is a server error (i.e. unacceptable HTTP status code) and also the recovery of bad translations SQLite files.

Also using `DispatchQueue.default` so that it is easy to debug Promises just by modifying `DispatchQueue.default` in the `AppDelegate` to be `zalgo`.