### PR TITLE
258: No highlights for Arabic autocomplete results

### DIFF
--- a/Quran/SearchPresenter.swift
+++ b/Quran/SearchPresenter.swift
@@ -131,6 +131,7 @@ class DefaultSearchPresenter: SearchPresenter, SearchViewDelegate {
     }
 }
 extension SearchAutocompletion {
+    private static var arabicRegex = try! NSRegularExpression(pattern: "\\p{Arabic}") // swiftlint:disable:this force_try
     fileprivate func asAttributedString() -> NSAttributedString {
         let normalAttributes: [NSAttributedStringKey: Any] = [
             .font: UIFont.systemFont(ofSize: 14),
@@ -142,8 +143,12 @@ extension SearchAutocompletion {
         ]
 
         let attributedString = NSMutableAttributedString(string: text, attributes: highlightedAttributes)
-        let highlightedNSRange = text.rangeAsNSRange(highlightedRange)
-        attributedString.setAttributes(normalAttributes, range: highlightedNSRange)
+
+        let regex = SearchAutocompletion.arabicRegex
+        if regex.firstMatch(in: text, options: [], range: NSRange(location: 0, length: text.count)) == nil {
+            let highlightedNSRange = text.rangeAsNSRange(highlightedRange)
+            attributedString.setAttributes(normalAttributes, range: highlightedNSRange)
+        }
         return attributedString
     }
 }


### PR DESCRIPTION
Fixes #258 
This is mainly because an Arabic word will be split if part of it highlighted and the other part is not.

  ![simulator screen shot - iphone 8 - 2018-09-05 at 22 50 21](https://user-images.githubusercontent.com/5665498/45132234-2aecbc00-b15e-11e8-93fb-4921485a0ddb.png)
