### PR TITLE
fix #211: shows image next to translation

### DIFF
--- a/Quran.xcodeproj/project.pbxproj
+++ b/Quran.xcodeproj/project.pbxproj
@@ -4322,7 +4322,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = UIKitExtension/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.quran.UIKitExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -4352,7 +4352,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = UIKitExtension/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.quran.UIKitExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Quran/WordPointerInteractor.swift
+++ b/Quran/WordPointerInteractor.swift
@@ -21,6 +21,7 @@ protocol WordPointerPresentable: Presentable {
     func animateOut(completion: @escaping () -> Void)
 
     func showWordPopover(text: String, at point: CGPoint)
+    func showWordPopover(text: String, at point: CGPoint, word: AyahWord, position: AyahWord.Position)
     func hideWordPopover()
 }
 
@@ -106,7 +107,7 @@ final class WordPointerInteractor: PresentableInteractor<WordPointerPresentable>
     }
 
     private func showWordPopover(text: String, at point: CGPoint, word: AyahWord, position: AyahWord.Position) {
-        presenter.showWordPopover(text: text, at: point)
+        presenter.showWordPopover(text: text, at: point, word: word, position: position)
         selectedWord = word
     }
 

--- a/Quran/WordPointerViewController.swift
+++ b/Quran/WordPointerViewController.swift
@@ -226,6 +226,27 @@ final class WordPointerViewController: UIViewController, WordPointerPresentable,
     func hideWordPopover() {
         popover.hideNoAnimation()
     }
+    
+    lazy var castParent = container as? QuranView
+
+    func showWordPopover(text: String, at point: CGPoint, word: AyahWord, position: AyahWord.Position) {
+        let page = Quran.pageForAyah(position.ayah)
+
+        guard let cells = castParent?.collectionView.visibleCells as? [QuranImagePageCollectionViewCell],
+            let cell = cells.first(where: { $0.page?.pageNumber == page }),
+            let infos = cell.highlightingView.ayahInfoData?[position.ayah],
+            let info = infos.first(where: { $0.position == position.position }),
+            let croppedImage = cell.mainImageView.image?.cgImage?.cropping(to: info.rect) else { return }
+        var action: PopoverAction
+        var wordImage = UIImage(cgImage: croppedImage)
+        if Theme.current == .light {
+            wordImage = wordImage.inverted()
+        }
+        wordImage = wordImage.aspectFittedToHeight(40.0 - 8.0 * 2)
+        action = PopoverAction(image: wordImage, title: text, handler: nil)
+        let isUpward = point.y < 63
+        popover.show(to: point, isUpward: isUpward, with: [action])
+    }
 
     // MARK: - Translation Selection
 

--- a/UIKitExtension/UIImage+Extension.swift
+++ b/UIKitExtension/UIImage+Extension.swift
@@ -119,6 +119,17 @@ extension UIImage {
         UIGraphicsEndImageContext()
         return newImage
     }
+    
+    public func aspectFittedToHeight(_ newHeight: CGFloat) -> UIImage {
+        let scale = newHeight / self.size.height
+        let newWidth = self.size.width * scale
+        let newSize = CGSize(width: newWidth, height: newHeight)
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        
+        return renderer.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: newSize))
+        }
+    }
 
     public func inverted() -> UIImage {
         guard let filter = CIFilter(name: "CIColorInvert") else {


### PR DESCRIPTION
This is an attempt at fixing #211. The code shows an image of the word next to the text in the popover.

This solution needs at least iOS 10.0 to work.

Some Issues that I couldn't solve:
* The image that gets displayed is somewhat small, due to limitations in the Popover pod
* It quite a few calculations every time the function is called, not resource friendly
* Not tested on a real device

[Video](https://youtu.be/39pVtjO1Xpk)