### PR TITLE
Improve the performance of QuranKit

### DIFF
--- a/Sources/QuranKit/AyahNumber.swift
+++ b/Sources/QuranKit/AyahNumber.swift
@@ -70,11 +70,6 @@ public struct AyahNumber: Navigatable {
     }
 
     public var page: Page {
-        for (page, nextPage) in zip(quran.pages, quran.pages.dropFirst()) {
-            if self < nextPage.firstVerse {
-                return page
-            }
-        }
-        return quran.pages.last!
+        quran.pages.binarySearchFirst { self >= $0.firstVerse }
     }
 }

--- a/Sources/QuranKit/LazyAtomic.swift
+++ b/Sources/QuranKit/LazyAtomic.swift
@@ -1,0 +1,41 @@
+//
+//  LazyAtomic.swift
+//  
+//
+//  Created by Mohamed Afifi on 2022-01-04.
+//
+
+import Foundation
+
+@propertyWrapper
+final class LazyAtomic<Value> {
+
+    private var initializer: (() -> Value)?
+    private var value: Value?
+    private let lock = NSLock()
+    init() {
+    }
+
+    var wrappedValue: () -> Value {
+        get {
+            return {
+                self.lock.lock()
+                defer {
+                    self.lock.unlock()
+                }
+                if let value = self.value {
+                    return value
+                }
+                guard let initializer = self.initializer else {
+                    fatalError("initializer must be set")
+                }
+                let initializedValue = initializer()
+                self.value = initializedValue
+                return initializedValue
+            }
+        }
+        set {
+            initializer = newValue
+        }
+    }
+}

--- a/Sources/QuranKit/Page.swift
+++ b/Sources/QuranKit/Page.swift
@@ -48,12 +48,7 @@ public struct Page: QuranValueGroup {
     }
 
     public var startJuz: Juz {
-        for (juz, nextJuz) in zip(quran.juzs, quran.juzs.dropFirst()) {
-            if self < nextJuz.page {
-                return juz
-            }
-        }
-        return quran.juzs.last!
+        return quran.juzs.binarySearchFirst { self >= $0.page }
     }
 
     public var quarter: Quarter? {

--- a/Sources/QuranKit/Quran.swift
+++ b/Sources/QuranKit/Quran.swift
@@ -7,10 +7,20 @@
 
 import Foundation
 
-public struct Quran: Hashable {
+public final class Quran: Hashable {
     private let id = UUID()
     let raw: QuranReadingInfoRawData
     public static let madani = Quran(raw: MadaniQuranReadingInfoRawData())
+
+    init(raw: QuranReadingInfoRawData) {
+        self.raw = raw
+        lazySuras = { self.surasRange.map { Sura(quran: self, suraNumber: $0)! } }
+        lazyPages = { self.pagesRange.map { Page(quran: self, pageNumber: $0)! } }
+        lazyJuzs = { (1 ... self.numberOfJuzs).map { Juz(quran: self, juzNumber: $0) } }
+        lazyQuarters = { (1 ... self.raw.quarters.count).map { Quarter(quran: self, quarterNumber: $0) } }
+        lazyHizbs = { (1 ... self.numberOfHizbs).map { Hizb(quran: self, hizbNumber: $0) } }
+        lazyVerses = { self.suras.flatMap(\.verses) }
+    }
 
     public var arabicBesmAllah: String {
         raw.arabicBesmAllah
@@ -20,18 +30,44 @@ public struct Quran: Hashable {
         hasher.combine(id)
     }
 
-    public static func == (lhs: Self, rhs: Self) -> Bool {
+    public static func == (lhs: Quran, rhs: Quran) -> Bool {
         lhs.id == rhs.id
+    }
+
+    @LazyAtomic private var lazySuras: () -> [Sura]
+     public var suras: [Sura] {
+         lazySuras()
+    }
+
+    @LazyAtomic private var lazyPages: () -> [Page]
+    public var pages: [Page] {
+        lazyPages()
+    }
+
+    @LazyAtomic private var lazyJuzs: () -> [Juz]
+    public var juzs: [Juz] {
+        lazyJuzs()
+    }
+
+    @LazyAtomic private var lazyQuarters: () -> [Quarter]
+    public var quarters: [Quarter] {
+        lazyQuarters()
+    }
+
+    @LazyAtomic private var lazyHizbs: () -> [Hizb]
+    public var hizbs: [Hizb] {
+        lazyHizbs()
+    }
+
+    @LazyAtomic private var lazyVerses: () -> [AyahNumber]
+    public var verses: [AyahNumber] {
+        lazyVerses()
     }
 }
 
 extension Quran {
     var pagesRange: ClosedRange<Int> {
         1 ... raw.startSuraOfPage.count
-    }
-
-    public var pages: [Page] {
-        pagesRange.map { Page(quran: self, pageNumber: $0)! }
     }
 }
 
@@ -43,32 +79,18 @@ extension Quran {
     public var firstSura: Sura {
         suras.first!
     }
-
-    public var suras: [Sura] {
-        surasRange.map { Sura(quran: self, suraNumber: $0)! }
-    }
 }
 
 extension Quran {
     private static let numberOfHizbsInJuz = 2
     private var numberOfJuzs: Int { numberOfHizbs / Self.numberOfHizbsInJuz }
-    public var juzs: [Juz] {
-        (1 ... numberOfJuzs).map { Juz(quran: self, juzNumber: $0) }
-    }
-}
 
-extension Quran {
-    public var quarters: [Quarter] {
-        (1 ... raw.quarters.count).map { Quarter(quran: self, quarterNumber: $0) }
-    }
 }
 
 extension Quran {
     private static let numberOfQuartersInHizb = 4
     private var numberOfHizbs: Int { raw.quarters.count / Self.numberOfQuartersInHizb }
-    public var hizbs: [Hizb] {
-        (1 ... numberOfHizbs).map { Hizb(quran: self, hizbNumber: $0) }
-    }
+
 }
 
 extension Quran {
@@ -78,9 +100,5 @@ extension Quran {
 
     public var lastVerse: AyahNumber {
         verses.last!
-    }
-
-    public var verses: [AyahNumber] {
-        suras.flatMap(\.verses)
     }
 }

--- a/Sources/QuranKit/Util.swift
+++ b/Sources/QuranKit/Util.swift
@@ -1,0 +1,34 @@
+//
+//  Util.swift
+//
+//
+//  Created by Mohamed Afifi on 2022-01-08.
+//
+
+import Foundation
+
+extension RandomAccessCollection {
+    func binarySearchFirst(predicate: (Element) -> Bool) -> Element {
+        let index = binarySearchIndex(predicate: predicate)
+        let previousIndex = self.index(index, offsetBy: -1)
+        return self[previousIndex]
+    }
+
+    /// Finds such index N that predicate is true for all elements up to
+    /// but not including the index N, and is false for all elements
+    /// starting with index N.
+    /// Behavior is undefined if there is no such N.
+    func binarySearchIndex(predicate: (Element) -> Bool) -> Index {
+        var low = startIndex
+        var high = endIndex
+        while low != high {
+            let mid = index(low, offsetBy: distance(from: low, to: high)/2)
+            if predicate(self[mid]) {
+                low = index(after: mid)
+            } else {
+                high = mid
+            }
+        }
+        return low
+    }
+}

--- a/Tests/QuranKitTests/AyahNumberTests.swift
+++ b/Tests/QuranKitTests/AyahNumberTests.swift
@@ -42,6 +42,10 @@ final class AyahNumberTests: XCTestCase {
         XCTAssertEqual(verses[27], verses[29].previous?.previous)
         XCTAssertNil(verses[0].previous)
 
+        XCTAssertEqual(verses[0].page.pageNumber, 1)
+        XCTAssertEqual(verses.last!.page.pageNumber, 604)
+        XCTAssertEqual(quran.suras[111].firstVerse.page.pageNumber, 604)
+        XCTAssertEqual(quran.suras[111].firstVerse.previous!.page.pageNumber, 603)
         XCTAssertEqual(verses[29].page.pageNumber, 4)
         XCTAssertEqual(verses[3].page.pageNumber, 1)
         XCTAssertEqual(verses[6235].page.pageNumber, 604)

--- a/Tests/QuranKitTests/PageTests.swift
+++ b/Tests/QuranKitTests/PageTests.swift
@@ -39,6 +39,11 @@ final class PageTests: XCTestCase {
         XCTAssertEqual(pages[206].startSura.suraNumber, 9)
         XCTAssertEqual(pages[207].startSura.suraNumber, 10)
 
+        XCTAssertEqual(pages[0].startJuz.juzNumber, 1)
+        XCTAssertEqual(pages.last!.startJuz.juzNumber, 30)
+        XCTAssertEqual(pages[540].startJuz.juzNumber, 27)
+        XCTAssertEqual(pages[541].startJuz.juzNumber, 28)
+        XCTAssertEqual(pages[542].startJuz.juzNumber, 28)
         XCTAssertEqual(pages[599].startJuz.juzNumber, 30)
         XCTAssertEqual(pages[1].startJuz.juzNumber, 1)
         XCTAssertEqual(pages[207].startJuz.juzNumber, 11)

--- a/Tests/QuranKitTests/QuarterTests.swift
+++ b/Tests/QuranKitTests/QuarterTests.swift
@@ -57,4 +57,11 @@ final class QuarterTests: XCTestCase {
         XCTAssertEqual(quarters[8].hizb.hizbNumber, 3)
         XCTAssertEqual(quarters[239].hizb.hizbNumber, 60)
     }
+
+    func testQuartersJuzTime() {
+        measure {
+            let quarters = quran.quarters
+            _ = Dictionary(grouping: quarters, by: \.juz)
+        }
+    }
 }

--- a/Tests/QuranKitTests/SuraTests.swift
+++ b/Tests/QuranKitTests/SuraTests.swift
@@ -79,4 +79,23 @@ final class SuraTests: XCTestCase {
         XCTAssertEqual(suras[24].lastVerse.sura.suraNumber, 25)
         XCTAssertEqual(suras[24].lastVerse.ayah, 77)
     }
+
+    func testSurasPagesTime() {
+        measure {
+            let quran = Quran(raw: MadaniQuranReadingInfoRawData())
+            let suras = quran.suras
+            _ = Dictionary(grouping: suras, by: { $0.page.startJuz })
+        }
+    }
+
+    func testSurasPagesCachedTime() {
+        let quran = Quran(raw: MadaniQuranReadingInfoRawData())
+        let suras = quran.suras
+        _ = Dictionary(grouping: suras, by: { $0.page.startJuz })
+
+        measure {
+            let suras = quran.suras
+            _ = Dictionary(grouping: suras, by: { $0.page.startJuz })
+        }
+    }
 }


### PR DESCRIPTION
* Using final class for the Quran object.
* Cache pages, suras, juzs, hizbs in the Quran object.
* Use binary search to find juz' of a page and page of a verse.

This improved reading juzs for all suras time from 8s to 0.001s.