### PR TITLE
Increase the default Quran font size in translation UI 

### DIFF
--- a/Domain/QuranTextKit/Sources/Preferences/FontSizePreferences.swift
+++ b/Domain/QuranTextKit/Sources/Preferences/FontSizePreferences.swift
@@ -25,7 +25,7 @@ public struct FontSizePreferences {
 
     // MARK: Private
 
-    private static let defaultValue = FontSize.medium
+    private static let defaultValue = FontSize.large
     private static let translationFontSizeKey = PreferenceKey<Int>(key: "translationFontSize", defaultValue: defaultValue.rawValue)
     private static let arabicFontSizeKey = PreferenceKey<Int>(key: "arabicFont", defaultValue: defaultValue.rawValue)
 }

--- a/Model/QuranText/FontSize.swift
+++ b/Model/QuranText/FontSize.swift
@@ -8,25 +8,35 @@
 import SwiftUI
 
 public enum FontSize: Int, CaseIterable, CustomStringConvertible {
-    case xxLarge = -1
-    case xLarge = 0
-    case large = 1
-    case medium = 2
-    case small = 3
-    case xSmall = 4
-    case xxSmall = 5
+    case accessibility5 = -6
+    case accessibility4 = -5
+    case accessibility3 = -4
+    case accessibility2 = -3
+    case accessibility1 = -2
+    case xxxLarge = -1
+    case xxLarge = 0
+    case xLarge = 1
+    case large = 2
+    case medium = 3
+    case small = 4
+    case xSmall = 5
 
     // MARK: Public
 
     public var description: String {
         switch self {
-        case .xxLarge: return "xxLarge"
-        case .xLarge: return "xLarge"
-        case .large: return "large"
-        case .medium: return "medium"
-        case .small: return "small"
-        case .xSmall: return "xSmall"
-        case .xxSmall: return "xxSmall"
+        case .accessibility5: "accessibility5"
+        case .accessibility4: "accessibility4"
+        case .accessibility3: "accessibility3"
+        case .accessibility2: "accessibility2"
+        case .accessibility1: "accessibility1"
+        case .xxxLarge: "xxxLarge"
+        case .xxLarge: "xxLarge"
+        case .xLarge: "xLarge"
+        case .large: "large"
+        case .medium: "medium"
+        case .small: "small"
+        case .xSmall: "xSmall"
         }
     }
 }
@@ -34,13 +44,18 @@ public enum FontSize: Int, CaseIterable, CustomStringConvertible {
 extension FontSize {
     public var dynamicTypeSize: DynamicTypeSize {
         switch self {
-        case .xxLarge: .xxxLarge
-        case .xLarge: .xxLarge
-        case .large: .xLarge
-        case .medium: .large
-        case .small: .medium
-        case .xSmall: .small
-        case .xxSmall: .xSmall
+        case .accessibility5: .accessibility5
+        case .accessibility4: .accessibility4
+        case .accessibility3: .accessibility3
+        case .accessibility2: .accessibility2
+        case .accessibility1: .accessibility1
+        case .xxxLarge: .xxxLarge
+        case .xxLarge: .xxLarge
+        case .xLarge: .xLarge
+        case .large: .large
+        case .medium: .medium
+        case .small: .small
+        case .xSmall: .xSmall
         }
     }
 }

--- a/UI/NoorUI/Features/MoreMenu/components/MoreMenuFontSize.swift
+++ b/UI/NoorUI/Features/MoreMenu/components/MoreMenuFontSize.swift
@@ -52,20 +52,18 @@ struct MoreMenuFontSize: View {
 
     private var fontSizeInPoints: CGFloat {
         switch fontSize {
-        case .xxLarge:
-            return 35
-        case .xLarge:
-            return 31
-        case .large:
-            return 25
-        case .medium:
-            return 20
-        case .small:
-            return 14
-        case .xSmall:
-            return 10
-        case .xxSmall:
-            return 7
+        case .accessibility5: return 61
+        case .accessibility4: return 57
+        case .accessibility3: return 51
+        case .accessibility2: return 46
+        case .accessibility1: return 41
+        case .xxxLarge: return 36
+        case .xxLarge: return 31
+        case .xLarge: return 25
+        case .large: return 20
+        case .medium: return 14
+        case .small: return 10
+        case .xSmall: return 7
         }
     }
 }

--- a/UI/NoorUI/Font/FontName++.swift
+++ b/UI/NoorUI/Font/FontName++.swift
@@ -12,7 +12,7 @@ import NoorFont
 import QuranText
 import SwiftUI
 
-private let arabicQuranTextFontSize: CGFloat = 17
+private let arabicQuranTextFontSize: CGFloat = 21
 private let arabicTafseerTextFontSize: CGFloat = 21
 
 public extension Font {

--- a/UI/NoorUI/Font/FontSize++.swift
+++ b/UI/NoorUI/Font/FontSize++.swift
@@ -21,13 +21,18 @@ extension FontSize: Strideable {
 extension FontSize {
     func fontSize(forMediumSize size: CGFloat) -> CGFloat {
         let factor: CGFloat = switch self {
-        case .xxSmall: 0.7 * 0.7 * 0.7
-        case .xSmall: 0.7 * 0.7
-        case .small: 0.7
-        case .medium: 1
-        case .large: 1 / 0.8
-        case .xLarge: 1 / 0.8 / 0.8
-        case .xxLarge: 1 / 0.8 / 0.8 / 0.8
+        case .xSmall: 0.7 * 0.7 * 0.7
+        case .small: 0.7 * 0.7
+        case .medium: 0.7
+        case .large: 1
+        case .xLarge: 1 / 0.8
+        case .xxLarge: 1 / 0.8 / 0.8
+        case .xxxLarge: 1 / 0.8 / 0.8 / 0.8
+        case .accessibility1: 1 / 0.8 / 0.8 / 0.8 / 0.8
+        case .accessibility2: 1 / 0.8 / 0.8 / 0.8 / 0.8 / 0.8
+        case .accessibility3: 1 / 0.8 / 0.8 / 0.8 / 0.8 / 0.8 / 0.8
+        case .accessibility4: 1 / 0.8 / 0.8 / 0.8 / 0.8 / 0.8 / 0.8 / 0.8
+        case .accessibility5: 1 / 0.8 / 0.8 / 0.8 / 0.8 / 0.8 / 0.8 / 0.8 / 0.8
         }
         return size * factor
     }


### PR DESCRIPTION
- Increase the default quran font size from 17 to 21.
- Add more font sizes that matches [DynamicTypeSize](https://developer.apple.com/documentation/swiftui/dynamictypesize)