### PR TITLE
Fix for Audio Download Screen

### DIFF
--- a/Quran/AudioDownloadsDataSource.swift
+++ b/Quran/AudioDownloadsDataSource.swift
@@ -170,8 +170,9 @@ extension AudioDownloadsDataSource: DownloadingObserverDelegate {
         }
         let cell = self.ds_reusableViewDelegate?.ds_cellForItem(at: localIndexPath) as? AudioDownloadTableViewCell
 
-        let oldValue = floor((cell?.downloadButton.state.progress ?? 0) * 100)
-        let newValue = floor(item.state.progress * 100)
+        let scale: Float = 2_000
+        let oldValue = floor((cell?.downloadButton.state.progress ?? 0) * scale)
+        let newValue = floor(item.state.progress * scale)
 
         cell?.downloadButton.state = item.state
 

--- a/Quran/AudioDownloadsDataSource.swift
+++ b/Quran/AudioDownloadsDataSource.swift
@@ -177,6 +177,7 @@ extension AudioDownloadsDataSource: DownloadingObserverDelegate {
 
         if newValue - oldValue > 0.9 {
             reload(item: item, cell: cell, response: item.response)
+            NSLog("Reloading \(newValue), \(oldValue)")
         }
     }
 
@@ -224,8 +225,16 @@ extension AudioDownloadsDataSource: DownloadingObserverDelegate {
                     return
                 }
 
+                let oldItem = self.items[localIndexPath.item]
+                let finalResponse: DownloadBatchResponse?
+                if response == nil || oldItem.response == nil {
+                    finalResponse = nil
+                } else {
+                    finalResponse = response
+                }
+
                 // update the item to be not downloading
-                let newItem = DownloadableQariAudio(audio: audio, response: response)
+                let newItem = DownloadableQariAudio(audio: audio, response: finalResponse)
                 self.items[localIndexPath.item] = newItem
 
                 cell?.configure(with: audio)


### PR DESCRIPTION
* Fix for an issue that makes the downloading progress always visible even after the downloading is completed.
* Increase frequency of reloading the downloaded size to be every 0.05% (around 1MB) previously was every 1%.