### PR TITLE
Search was broken due to concurrent search requests

### DIFF
--- a/Features/SearchFeature/SearchTypes.swift
+++ b/Features/SearchFeature/SearchTypes.swift
@@ -6,30 +6,19 @@
 //
 
 import Foundation
+import QuranText
 
 enum SearchUIState {
     case entry
-    case autocomplete
-    case loading
-    case searchResults
+    case search(_ term: String)
 }
 
-enum SearchTerm {
-    case autocomplete(_ term: String)
-    case noAction(_ term: String)
+enum SearchState {
+    case searching
+    case searchResult(_ results: [SearchResults])
+}
 
-    // MARK: Internal
-
-    var term: String {
-        switch self {
-        case .autocomplete(let term), .noAction(let term): return term
-        }
-    }
-
-    var isAutocomplete: Bool {
-        switch self {
-        case .autocomplete: return true
-        case .noAction: return false
-        }
-    }
+enum KeyboardState {
+    case open
+    case closed
 }

--- a/Features/SearchFeature/SearchViewController.swift
+++ b/Features/SearchFeature/SearchViewController.swift
@@ -9,8 +9,9 @@ import Combine
 import Foundation
 import Localization
 import SwiftUI
+import VLogging
 
-final class SearchViewController: UIViewController, UISearchResultsUpdating, UISearchBarDelegate {
+final class SearchViewController: UIViewController, UISearchBarDelegate {
     // MARK: Lifecycle
 
     init(viewModel: SearchViewModel) {
@@ -44,41 +45,57 @@ final class SearchViewController: UIViewController, UISearchResultsUpdating, UIS
         searchController.obscuresBackgroundDuringPresentation = false
         searchController.hidesNavigationBarDuringPresentation = true
         searchController.searchBar.placeholder = l("search.placeholder.text")
-        searchController.searchResultsUpdater = self
         searchController.searchBar.delegate = self
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
         definesPresentationContext = true
 
         viewModel.$searchTerm
-            .map(\.term)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] searchTerm in
-                if searchTerm != self?.searchController.searchBar.text {
-                    self?.searchController.searchBar.text = searchTerm
-                }
+                self?.searchController.searchBar.text = searchTerm
             }
             .store(in: &cancellables)
 
-        viewModel.resignSearchBar
+        viewModel.$keyboardState
+            .removeDuplicates()
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] in
-                self?.searchController.searchBar.endEditing(true)
+            .sink { [weak self] state in
+                switch state {
+                case .closed:
+                    self?.searchController.searchBar.endEditing(true)
+                case .open:
+                    self?.searchController.searchBar.becomeFirstResponder()
+                }
             }
             .store(in: &cancellables)
     }
 
     // MARK: - Search delegate methods
 
-    func updateSearchResults(for searchController: UISearchController) {
-        let term = searchController.searchBar.text ?? ""
-        if viewModel.searchTerm.term != term {
-            viewModel.searchTerm = .autocomplete(term)
-        }
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        logger.info("[Search] textDidChange to \(searchText)")
+        viewModel.autocomplete(searchText)
+    }
+
+    func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
+        logger.info("[Search] searchBarTextDidBeginEditing \(searchBar.text ?? "")")
+        viewModel.keyboardState = .open
+    }
+
+    func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
+        logger.info("[Search] searchBarTextDidEndEditing \(searchBar.text ?? "")")
+        viewModel.keyboardState = .closed
     }
 
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        logger.info("[Search] searchBarSearchButtonClicked \(searchBar.text ?? "")")
         viewModel.searchForUserTypedTerm()
+    }
+
+    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+        logger.info("[Search] searchBarCancelButtonClicked")
+        viewModel.reset()
     }
 
     // MARK: Private


### PR DESCRIPTION
This change ensures only one search request executes at a time. Additionally, the change ensures proper search lifecycle handling.