### PR TITLE
281: Fix translation text gets trimmed

### DIFF
--- a/Quran/TranslationPageLayoutOperation.swift
+++ b/Quran/TranslationPageLayoutOperation.swift
@@ -83,6 +83,7 @@ class TranslationPageLayoutOperation: AbstractPreloadingOperation<TranslationPag
         layoutManager.addTextContainer(textContainer)
 
         // get number of glyphs
+        layoutManager.ensureLayout(for: textContainer)
         let numberOfGlyphs = layoutManager.numberOfGlyphs
         let range = NSRange(location: 0, length: numberOfGlyphs)
 


### PR DESCRIPTION
Fixes #281.

Translation text was getting trimmed for some languages that requires `NSLayoutManager.ensureLayout` to be called before getting `NSLayoutManager.numberOfGlyphs` as `numberOfGlyphs` would get an underestimated value if called first.