### PR TITLE
Revert Translation Matching Logic to Use FileName

### DIFF
--- a/Domain/TranslationService/Sources/TranslationsRepository.swift
+++ b/Domain/TranslationService/Sources/TranslationsRepository.swift
@@ -52,16 +52,16 @@ public struct TranslationsRepository {
 
     // MARK: Private
 
-    private func combine(local: [Translation], remote: [Translation]) -> ([Translation], [Int: Translation]) {
-        let localMapConstant = local.flatGroup { $0.id }
+    private func combine(local: [Translation], remote: [Translation]) -> ([Translation], [String: Translation]) {
+        let localMapConstant = local.flatGroup { $0.fileName }
         var localMap = localMapConstant
 
         var combinedList: [Translation] = []
         remote.forEach { remote in
             var combined = remote
-            if let local = localMap[remote.id] {
+            if let local = localMap[remote.fileName] {
                 combined.installedVersion = local.installedVersion
-                localMap[remote.id] = nil
+                localMap[remote.fileName] = nil
             }
             combinedList.append(combined)
         }
@@ -69,9 +69,9 @@ public struct TranslationsRepository {
         return (combinedList, localMapConstant)
     }
 
-    private func saveCombined(translations: [Translation], localMap: [Int: Translation]) async throws {
+    private func saveCombined(translations: [Translation], localMap: [String: Translation]) async throws {
         for translation in translations {
-            if localMap[translation.id] != nil {
+            if localMap[translation.fileName] != nil {
                 try await persistence.update(translation)
             } else {
                 try await persistence.insert(translation)

--- a/Domain/TranslationService/Sources/TranslationsRepository.swift
+++ b/Domain/TranslationService/Sources/TranslationsRepository.swift
@@ -71,11 +71,10 @@ public struct TranslationsRepository {
 
     private func saveCombined(translations: [Translation], localMap: [String: Translation]) async throws {
         for translation in translations {
-            if localMap[translation.fileName] != nil {
-                try await persistence.update(translation)
-            } else {
-                try await persistence.insert(translation)
+            if let oldTranslation = localMap[translation.fileName] {
+                try await persistence.remove(oldTranslation)
             }
+            try await persistence.insert(translation)
         }
     }
 }

--- a/Domain/TranslationService/Tests/TranslationsRepositoryTests.swift
+++ b/Domain/TranslationService/Tests/TranslationsRepositoryTests.swift
@@ -49,7 +49,7 @@ class TranslationsRepositoryTests: XCTestCase {
     func test_updatedVersion() async throws {
         let translation = translations[0]
         let updatedTranslation = Translation(
-            id: translation.id,
+            id: translation.id + 45,
             displayName: translation.displayName,
             translator: translation.translator,
             translatorForeign: translation.translatorForeign,
@@ -69,11 +69,10 @@ class TranslationsRepositoryTests: XCTestCase {
         XCTAssertEqual(localResults, [updatedTranslation])
     }
 
-    // TODO: This crashes the app, we should fix it.
-    func DISABLED_test_updatedFileName() async throws {
+    func test_updatedFileName() async throws {
         let translation = translations[0]
         let updatedTranslation = Translation(
-            id: translation.id,
+            id: translation.id + 19,
             displayName: translation.displayName,
             translator: translation.translator,
             translatorForeign: translation.translatorForeign,
@@ -90,7 +89,14 @@ class TranslationsRepositoryTests: XCTestCase {
         try await service.downloadAndSyncTranslations()
 
         let localResults = try await retriever.getLocalTranslations()
-        XCTAssertEqual(localResults, [updatedTranslation])
+
+        // Expected to create a duplicate entry if fileName changed,
+        // fileName should not change to upgrade, it's a unique value
+        // per translation
+        XCTAssertEqual(localResults.sorted(), [
+            expectedTranslation(translation, installedVersion: nil),
+            expectedTranslation(updatedTranslation, installedVersion: nil),
+        ].sorted())
     }
 
     // MARK: Private


### PR DESCRIPTION

This pull request reverts a recent change (https://github.com/quran/quran-ios/pull/526) in the matching logic of translations from using `Translation.Id` to `fileName`. The update was initially implemented to enhance the accuracy of translation matching. However, it was observed that new versions of the same translation are assigned new IDs, leading to inconsistencies in the matching process.

### Issue
After updating the matching logic to utilize `Translation.Id`, we encountered a significant issue where new versions of translations received different IDs, breaking the expected continuity and leading to mismatches in our application. This behavior was not anticipated and has affected the stability of the translation matching feature.

### Resolution
To address this, we've decided to revert to using the `fileName` as the matching reference. The `fileName` has been confirmed with the backend team to be a stable and unchanging field, ensuring consistent matching even when new versions of translations are released.

### Testing
The changes have been tested locally, and existing automated tests have been updated to reflect this new logic. Manual testing was also conducted to ensure that translations are being matched correctly with their respective `fileName`.
