### PR TITLE
WIP: Do not include basmallah before first verse when ayah selection is repeating

### DIFF
--- a/Sources/QuranAudioKit/AudioPlayer/GaplessAudioRequestBuilder.swift
+++ b/Sources/QuranAudioKit/AudioPlayer/GaplessAudioRequestBuilder.swift
@@ -64,11 +64,13 @@ final class GaplessAudioRequestBuilder: QuranAudioRequestBuilder {
 
                     var frames: [AudioFrame] = []
                     var fileAyahs: [AyahNumber] = []
+                    let isRepeating = frameRuns != .one || requestRuns != .one
 
                     for (offset, verse) in suraTimings.verses.enumerated() {
-                        // start from 0 (beginning) if first ayah of the sura
+                        // start from 0 (to include basmallah) if first ayah of the sura unless ayah selection is repeating
+                        let startTime = !isRepeating && offset == 0 && verse.ayah.ayah == 1 ? 0 : verse.time.seconds
                         let endTime = offset == suraTimings.verses.count - 1 ? suraTimings.endTime : nil
-                        let frame = AudioFrame(startTime: offset == 0 && verse.ayah.ayah == 1 ? 0 : verse.time.seconds, endTime: endTime?.seconds)
+                        let frame = AudioFrame(startTime: startTime, endTime: endTime?.seconds)
                         frames.append(frame)
                         fileAyahs.append(verse.ayah)
                     }

--- a/Sources/QuranAudioKit/AudioPlayer/GaplessAudioRequestBuilder.swift
+++ b/Sources/QuranAudioKit/AudioPlayer/GaplessAudioRequestBuilder.swift
@@ -64,11 +64,10 @@ final class GaplessAudioRequestBuilder: QuranAudioRequestBuilder {
 
                     var frames: [AudioFrame] = []
                     var fileAyahs: [AyahNumber] = []
-                    let isRepeating = frameRuns != .one || requestRuns != .one
 
                     for (offset, verse) in suraTimings.verses.enumerated() {
-                        // start from 0 (to include basmallah) if first ayah of the sura unless ayah selection is repeating
-                        let startTime = !isRepeating && offset == 0 && verse.ayah.ayah == 1 ? 0 : verse.time.seconds
+                        // start from 0 (to include basmallah) if first ayah of the sura
+                        let startTime = offset == 0 && verse.ayah.ayah == 1 ? 0 : verse.time.seconds
                         let endTime = offset == suraTimings.verses.count - 1 ? suraTimings.endTime : nil
                         let frame = AudioFrame(startTime: startTime, endTime: endTime?.seconds)
                         frames.append(frame)

--- a/Sources/QuranAudioKit/AudioPlayer/GappedAudioRequestBuilder.swift
+++ b/Sources/QuranAudioKit/AudioPlayer/GappedAudioRequestBuilder.swift
@@ -39,14 +39,15 @@ final class GappedAudioRequestBuilder: QuranAudioRequestBuilder {
                       frameRuns: Runs,
                       requestRuns: Runs) -> Promise<QuranAudioRequest>
     {
-        let (urls, ayahs) = urlsToPlay(reciter: reciter, from: start, to: end)
+        let isRepeating = frameRuns != .one || requestRuns != .one
+        let (urls, ayahs) = urlsToPlay(reciter: reciter, from: start, to: end, isRepeating: isRepeating)
         let files = urls.map { AudioFile(url: $0, frames: [AudioFrame(startTime: 0, endTime: nil)]) }
         let request = AudioRequest(files: files, endTime: nil, frameRuns: frameRuns, requestRuns: requestRuns)
         let quranRequest = GappedAudioRequest(request: request, ayahs: ayahs, reciter: reciter)
         return Promise.value(quranRequest)
     }
 
-    private func urlsToPlay(reciter: Reciter, from start: AyahNumber, to end: AyahNumber) -> (urls: [URL], ayahs: [AyahNumber]) {
+    private func urlsToPlay(reciter: Reciter, from start: AyahNumber, to end: AyahNumber, isRepeating: Bool) -> (urls: [URL], ayahs: [AyahNumber]) {
         guard case AudioType.gapped = reciter.audioType else {
             fatalError("Unsupported reciter type gapless. Only gapless reciters can be downloaded here.")
         }
@@ -60,7 +61,8 @@ final class GappedAudioRequestBuilder: QuranAudioRequestBuilder {
             let verses = surasDictionary[sura] ?? []
 
             // add besm Allah for all except Al-Fatihah and At-Tawbah
-            if sura.startsWithBesmAllah && verses[0] == sura.firstVerse {
+            // if ayah selection is repeated, do not include basmallah
+            if !isRepeating && sura.startsWithBesmAllah && verses[0] == sura.firstVerse {
                 urls.append(createRequestInfo(reciter: reciter, verse: start.quran.firstVerse))
                 ayahs.append(verses[0])
             }


### PR DESCRIPTION
When a user has selected ayahs for repeating, we should exclude the basmallah from playing before the first verse of a surah. A common use case for repeating ayahs is to memorize and by excluding the basmallah, the user can focus on just the ayahs they are trying to memorize.