### PR TITLE
Fix crash when getOnGoingDownloads is called early

### DIFF
--- a/Core/Utilities/Sources/Features/AsyncInitializer.swift
+++ b/Core/Utilities/Sources/Features/AsyncInitializer.swift
@@ -1,0 +1,39 @@
+//
+//  AsyncInitializer.swift
+//
+//
+//  Created by Mohamed Afifi on 2023-11-26.
+//
+
+public struct AsyncInitializer {
+    // MARK: Lifecycle
+
+    public init() {
+        var continuation: AsyncStream<Void>.Continuation!
+        let stream = AsyncStream<Void> { continuation = $0 }
+        self.continuation = continuation
+        self.stream = stream
+    }
+
+    // MARK: Public
+
+    public private(set) var initialized = false
+
+    public mutating func initialize() {
+        initialized = true
+        continuation.finish()
+    }
+
+    public func awaitInitialization() async {
+        if initialized {
+            return
+        }
+        // Wait until the stream finishes
+        for await _ in stream {}
+    }
+
+    // MARK: Private
+
+    private let continuation: AsyncStream<Void>.Continuation
+    private let stream: AsyncStream<Void>
+}

--- a/Data/BatchDownloader/Sources/Downloader/DownloadManager.swift
+++ b/Data/BatchDownloader/Sources/Downloader/DownloadManager.swift
@@ -67,17 +67,7 @@ public final class DownloadManager: Sendable {
 
     public func start() async {
         logger.info("Starting download manager")
-        let operationQueue = OperationQueue()
-        operationQueue.name = "com.quran.downloads"
-        operationQueue.maxConcurrentOperationCount = 1
-
-        let dispatchQueue = DispatchQueue(label: "com.quran.downloads.dispatch")
-        operationQueue.underlyingQueue = dispatchQueue
-
-        await dataController.bootstrapPersistence()
-
-        let session = sessionFactory(handler, operationQueue)
-        self.session = session
+        let session = createSession()
         await dataController.start(with: session)
         logger.info("Download manager start completed")
     }
@@ -101,4 +91,18 @@ public final class DownloadManager: Sendable {
     private var session: NetworkSession?
     private let handler: DownloadSessionDelegate
     private let dataController: DownloadBatchDataController
+
+    private func createSession() -> NetworkSession {
+        let operationQueue = OperationQueue()
+        operationQueue.name = "com.quran.downloads"
+        operationQueue.maxConcurrentOperationCount = 1
+
+        let dispatchQueue = DispatchQueue(label: "com.quran.downloads.dispatch")
+        operationQueue.underlyingQueue = dispatchQueue
+
+        let session = sessionFactory(handler, operationQueue)
+        self.session = session
+
+        return session
+    }
 }


### PR DESCRIPTION
Sometimes `DownloadManager.getOnGoingDownloads` may be called earlier than `DownloadManager.start`. This result in a crash.

This change ensures that getOnGoingDownloads awaits the initialization.