### PR TITLE
Update QariAudioFileListRetrieval.swift

### DIFF
--- a/Quran/QariAudioFileListRetrieval.swift
+++ b/Quran/QariAudioFileListRetrieval.swift
@@ -72,7 +72,7 @@ struct GaplessQariAudioFileListRetrieval: QariAudioFileListRetrieval {
 
             files.insert(QariSuraAudioFile(remote: remoteURL, local: localURL, sura: sura))
         }
-        return Array(files) + [dbFile]
+        return Array(files) + [dbFile as QariAudioFile]
     }
 }
 


### PR DESCRIPTION
build error fix: cast dbFile to base type QariAudioFile to allow using + operator to combine the QariSuraAudioFile list and the single QariDatabaseAudioFile (dbFile).