### PR TITLE
Fix Arabic Text Rendering in Notes Sharing

### DIFF
--- a/Domain/QuranTextKit/Sources/ShareableText/ShareableVerseTextRetriever.swift
+++ b/Domain/QuranTextKit/Sources/ShareableText/ShareableVerseTextRetriever.swift
@@ -65,7 +65,14 @@ public struct ShareableVerseTextRetriever {
 
     private func arabicText(for verse: AyahNumber) async throws -> String {
         let verseNumber = NumberFormatter.arabicNumberFormatter.format(verse.ayah)
-        return try await shareableVersePersistence.textForVerse(verse) + "﴿ \(verseNumber) ﴾"
+
+        // Avoid the arabic text to be displayed in the wrong direction in LTR languages
+        let rightToLeftMark = "\u{202B}"
+        let endMark = "\u{202C}"
+
+        let arabicVerse = try await shareableVersePersistence.textForVerse(verse) + "﴿ \(verseNumber) ﴾"
+
+        return "\(rightToLeftMark)\(arabicVerse)\(endMark)"
     }
 
     private func arabicScript(for verses: [AyahNumber]) async throws -> [String] {

--- a/Domain/QuranTextKit/Tests/ShareableVerseTextRetrieverTests.swift
+++ b/Domain/QuranTextKit/Tests/ShareableVerseTextRetrieverTests.swift
@@ -64,7 +64,6 @@ final class ShareableVerseTextRetrieverTests: XCTestCase {
         ]
         for test in tests {
             let versesText = try await shareableTextRetriever.textForVerses(test.verses)
-            print(versesText)
             XCTAssertEqual(test.result, versesText)
         }
     }

--- a/Domain/QuranTextKit/Tests/ShareableVerseTextRetrieverTests.swift
+++ b/Domain/QuranTextKit/Tests/ShareableVerseTextRetrieverTests.swift
@@ -51,19 +51,20 @@ final class ShareableVerseTextRetrieverTests: XCTestCase {
         let tests = [
             (
                 verses: [quran.suras[0].verses[2]],
-                result: ["ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ٣ ﴾",
+                result: ["\(rightToLeftMark)ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ٣ ﴾\(endMark)",
                          "",
                          "Al-Fātihah, Ayah 3"]
             ),
             (
                 verses: [quran.suras[0].verses[0], quran.suras[0].verses[1], quran.suras[0].verses[2]],
-                result: ["بِسۡمِ ٱللَّهِ ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ١ ﴾ ٱلۡحَمۡدُ لِلَّهِ رَبِّ ٱلۡعَـٰلَمِینَ﴿ ٢ ﴾ ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ٣ ﴾",
+                result: ["\(rightToLeftMark)بِسۡمِ ٱللَّهِ ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ١ ﴾\(endMark) \(rightToLeftMark)ٱلۡحَمۡدُ لِلَّهِ رَبِّ ٱلۡعَـٰلَمِینَ﴿ ٢ ﴾\(endMark) \(rightToLeftMark)ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ٣ ﴾\(endMark)",
                          "",
                          "Al-Fātihah, Ayah 1 - Al-Fātihah, Ayah 3"]
             ),
         ]
         for test in tests {
             let versesText = try await shareableTextRetriever.textForVerses(test.verses)
+            print(versesText)
             XCTAssertEqual(test.result, versesText)
         }
     }
@@ -74,7 +75,7 @@ final class ShareableVerseTextRetrieverTests: XCTestCase {
         let tests = [
             (
                 verses: [quran.suras[0].verses[2]],
-                result: ["ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ٣ ﴾",
+                result: ["\(rightToLeftMark)ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ٣ ﴾\(endMark)",
                          "",
                          "• Khan & Hilai:",
                          TestData.translationTextAt(translations[0], quran.suras[0].verses[2]),
@@ -86,7 +87,7 @@ final class ShareableVerseTextRetrieverTests: XCTestCase {
             ),
             (
                 verses: [quran.suras[0].verses[0], quran.suras[0].verses[1], quran.suras[0].verses[2]],
-                result: ["بِسۡمِ ٱللَّهِ ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ١ ﴾ ٱلۡحَمۡدُ لِلَّهِ رَبِّ ٱلۡعَـٰلَمِینَ﴿ ٢ ﴾ ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ٣ ﴾",
+                result: ["\(rightToLeftMark)بِسۡمِ ٱللَّهِ ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ١ ﴾\(endMark) \(rightToLeftMark)ٱلۡحَمۡدُ لِلَّهِ رَبِّ ٱلۡعَـٰلَمِینَ﴿ ٢ ﴾\(endMark) \(rightToLeftMark)ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ٣ ﴾\(endMark)",
                          "",
                          "• Khan & Hilai:",
                          TestData.translationTextAt(translations[0], quran.suras[0].verses[0]),
@@ -113,7 +114,7 @@ final class ShareableVerseTextRetrieverTests: XCTestCase {
         try await localTranslationsFake.setTranslations([TestData.khanTranslation])
 
         let numberReference = try await shareableTextRetriever.textForVerses([quran.suras[1].verses[49]])
-        XCTAssertEqual(numberReference, ["وَإِذۡ فَرَقۡنَا بِكُمُ ٱلۡبَحۡرَ فَأَنجَیۡنَـٰكُمۡ وَأَغۡرَقۡنَاۤ ءَالَ فِرۡعَوۡنَ وَأَنتُمۡ تَنظُرُونَ﴿ ٥٠ ﴾",
+        XCTAssertEqual(numberReference, ["\(rightToLeftMark)وَإِذۡ فَرَقۡنَا بِكُمُ ٱلۡبَحۡرَ فَأَنجَیۡنَـٰكُمۡ وَأَغۡرَقۡنَاۤ ءَالَ فِرۡعَوۡنَ وَأَنتُمۡ تَنظُرُونَ﴿ ٥٠ ﴾\(endMark)",
                                          "",
                                          "• Khan & Hilai:",
                                          "See ayah 38.",
@@ -121,7 +122,7 @@ final class ShareableVerseTextRetrieverTests: XCTestCase {
                                          "Al-Baqarah, Ayah 50"])
 
         let verseSavedAsTextReference = try await shareableTextRetriever.textForVerses([quran.suras[1].verses[50]])
-        XCTAssertEqual(verseSavedAsTextReference, ["وَإِذۡ وَ ٰ⁠عَدۡنَا مُوسَىٰۤ أَرۡبَعِینَ لَیۡلَةࣰ ثُمَّ ٱتَّخَذۡتُمُ ٱلۡعِجۡلَ مِنۢ بَعۡدِهِۦ وَأَنتُمۡ ظَـٰلِمُونَ﴿ ٥١ ﴾",
+        XCTAssertEqual(verseSavedAsTextReference, ["\(rightToLeftMark)وَإِذۡ وَ ٰ⁠عَدۡنَا مُوسَىٰۤ أَرۡبَعِینَ لَیۡلَةࣰ ثُمَّ ٱتَّخَذۡتُمُ ٱلۡعِجۡلَ مِنۢ بَعۡدِهِۦ وَأَنتُمۡ ظَـٰلِمُونَ﴿ ٥١ ﴾\(endMark)",
                                                    "",
                                                    "• Khan & Hilai:",
                                                    "See ayah 38.",
@@ -136,7 +137,8 @@ final class ShareableVerseTextRetrieverTests: XCTestCase {
     private var localTranslationsFake: LocalTranslationsFake!
     private let quran = Quran.hafsMadani1405
     private let statePreferences = QuranContentStatePreferences.shared
-
+    private let rightToLeftMark = "\u{202B}"
+    private let endMark = "\u{202C}"
     private let translations = [
         TestData.khanTranslation,
         TestData.sahihTranslation,

--- a/Features/NotesFeature/NotesViewModel.swift
+++ b/Features/NotesFeature/NotesViewModel.swift
@@ -72,30 +72,18 @@ final class NotesViewModel: ObservableObject {
 
     func prepareNotesForSharing() async throws -> String {
         try await crasher.recordError("Failed to share notes") {
-            var notesText = ""
+            var notesText = [String]()
             for note in await notes {
-                let noteText = if let noteContent = note.note.note, noteContent != "" {
+                let title = if let noteContent = note.note.note, noteContent != "" {
                     "\(noteContent.trimmingCharacters(in: .newlines))\n\n"
                 } else {
                     ""
                 }
+                let verses = try await textRetriever.textForVerses(Array(note.note.verses)).joined(separator: "\n")
 
-                let verses = try await textRetriever.textForVerses(Array(note.note.verses))
-                
-                // Avoid the arabic text to be displayed in the wrong direction in LTR languages
-                if let arabicVerse = verses.first {
-                    let restOfVerses = verses.dropFirst()
-
-                    let rightToLeftMark = "\u{202B}"
-                    let endMark = "\u{202E}"
-                    let arabicTextWithMarks = "\(rightToLeftMark)\(arabicVerse)\(endMark)"
-                    
-                    let verseText = ([arabicTextWithMarks] + restOfVerses).joined(separator: "\n")
-
-                    notesText += "\(noteText)\(verseText)\n\n\n\n"
-                }                
+                notesText.append("\(title)\(verses)")
             }
-            return notesText.trimmingCharacters(in: .whitespacesAndNewlines)
+            return notesText.joined(separator: "\n\n\n\n")
         }
     }
 


### PR DESCRIPTION
Tries to fix the issue with brackets in texts with bidirectional languages by nesting the arabic text with unicode characters

Based off of these [Apple Docs](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/SupportingRight-To-LeftLanguages/SupportingRight-To-LeftLanguages.html#//apple_ref/doc/uid/10000171i-CH17-SW11)
and this [Stack Overflow](https://stackoverflow.com/questions/37497610/ios-rtl-improperly-displaying-english-inside-rtl-string)

https://github.com/user-attachments/assets/45397e0b-3844-495f-8933-ae590ffb4a88

