### PR TITLE
Refactor property reading: use code-based creation

### DIFF
--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -133,26 +133,30 @@
 "reading.selector.selectMushaf.long" = "اختر هذا المصحف";
 "reading.selector.title" = "اختر المصحف";
 "reading.selector.selection-description" = "اضغط على المصحف للمزيد من المعلومات.";
+"reading.selector.property.hafs" = "مصحف حفص عن عاصم";
+"reading.selector.property.pages.604" = "٦٠٤ صفحة";
+"reading.selector.property.lines.15" = "١٥ سطرًا بالصفحة";
+"reading.selector.property.word-translation.supported" = "يدعم ترجمة الكلمات";
+"reading.selector.property.word-translation.not-supported" = "لا يدعم ترجمة الكلمات";
 
 // Hafs 1405
 "reading.hafs-1405.title" = "حفص، مصحف المدينة المنورة النمطي، ١٤٠٥هـ";
 "reading.hafs-1405.description" = "مصحف حفص عن عاصم، إصدر المدينة المنورة عام ١٤٠٥ هـ. كان التطبيق يقدم هذا الإصدار لفترة طويلة. \n إصدار مجمع الملك فهد لطباعة المصحف.";
-"reading.hafs-1405.properties" = "مصحف حفص عن عاصم\nإصدار١٤٠٥ هجري\n٦٠٤ صفحة\n١٥ سطرًا بالصفحة\nيدعم ترجمة الكلمات";
+"reading.hafs-1405.issue" = "إصدار ١٤٠٥ هجري";
 
 // Hafs 1421
 "reading.hafs-1421.title" = "حفص، مصحف المدينة المنورة النمطي، ١٤٢١هـ";
 "reading.hafs-1421.description" = "مصحف حفص عن عاصم، إصدر المدينة المنورة عام ١٤٢١ هـ. إصدار مجمع الملك فهد لطباعة المصحف.";
-"reading.hafs-1421.properties" = "مصحف حفص عن عاصم\nإصدار١٤٢١ هجري\n٦٠٤ صفحة\n١٥ سطرًا بالصفحة\n!لا يدعم ترجمة الكلمات";
+"reading.hafs-1421.issue" = "إصدار ١٤٢١ هجري";
 
 // Hafs 1440
 "reading.hafs-1440.title" = "حفص، مصحف المدينة المنورة النمطي، ١٤٤٠هـ";
 "reading.hafs-1440.description" = "مصحف حفص عن عاصم، إصدر المدينة المنورة عام ١٤٤٠ هـ. إصدار مجمع الملك فهد لطباعة المصحف.";
-"reading.hafs-1440.properties" = "مصحف حفص عن عاصم\nإصدار١٤٤٠ هجري\n٦٠٤ صفحة\n١٥ سطرًا بالصفحة\n!لا يدعم ترجمة الكلمات";
+"reading.hafs-1440.issue" = "إصدار ١٤٤٠ هجري";
 
 // Hafs Tajweed
 "reading.tajweed.title" = "مصحف التجويد";
 "reading.tajweed.description" = "مصحف التجويد (حفص عن عاصم) – دار المعرفة";
-"reading.tajweed.properties" = "مصحف حفص عن عاصم\n٦٠٤ صفحة\n١٥ سطرًا بالصفحة\nيدعم ترجمة الكلمات";
 
 // MARK: - What's new
 

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -136,26 +136,30 @@
 "reading.selector.selectMushaf.long" = "Set as current Mushaf";
 "reading.selector.title" = "Choose Mushaf";
 "reading.selector.selection-description" = "Tap on a Mushaf for more information.";
+"reading.selector.property.hafs" = "Hafs Mushaf";
+"reading.selector.property.pages.604" = "604 pages";
+"reading.selector.property.lines.15" = "15-line page";
+"reading.selector.property.word-translation.supported" = "Word-by-word translation";
+"reading.selector.property.word-translation.not-supported" = "No Word-by-word translation";
 
 // Hafs 1405
 "reading.hafs-1405.title" = "Hafs, classic Madina, 1405 AH";
 "reading.hafs-1405.description" = "The classic hafs Mushaf issued in Madina in 1405 Hijri. The app used to offer this version for a long time.\nFrom the King Fahd Quran Printing Complex.";
-"reading.hafs-1405.properties" = "Hafs Mushaf\nIssued in 1405 Hijri\n604 pages\n15-line page\nWord-by-word translation";
+"reading.hafs-1405.issue" = "Issued in 1405 Hijri";
 
 // Hafs 1421
 "reading.hafs-1421.title" = "Hafs, Madina, 1421 AH";
 "reading.hafs-1421.description" = "The hafs Mushaf issued in Madina in 1421 Hijri. From the King Fahd Quran Printing Complex.";
-"reading.hafs-1421.properties" = "Hafs Mushaf\nIssued in 1421 Hijri\n604 pages\n15-line page\n!No Word-by-word translation";
+"reading.hafs-1421.issue" = "Issued in 1421 Hijri";
 
 // Hafs 1440
 "reading.hafs-1440.title" = "Hafs, Madina, 1440 AH";
 "reading.hafs-1440.description" = "The hafs Mushaf issued in Madina in 1440 Hijri. From the King Fahd Quran Printing Complex.";
-"reading.hafs-1440.properties" = "Hafs Mushaf\nIssued in 1440 Hijri\n604 pages\n15-line page\n!No Word-by-word translation";
+"reading.hafs-1440.issue" = "Issued in 1440 Hijri";
 
 // Hafs Tajweed
 "reading.tajweed.title" = "Hafs, Tajweed";
 "reading.tajweed.description" = "The tajweed hafs Mushaf. Al-Quran Al-Kareem - Dar al-Marefa Edition.";
-"reading.tajweed.properties" = "Hafs Mushaf\n604 pages\n15-line page\nWord-by-word translation";
 
 // MARK: - What's new
 

--- a/Core/Localization/Resources/nl.lproj/Localizable.strings
+++ b/Core/Localization/Resources/nl.lproj/Localizable.strings
@@ -134,18 +134,25 @@
 "reading.selector.selectMushaf.long" = "Stel in als huidige Mushaf";
 "reading.selector.title" = "Kies Musaf";
 "reading.selector.selection-description" = "Tik op een Mushaf voor meer informatie.";
+"reading.selector.property.hafs" = "Hafs Mushaf";
+"reading.selector.property.pages.604" = "604 pagina's";
+"reading.selector.property.lines.15" = "Pagina van 15 regels";
+"reading.selector.property.word-translation.supported" = "Woord-voor-woord vertaling";
+"reading.selector.property.word-translation.not-supported" = "Geen woord-voor-woord vertaling";
 
 // Hafs 1405
 "reading.hafs-1405.title" = "Hafs, klassieke Madina, 1405 AH";
 "reading.hafs-1405.description" = "De klassieke hafs Mushaf, uitgegeven in Madina in 1405 Hijri. De app bood deze versie lange tijd aan.\nUit het King Fahd Quran Printing Complex.";
-"reading.hafs-1405.properties" = "Hafs Mushaf\nUitgegeven in 1405 Hijri\n604 pagina's\nPagina van 15 regels\nWoord-voor-woord vertaling";
+"reading.hafs-1405.issue" = "Uitgegeven in 1405 Hijri";
 
 // Hafs 1421
+"reading.hafs-1421.title" = "Hafs, klassieke Madina, 1421 AH";
+"reading.hafs-1421.issue" = "Uitgegeven in 1421 Hijri";
 
 // Hafs 1440
 "reading.hafs-1440.title" = "Hafs, Madina, 1440 AH";
 "reading.hafs-1440.description" = "De hafs Mushaf uitgegeven in Medina in 1440 Hijri. Van het King Fahd Quran Printing Complex.";
-"reading.hafs-1440.properties" = "Hafs Mushaf\nUitgegeven in 1405 Hijri\n604 pagina's\nPagina van 15 regels\n!Woord-voor-woord vertaling";
+"reading.hafs-1440.issue" = "Uitgegeven in 1440 Hijri";
 
 // Hafs Tajweed
 

--- a/Core/Localization/Resources/vi.lproj/Localizable.strings
+++ b/Core/Localization/Resources/vi.lproj/Localizable.strings
@@ -134,26 +134,30 @@
 "reading.selector.selectMushaf.long" = "Đặt làm Mushaf hiện tại";
 "reading.selector.title" = "Chọn Mushaf";
 "reading.selector.selection-description" = "Chạm vào Mushaf để biết thêm thông tin.";
+"reading.selector.property.hafs" = "Hafs Mushaf";
+"reading.selector.property.pages.604" = "604 trang";
+"reading.selector.property.lines.15" = "15-dòng mỗi trang";
+"reading.selector.property.word-translation.supported" = "Dịch Từng Từ";
+"reading.selector.property.word-translation.not-supported" = "Không có Dịch Từng Từ";
 
 // Hafs 1405
 "reading.hafs-1405.title" = "Hafs, Madina cổ điển, 1405 AH";
 "reading.hafs-1405.description" = "Hafs cổ điển Mushaf ban hành ở Madina vào năm 1405 Hijri. Ứng dụng đã từng cung cấp phiên bản này trong một thời gian dài.\nTừ Tổ hợp In ấn Kinh Quran của Vua Fahd.";
-"reading.hafs-1405.properties" = "Hafs Mushaf\nBan hành năm 1405 Hijri\n604 trang\n15-dòng mỗi trang\nDịch Từng Từ";
+"reading.hafs-1405.issue" = "Ban hành năm 1405 Hijri";
 
 // Hafs 1421
 "reading.hafs-1421.title" = "Hafs, Madina, 1421 AH";
 "reading.hafs-1421.description" = "Hafs Mushaf ban hành ở Madina vào năm 1421 Hijri. Từ Tổ hợp in Kinh Quran King Fahd.";
-"reading.hafs-1421.properties" = "Hafs Mushaf\nBan hành năm 1421 Hijri\n604 trang\n15-dòng mỗi trang\n!Không có Dịch Từng Từ";
+"reading.hafs-1421.issue" = "Ban hành năm 1421 Hijri";
 
 // Hafs 1440
 "reading.hafs-1440.title" = "Hafs, Madina, 1440 AH";
 "reading.hafs-1440.description" = "Hafs Mushaf ban hành ở Madina vào năm 1440 Hijri. Từ Tổ hợp in Kinh Quran King Fahd.";
-"reading.hafs-1440.properties" = "Hafs Mushaf\nBan hành năm 1440 Hijri\n604 trang\n15-dòng mỗi trang\n!Không có Dịch Từng Từ";
+"reading.hafs-1440.issue" = "Ban hành năm 1440 Hijri";
 
 // Hafs Tajweed
 "reading.tajweed.title" = "Hafs, Tajweed";
 "reading.tajweed.description" = "Tajweed hafs Mushaf. Al-Quran Al-Kareem - Phiên bản Dar al-Marefa.";
-"reading.tajweed.properties" = "Hafs Mushaf\n604 trang\n15-dòng mỗi trang\nDịch Từng Từ";
 
 // MARK: - What's new
 

--- a/Features/ReadingSelectorFeature/ReadingSelectorViewModel.swift
+++ b/Features/ReadingSelectorFeature/ReadingSelectorViewModel.swift
@@ -81,7 +81,7 @@ private extension ReadingInfo where Value == Reading {
             value: reading,
             title: reading.title,
             description: reading.description,
-            properties: reading.propertiesDescription
+            properties: reading.properties
         )
     }
 }

--- a/Features/ReadingSelectorFeature/View/Reading+Resources.swift
+++ b/Features/ReadingSelectorFeature/View/Reading+Resources.swift
@@ -13,6 +13,18 @@ import QuranKit
 import UIKit
 
 extension Reading {
+    struct Property: Hashable {
+        enum PropertType {
+            case supports
+            case lacks
+        }
+
+        // MARK: Internal
+
+        let type: PropertType
+        let property: String
+    }
+
     var title: String {
         switch self {
         case .hafs_1405:
@@ -39,16 +51,39 @@ extension Reading {
         }
     }
 
-    var propertiesDescription: String {
+    var properties: [Property] {
         switch self {
         case .hafs_1405:
-            return l("reading.hafs-1405.properties")
+            return [
+                Property(type: .supports, property: l("reading.selector.property.hafs")),
+                Property(type: .supports, property: l("reading.hafs-1405.issue")),
+                Property(type: .supports, property: l("reading.selector.property.pages.604")),
+                Property(type: .supports, property: l("reading.selector.property.lines.15")),
+                Property(type: .supports, property: l("reading.selector.property.word-translation.supported")),
+            ]
         case .hafs_1421:
-            return l("reading.hafs-1421.properties")
+            return [
+                Property(type: .supports, property: l("reading.selector.property.hafs")),
+                Property(type: .supports, property: l("reading.hafs-1421.issue")),
+                Property(type: .supports, property: l("reading.selector.property.pages.604")),
+                Property(type: .supports, property: l("reading.selector.property.lines.15")),
+                Property(type: .lacks, property: l("reading.selector.property.word-translation.not-supported")),
+            ]
         case .hafs_1440:
-            return l("reading.hafs-1440.properties")
+            return [
+                Property(type: .supports, property: l("reading.selector.property.hafs")),
+                Property(type: .supports, property: l("reading.hafs-1440.issue")),
+                Property(type: .supports, property: l("reading.selector.property.pages.604")),
+                Property(type: .supports, property: l("reading.selector.property.lines.15")),
+                Property(type: .lacks, property: l("reading.selector.property.word-translation.not-supported")),
+            ]
         case .tajweed:
-            return l("reading.tajweed.properties")
+            return [
+                Property(type: .supports, property: l("reading.selector.property.hafs")),
+                Property(type: .supports, property: l("reading.selector.property.pages.604")),
+                Property(type: .supports, property: l("reading.selector.property.lines.15")),
+                Property(type: .lacks, property: l("reading.selector.property.word-translation.not-supported")),
+            ]
         }
     }
 

--- a/Features/ReadingSelectorFeature/View/ReadingInfo.swift
+++ b/Features/ReadingSelectorFeature/View/ReadingInfo.swift
@@ -7,52 +7,26 @@
 
 import Foundation
 import Localization
+import QuranKit
 
-public struct ReadingInfo<Value: Hashable>: Hashable, Identifiable {
-    struct Property: Hashable {
-        enum PropertType {
-            case supports
-            case lacks
-        }
-
-        // MARK: Lifecycle
-
-        init(property: String) {
-            if property.hasPrefix("!") {
-                type = .lacks
-                self.property = property.replacingOccurrences(of: "!", with: "")
-            } else {
-                type = .supports
-                self.property = property
-            }
-        }
-
-        // MARK: Internal
-
-        let type: PropertType
-        let property: String
-    }
-
+struct ReadingInfo<Value: Hashable>: Hashable, Identifiable {
     // MARK: Lifecycle
 
-    public init(value: Value, title: String, description: String, properties: String) {
+    init(value: Value, title: String, description: String, properties: [Reading.Property]) {
         self.value = value
         self.title = title
         self.description = description
-        self.properties = properties.components(separatedBy: "\n").map(Property.init)
+        self.properties = properties
     }
-
-    // MARK: Public
-
-    public let value: Value
-    public let title: String
-    public let description: String
-
-    public var id: Value { value }
 
     // MARK: Internal
 
-    let properties: [Property]
+    let value: Value
+    let title: String
+    let description: String
+    let properties: [Reading.Property]
+
+    var id: Value { value }
 }
 
 // Test data
@@ -69,7 +43,7 @@ enum ReadingInfoTestData {
                 value: $0,
                 title: l("reading.hafs-1405.title"),
                 description: l("reading.hafs-1405.description"),
-                properties: l("reading.hafs-1405.properties")
+                properties: []
             )
         }
     }


### PR DESCRIPTION
Changes:
- Transitioned property creation from localization-based to code-based implementation.
- Resolved issue that Tajweed Mushaf mistakenly supports word-by-word translation.