### PR TITLE
Search UI Similar to New App Store Search UI

### DIFF
--- a/Quran/SearchResultsDataSource.swift
+++ b/Quran/SearchResultsDataSource.swift
@@ -129,6 +129,7 @@ private class SearchResultDataSource: BasicDataSource<SearchResultUI, SearchResu
         cell.resultLabel.attributedText = item.attributedString
         cell.pageNumber.text = item.pageNumber
         cell.ayahDescription.text = item.ayahDescription
+        cell.separatorInset = UIEdgeInsets(top: 0, left: 15, bottom: 0, right: 0)
     }
 
     override func ds_collectionView(_ collectionView: GeneralCollectionView, sizeForItemAt indexPath: IndexPath) -> CGSize {

--- a/Quran/SearchResultsViewController.swift
+++ b/Quran/SearchResultsViewController.swift
@@ -33,6 +33,7 @@ class SearchResultsViewController: BaseTableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        kind = .cell
         tableView.ds_register(cellNib: SearchAutocompleteTableViewCell.self)
         tableView.ds_register(cellClass: FullScreenLoadingTableViewCell.self)
         tableView.ds_register(cellNib: SearchResultTableViewCell.self)

--- a/Quran/SearchViewController.swift
+++ b/Quran/SearchViewController.swift
@@ -33,7 +33,7 @@ class SearchViewController: BaseViewController, UISearchResultsUpdating, UISearc
     var router: SearchRouter? // DESIGN: Shouldn't be saved here
     weak var delegate: SearchViewDelegate?
 
-    lazy var searchController: UISearchController? = SearchControllerWithNoCancelButton(searchResultsController: searchResults)
+    lazy var searchController: UISearchController? = UISearchController(searchResultsController: searchResults)
     lazy var searchResults: SearchResultsViewController = {
         let controller = SearchResultsViewController()
         controller.dataSource.onAutocompletionSelected = { [weak self] index in
@@ -70,8 +70,9 @@ class SearchViewController: BaseViewController, UISearchResultsUpdating, UISearc
         searchController?.searchResultsUpdater = self
         searchController?.searchBar.delegate = self
 
-        searchController?.searchBar.searchTextPositionAdjustment = UIOffset(horizontal: 8, vertical: 0)
-        searchController?.searchBar.showsCancelButton = false
+        searchController?.searchBar.barStyle = .black
+        searchController?.searchBar.isTranslucent = true
+        searchController?.searchBar.searchBarStyle = .minimal
         searchController?.dimsBackgroundDuringPresentation = true
         searchController?.hidesNavigationBarDuringPresentation = false
         definesPresentationContext = true
@@ -161,11 +162,5 @@ class SearchViewController: BaseViewController, UISearchResultsUpdating, UISearc
             button.addTarget(self, action: tapSelector, for: .touchUpInside)
             stack.addArrangedSubview(button)
         }
-    }
-
-    override func themeDidChange() {
-        super.themeDidChange()
-        let searchBackgroundImage = UIColor.searchBarBackground.image(size: CGSize(width: 28, height: 28))?.rounded(by: 4)
-        searchController?.searchBar.setSearchFieldBackgroundImage(searchBackgroundImage, for: .normal)
     }
 }


### PR DESCRIPTION
Fixes #209

* Adding a cancel button
* Same background for both the result and the entire view.
* Default `UISearchBar` appearance for old and latest iOS.
* Set a fixed separator inset which improves the separator inset for empty rows.