### PR TITLE
250: Search Performance Improvement

### DIFF
--- a/Quran/SQLiteAyahTextPersistence.swift
+++ b/Quran/SQLiteAyahTextPersistence.swift
@@ -24,7 +24,7 @@ private struct Columns {
     static let sura = Expression<Int>("sura")
     static let ayah = Expression<Int>("ayah")
     static let text = Expression<String>("text")
-    static let snippet = Expression<String>(literal: "snippet(verses, '<b>', '</b>', '...', -1, 64)")
+    static let snippet = Expression<String>(literal: "snippet(verses, '<b>', '<b>', '...', -1, 64)")
 }
 
 class SQLiteArabicTextPersistence: AyahTextPersistence, WordByWordTranslationPersistence, ReadonlySQLitePersistence {


### PR DESCRIPTION
Fixes #250 

  Using `<b>` tokens for both start and end then splitting the search term on `<b>` and constructing the `NSAttributedString` for individual substrings increases the performance significantly compared to assuming a generic HTML text.