### PR TITLE
292: Fix popover for new iPhones iPhone XR & iPhone X Max

### DIFF
--- a/Quran/PhonePopoverPresentationControllerDelegate.swift
+++ b/Quran/PhonePopoverPresentationControllerDelegate.swift
@@ -18,7 +18,7 @@
 //  GNU General Public License for more details.
 //
 class PhonePopoverPresentationControllerDelegate: NSObject, UIPopoverPresentationControllerDelegate {
-    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+    func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
         return .none
     }
 }

--- a/Quran/QariTableViewControllerCreator.swift
+++ b/Quran/QariTableViewControllerCreator.swift
@@ -39,7 +39,7 @@ class QariTableViewControllerCreator: NSObject, Creator, UIPopoverPresentationCo
         return controller
     }
 
-    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+    func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
         return .fullScreen
     }
 

--- a/Quran/QuranViewController.swift
+++ b/Quran/QuranViewController.swift
@@ -295,7 +295,7 @@ class QuranViewController: BaseViewController, AudioBannerViewPresenterDelegate,
         present(controller, animated: true, completion: nil)
     }
 
-    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+    func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
         return .none
     }
 


### PR DESCRIPTION
Fixes #292 

Using the iOS 8.3 API:
```swift   
optional func adaptivePresentationStyle(for controller: UIPresentationController,
                                        traitCollection: UITraitCollection) -> UIModalPresentationStyle
```