### PR TITLE
Improve autocomplete results

### DIFF
--- a/Quran.xcodeproj/project.pbxproj
+++ b/Quran.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		5428A686213DBDDA00B91F13 /* ThemedBackgroundColorButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5428A685213DBDDA00B91F13 /* ThemedBackgroundColorButton.swift */; };
 		5428A687213DC55500B91F13 /* QuranUIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 544EC38320C45BB600D2E7B5 /* QuranUIImage.swift */; };
 		5428A68B213DCD0B00B91F13 /* ThemeSettingsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5428A68A213DCD0B00B91F13 /* ThemeSettingsDataSource.swift */; };
+		5428A68D2140444C00B91F13 /* SearchAutocompleteTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5428A68C2140444C00B91F13 /* SearchAutocompleteTableViewCell.xib */; };
 		542DCBC71ECC4BDC0023D6FD /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542DCBC61ECC4BDC0023D6FD /* SearchService.swift */; };
 		542DCBCD1ECC53D00023D6FD /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542DCBCC1ECC53D00023D6FD /* ActivityIndicator.swift */; };
 		542DCBD21ECC56610023D6FD /* Driver+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542DCBD11ECC56610023D6FD /* Driver+Extensions.swift */; };
@@ -618,6 +619,7 @@
 		542732D11EB541AA00DC5C0F /* DownloadBatchDataController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownloadBatchDataController.swift; sourceTree = "<group>"; };
 		5428A685213DBDDA00B91F13 /* ThemedBackgroundColorButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemedBackgroundColorButton.swift; sourceTree = "<group>"; };
 		5428A68A213DCD0B00B91F13 /* ThemeSettingsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeSettingsDataSource.swift; sourceTree = "<group>"; };
+		5428A68C2140444C00B91F13 /* SearchAutocompleteTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SearchAutocompleteTableViewCell.xib; sourceTree = "<group>"; };
 		542DCBC61ECC4BDC0023D6FD /* SearchService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
 		542DCBCC1ECC53D00023D6FD /* ActivityIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
 		542DCBD11ECC56610023D6FD /* Driver+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Driver+Extensions.swift"; sourceTree = "<group>"; };
@@ -1601,6 +1603,7 @@
 				542DCBDA1ECC97DD0023D6FD /* SearchNoResultTableViewCell.swift */,
 				542DCBDB1ECC97DD0023D6FD /* SearchNoResultTableViewCell.xib */,
 				544EC36D20BA6BCF00D2E7B5 /* SearchAutocompleteTableViewCell.swift */,
+				5428A68C2140444C00B91F13 /* SearchAutocompleteTableViewCell.xib */,
 			);
 			name = UIKit;
 			sourceTree = "<group>";
@@ -2923,6 +2926,7 @@
 				5419E4BB1CFA26B900071A6D /* Android.strings in Resources */,
 				54B2666C1CCA93C500D3AEF8 /* SuraTableViewCell.xib in Resources */,
 				54699B8F1E8DC0D200211A60 /* QuranTranslationCollectionPageCollectionViewCell.xib in Resources */,
+				5428A68D2140444C00B91F13 /* SearchAutocompleteTableViewCell.xib in Resources */,
 				5419E51E1CFA2BC100071A6D /* Readers.strings in Resources */,
 				54B265F01CC57D8F00D3AEF8 /* Assets.xcassets in Resources */,
 			);

--- a/Quran/SearchAutocompleteTableViewCell.swift
+++ b/Quran/SearchAutocompleteTableViewCell.swift
@@ -21,4 +21,6 @@
 import UIKit
 
 class SearchAutocompleteTableViewCell: ThemedTableViewCell {
+    @IBOutlet weak var label: UILabel!
+    @IBOutlet weak var icon: ThemedImageView!
 }

--- a/Quran/SearchAutocompleteTableViewCell.xib
+++ b/Quran/SearchAutocompleteTableViewCell.xib
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="pJI-4N-6vM" customClass="SearchAutocompleteTableViewCell" customModule="Quran" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pJI-4N-6vM" id="cZh-my-odk">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="251" image="ic_ab_search" translatesAutoresizingMaskIntoConstraints="NO" id="Pjt-9b-zVx" customClass="ThemedImageView" customModule="Quran" customModuleProvider="target">
+                        <rect key="frame" x="20" y="13" width="36" height="18"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="18" id="clP-Fs-Uf5"/>
+                        </constraints>
+                    </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qfd-IR-HXO">
+                        <rect key="frame" x="66" y="0.0" width="302" height="43.5"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="Qfd-IR-HXO" secondAttribute="trailing" constant="7" id="57h-e3-3cJ"/>
+                    <constraint firstItem="Qfd-IR-HXO" firstAttribute="top" secondItem="cZh-my-odk" secondAttribute="top" id="DIK-lC-6wM"/>
+                    <constraint firstItem="Qfd-IR-HXO" firstAttribute="leading" secondItem="Pjt-9b-zVx" secondAttribute="trailing" constant="10" id="OsW-hO-nhg"/>
+                    <constraint firstAttribute="bottom" secondItem="Qfd-IR-HXO" secondAttribute="bottom" id="Rei-d5-ZYA"/>
+                    <constraint firstItem="Pjt-9b-zVx" firstAttribute="leading" secondItem="cZh-my-odk" secondAttribute="leading" constant="20" id="gqP-WL-tFy"/>
+                    <constraint firstItem="Pjt-9b-zVx" firstAttribute="centerY" secondItem="cZh-my-odk" secondAttribute="centerY" id="peZ-Dy-L9j"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="icon" destination="Pjt-9b-zVx" id="NtZ-xA-WVf"/>
+                <outlet property="label" destination="Qfd-IR-HXO" id="xFd-h3-DYE"/>
+            </connections>
+            <point key="canvasLocation" x="-20" y="-129"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="ic_ab_search" width="36" height="36"/>
+    </resources>
+</document>

--- a/Quran/SearchResultsDataSource.swift
+++ b/Quran/SearchResultsDataSource.swift
@@ -103,12 +103,16 @@ class SearchResultsDataSource: SegmentedDataSource {
 }
 
 private class SearchAutocompletionDataSource: BasicDataSource<NSAttributedString, SearchAutocompleteTableViewCell> {
+    private let image = #imageLiteral(resourceName: "search-128").scaled(toHeight: 18)?.withRenderingMode(.alwaysTemplate)
 
     override func ds_collectionView(_ collectionView: GeneralCollectionView,
                                     configure cell: SearchAutocompleteTableViewCell,
                                     with item: NSAttributedString,
                                     at indexPath: IndexPath) {
-        cell.textLabel?.attributedText = item
+        cell.label?.attributedText = item
+        cell.icon?.image = image
+        cell.icon?.kind = .labelWeak
+        cell.separatorInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 0)
     }
 
     override func ds_collectionView(_ collectionView: GeneralCollectionView, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/Quran/SearchResultsViewController.swift
+++ b/Quran/SearchResultsViewController.swift
@@ -33,12 +33,13 @@ class SearchResultsViewController: BaseTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        tableView.ds_register(cellClass: SearchAutocompleteTableViewCell.self)
+        tableView.ds_register(cellNib: SearchAutocompleteTableViewCell.self)
         tableView.ds_register(cellClass: FullScreenLoadingTableViewCell.self)
         tableView.ds_register(cellNib: SearchResultTableViewCell.self)
         tableView.ds_register(cellNib: SearchNoResultTableViewCell.self)
         tableView.ds_register(headerFooterClass: JuzTableViewHeaderFooterView.self)
         tableView.ds_useDataSource(dataSource)
+        tableView.separatorInset = UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 0)
         clearsSelectionOnViewWillAppear = true
     }
 

--- a/Quran/SearchService.swift
+++ b/Quran/SearchService.swift
@@ -61,7 +61,7 @@ class SQLiteSearchService: SearchAutocompletionService, SearchService {
                     }
                 }
                 return []
-            }
+            }.map { [SearchAutocompletion(text: term, highlightedRange: term.startIndex..<term.endIndex)] + $0 }
     }
 
     func search(for term: String) -> Observable<SearchResults> {


### PR DESCRIPTION
Fixes #169

*  Showing just a handful of words for autocomplete result instead of a full verse text.
* Ability to show multiple results from the same verse.
* Always show search term as first autocomplete result.
* Add a search icon on the left of each result, similar to how the new app store is doing it.

The updated look for the autocompletes
![simulator screen shot - ipad 5th generation - 2018-09-05 at 22 43 46](https://user-images.githubusercontent.com/5665498/45132003-44413880-b15d-11e8-8865-dd49fa26c4a8.png)
