### PR TITLE
Custom URL Scheme Implementation

### DIFF
--- a/Example/QuranEngineApp/Classes/AppDelegate.swift
+++ b/Example/QuranEngineApp/Classes/AppDelegate.swift
@@ -49,27 +49,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let downloadManager = container.downloadManager
         downloadManager.setBackgroundSessionCompletion(completionHandler)
     }
-    
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
-        // Check if the URL scheme matches the custom scheme
-        if url.scheme == "quran-ios" {
-            // Parse the URL to determine the desired action
-            let path = url.host ?? ""
-            
-            // Implement custom logic to navigate to a specific view or perform an action
-            // Example: Navigate to a specific surah or ayah
-            handleCustomURL(path: path)
-            
-            return true
-        }
-        return false
-    }
-
-    private func handleCustomURL(path: String) {
-        // Example logic to handle the custom URL path
-        // This could involve navigating to a specific part of the app
-        // For instance, opening a specific Surah or Ayah
-    }
 
     // MARK: Private
 

--- a/Example/QuranEngineApp/Classes/AppDelegate.swift
+++ b/Example/QuranEngineApp/Classes/AppDelegate.swift
@@ -49,6 +49,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let downloadManager = container.downloadManager
         downloadManager.setBackgroundSessionCompletion(completionHandler)
     }
+    
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
+        // Check if the URL scheme matches the custom scheme
+        if url.scheme == "quran-ios" {
+            // Parse the URL to determine the desired action
+            let path = url.host ?? ""
+            
+            // Implement custom logic to navigate to a specific view or perform an action
+            // Example: Navigate to a specific surah or ayah
+            handleCustomURL(path: path)
+            
+            return true
+        }
+        return false
+    }
+
+    private func handleCustomURL(path: String) {
+        // Example logic to handle the custom URL path
+        // This could involve navigating to a specific part of the app
+        // For instance, opening a specific Surah or Ayah
+    }
 
     // MARK: Private
 

--- a/Example/QuranEngineApp/Classes/Container.swift
+++ b/Example/QuranEngineApp/Classes/Container.swift
@@ -54,23 +54,6 @@ class Container: AppDependencies {
     var logsDirectory: URL { FileManager.documentsURL.appendingPathComponent("logs") }
 
     var supportsCloudKit: Bool { false }
-    
-    // MARK: Public
-    func handleIncomingUrl(urlContext: UIOpenURLContext) {
-        let url = urlContext.url
-        
-        if url.scheme == "quran" || url.scheme == "quran-ios" {
-            let path: String
-            
-            if #available(iOS 16.0, *) {
-                path = url.path(percentEncoded: true)
-            } else {
-                path = url.path
-            }
-            
-            _ = navigateTo(path: path)
-        }
-    }
 
     // MARK: Private
 
@@ -83,11 +66,6 @@ class Container: AppDependencies {
         }
         return stack
     }()
-    
-    private func navigateTo(path: String) -> Bool {
-        // Implement the actual navigation or handling logic in follow up pr
-        return true
-    }
 }
 
 private enum Constant {

--- a/Example/QuranEngineApp/Classes/Container.swift
+++ b/Example/QuranEngineApp/Classes/Container.swift
@@ -15,6 +15,7 @@ import LastPagePersistence
 import NotePersistence
 import PageBookmarkPersistence
 import ReadingService
+import UIKit
 
 /// Hosts singleton dependencies
 class Container: AppDependencies {
@@ -53,6 +54,23 @@ class Container: AppDependencies {
     var logsDirectory: URL { FileManager.documentsURL.appendingPathComponent("logs") }
 
     var supportsCloudKit: Bool { false }
+    
+    // MARK: Public
+    func handleIncomingUrl(urlContext: UIOpenURLContext) {
+        let url = urlContext.url
+        
+        if url.scheme == "quran" || url.scheme == "quran-ios" {
+            let path: String
+            
+            if #available(iOS 16.0, *) {
+                path = url.path(percentEncoded: true)
+            } else {
+                path = url.path
+            }
+            
+            _ = navigateTo(path: path)
+        }
+    }
 
     // MARK: Private
 
@@ -65,6 +83,11 @@ class Container: AppDependencies {
         }
         return stack
     }()
+    
+    private func navigateTo(path: String) -> Bool {
+        // Implement the actual navigation or handling logic in follow up pr
+        return true
+    }
 }
 
 private enum Constant {

--- a/Example/QuranEngineApp/Classes/SceneDelegate.swift
+++ b/Example/QuranEngineApp/Classes/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.overrideUserInterfaceStyle = ThemeService.shared.theme.userInterfaceStyle
         self.window = window
 
-        let launchBuilder = LaunchBuilder(container: Container.shared)
+        let launchBuilder = LaunchBuilder(container: container)
         let launchStartup = launchBuilder.launchStartup()
         launchStartup.launch(from: window)
 
@@ -57,31 +57,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        guard let urlContext = URLContexts.first else {
+        guard let urlContext: UIOpenURLContext = URLContexts.first else {
             return
         }
-        
-        let url = urlContext.url
-        if url.scheme == "quran" || url.scheme == "quran-ios" {
-            let path: String
-            
-            if #available(iOS 16.0, *) {
-                path = url.path(percentEncoded: true)
-            } else {
-                path = url.path
-            }
-            
-            _ = navigateTo(path: path)
-        }
-    }
-    
-    private func navigateTo(path: String) -> Bool {
-        print("Navigating to: \(path)")
-        // Implement the actual navigation or handling logic in follow up pr
-        return true
+        container.handleIncomingUrl(urlContext: urlContext)
     }
 
     // MARK: Private
 
     private var launchStartup: LaunchStartup?
+    private let container = Container.shared
 }

--- a/Example/QuranEngineApp/Classes/SceneDelegate.swift
+++ b/Example/QuranEngineApp/Classes/SceneDelegate.swift
@@ -13,6 +13,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // MARK: Internal
 
     var window: UIWindow?
+    private var launchBuilder: LaunchBuilder?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
@@ -21,9 +22,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.overrideUserInterfaceStyle = ThemeService.shared.theme.userInterfaceStyle
         self.window = window
 
-        let launchBuilder = LaunchBuilder(container: container)
-        let launchStartup = launchBuilder.launchStartup()
-        launchStartup.launch(from: window)
+        self.launchBuilder = LaunchBuilder(container: container)
+        let launchStartup = launchBuilder?.launchStartup()
+        launchStartup?.launch(from: window)
 
         self.launchStartup = launchStartup
     }
@@ -60,7 +61,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let urlContext: UIOpenURLContext = URLContexts.first else {
             return
         }
-        container.handleIncomingUrl(urlContext: urlContext)
+        launchBuilder?.handleIncomingUrl(urlContext: urlContext)
     }
 
     // MARK: Private

--- a/Example/QuranEngineApp/Classes/SceneDelegate.swift
+++ b/Example/QuranEngineApp/Classes/SceneDelegate.swift
@@ -55,6 +55,31 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
     }
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        guard let urlContext = URLContexts.first else {
+            return
+        }
+        
+        let url = urlContext.url
+        if url.scheme == "quran" || url.scheme == "quran-ios" {
+            let path: String
+            
+            if #available(iOS 16.0, *) {
+                path = url.path(percentEncoded: true)
+            } else {
+                path = url.path
+            }
+            
+            _ = navigateTo(path: path)
+        }
+    }
+    
+    private func navigateTo(path: String) -> Bool {
+        print("Navigating to: \(path)")
+        // Implement the actual navigation or handling logic in follow up pr
+        return true
+    }
 
     // MARK: Private
 

--- a/Example/QuranEngineApp/Info.plist
+++ b/Example/QuranEngineApp/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.quran.QuranEngineApp</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>quran-ios</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Example/QuranEngineApp/Info.plist
+++ b/Example/QuranEngineApp/Info.plist
@@ -2,17 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleURLName</key>
-			<string>com.quran.QuranEngineApp</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>quran-ios</string>
-			</array>
-		</dict>
-	</array>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>com.quran.QuranEngineApp</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>quran</string>
+                <string>quran-ios</string>
+            </array>
+        </dict>
+    </array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Features/AppStructureFeature/Launch/LaunchBuilder.swift
+++ b/Features/AppStructureFeature/Launch/LaunchBuilder.swift
@@ -11,6 +11,7 @@ import AppMigrationFeature
 import AudioUpdater
 import ReciterService
 import SettingsService
+import UIKit
 
 @MainActor
 public struct LaunchBuilder {
@@ -36,8 +37,30 @@ public struct LaunchBuilder {
             reviewService: ReviewService(analytics: container.analytics)
         )
     }
+    
+    public func handleIncomingUrl(urlContext: UIOpenURLContext) {
+        let url = urlContext.url
+        
+        if url.scheme == "quran" || url.scheme == "quran-ios" {
+            let path: String
+            
+            if #available(iOS 16.0, *) {
+                path = url.path(percentEncoded: true)
+            } else {
+                path = url.path
+            }
+            
+            _ = navigateTo(path: path)
+        }
+    }
 
     // MARK: Internal
 
     let container: AppDependencies
+    
+    // MARK: Public
+    private func navigateTo(path: String) -> Bool {
+        // Implement the actual navigation or handling logic in follow up pr
+        return true
+    }
 }


### PR DESCRIPTION
Implemented custom url scheme to support launching the Quran Application from outside the application
For example, enter this in browser `quran-ios://` and it will redirect you to the Quran Application

Example Video

https://github.com/user-attachments/assets/cafcc9f4-5c24-4ebd-b6fb-1b680ab69f7c

