### PR TITLE
Add set as current Mushaf to the top of the details screen

### DIFF
--- a/Features/ReadingSelectorFeature/View/ReadingDetails.swift
+++ b/Features/ReadingSelectorFeature/View/ReadingDetails.swift
@@ -21,19 +21,23 @@ struct ReadingDetails<Value: Hashable, ImageView: View>: View {
         NavigationView {
             ScrollView {
                 VStack {
+                    setCurrentMushafButton
+                        .padding(.top)
+
                     Text(reading.description)
-                        .padding()
+                        .padding(.top)
 
                     propertiesList
-                        .padding([.horizontal])
+                        .padding(.top)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
                     ReadingImage(imageView: imageView)
-                        .padding()
+                        .padding(.top)
 
                     setCurrentMushafButton
-                        .padding()
+                        .padding(.top)
                 }
+                .padding(.horizontal)
             }
             .navigationTitle(reading.title)
             .navigationBarTitleDisplayMode(.inline)

--- a/Features/ReadingSelectorFeature/View/ReadingInfo.swift
+++ b/Features/ReadingSelectorFeature/View/ReadingInfo.swift
@@ -43,7 +43,11 @@ enum ReadingInfoTestData {
                 value: $0,
                 title: l("reading.hafs-1405.title"),
                 description: l("reading.hafs-1405.description"),
-                properties: []
+                properties: [
+                    .init(type: .supports, property: "Property 1"),
+                    .init(type: .supports, property: "Property 2"),
+                    .init(type: .lacks, property: "Property 3"),
+                ]
             )
         }
     }


### PR DESCRIPTION
Some users don't understand they need to tap "set as current Mushaf" to change the current mushaf.