### PR TITLE
Use filename to identify translation

### DIFF
--- a/Sources/TranslationService/ActiveTranslationsPersistence.swift
+++ b/Sources/TranslationService/ActiveTranslationsPersistence.swift
@@ -94,13 +94,12 @@ struct SQLiteActiveTranslationsPersistence: ActiveTranslationsPersistence, SQLit
     func update(_ translation: Translation) throws {
         try run { connection in
             let update = Translations.table
-                .where(Translations.id == translation.id)
+                .where(Translations.fileName == translation.fileName)
                 .update(
                     Translations.name <- translation.displayName,
                     Translations.translator <- translation.translator,
                     Translations.translatorForeign <- translation.translatorForeign,
                     Translations.fileURL <- translation.fileURL.absoluteString,
-                    Translations.fileName <- translation.fileName,
                     Translations.languageCode <- translation.languageCode,
                     Translations.version <- translation.version,
                     Translations.installedVersion <- translation.installedVersion

--- a/Sources/TranslationService/TranslationsRepository.swift
+++ b/Sources/TranslationService/TranslationsRepository.swift
@@ -41,16 +41,16 @@ public struct TranslationsRepository {
             .map(saveCombined) // save combined list
     }
 
-    private func combine(local: [Translation], remote: [Translation]) -> ([Translation], [Int: Translation]) {
-        let localMapConstant = local.flatGroup { $0.id }
+    private func combine(local: [Translation], remote: [Translation]) -> ([Translation], [String: Translation]) {
+        let localMapConstant = local.flatGroup { $0.fileName }
         var localMap = localMapConstant
 
         var combinedList: [Translation] = []
         remote.forEach { remote in
             var combined = remote
-            if let local = localMap[remote.id] {
+            if let local = localMap[remote.fileName] {
                 combined.installedVersion = local.installedVersion
-                localMap[remote.id] = nil
+                localMap[remote.fileName] = nil
             }
             combinedList.append(combined)
         }
@@ -58,9 +58,9 @@ public struct TranslationsRepository {
         return (combinedList, localMapConstant)
     }
 
-    private func saveCombined(translations: [Translation], localMap: [Int: Translation]) throws {
+    private func saveCombined(translations: [Translation], localMap: [String: Translation]) throws {
         try translations.forEach { translation in
-            if localMap[translation.id] != nil {
+            if localMap[translation.fileName] != nil {
                 try self.persistence.update(translation)
             } else {
                 try self.persistence.insert(translation)


### PR DESCRIPTION
As id field can be different between different translation versions.