### PR TITLE
Fix Arabic Number Bug and Improve Notes Sharing

### DIFF
--- a/Core/Localization/NumberFormatter+Extension.swift
+++ b/Core/Localization/NumberFormatter+Extension.swift
@@ -49,7 +49,7 @@ extension NumberFormatter {
 
     public static var arabicNumberFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
-        formatter.locale = Locale(identifier: "ar")
+        formatter.locale = Locale(identifier: "ar-SA")
         return formatter
     }()
 }

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -148,7 +148,8 @@ final class AyahMenuViewModel {
         logger.info("AyahMenu: share. Verses: \(deps.verses)")
         Task {
             if let lines = try? await retrieveSelectedAyahText() {
-                listener?.shareText(lines, in: self.deps.sourceView, at: self.deps.pointInView)
+                let withNewLines = lines.joined(separator: "\n")
+                listener?.shareText([withNewLines], in: self.deps.sourceView, at: self.deps.pointInView)
             }
         }
     }

--- a/Features/NotesFeature/NotesViewModel.swift
+++ b/Features/NotesFeature/NotesViewModel.swift
@@ -73,17 +73,23 @@ final class NotesViewModel: ObservableObject {
     func prepareNotesForSharing() async throws -> String {
         try await crasher.recordError("Failed to share notes") {
             var notesText = [String]()
-            for note in await notes {
-                let title = if let noteContent = note.note.note, noteContent != "" {
-                    "\(noteContent.trimmingCharacters(in: .newlines))\n\n"
+            let notes: [NoteItem] = await self.notes
+            for (index, note) in notes.enumerated() {
+                let title: [String] = if let noteContent = note.note.note, noteContent != "" {
+                    [
+                        "\(noteContent.trimmingCharacters(in: .newlines))", "",
+                    ]
                 } else {
-                    ""
+                    []
                 }
-                let verses = try await textRetriever.textForVerses(Array(note.note.verses)).joined(separator: "\n")
+                let verses = try await textRetriever.textForVerses(Array(note.note.verses))
 
-                notesText.append("\(title)\(verses)")
+                notesText.append(contentsOf: title + verses)
+                if (index != notes.count - 1) {
+                    notesText.append(contentsOf: ["","",""])
+                }
             }
-            return notesText.joined(separator: "\n\n\n\n")
+            return notesText.joined(separator: "\n")
         }
     }
 

--- a/Features/NotesFeature/NotesViewModel.swift
+++ b/Features/NotesFeature/NotesViewModel.swift
@@ -85,8 +85,8 @@ final class NotesViewModel: ObservableObject {
                 let verses = try await textRetriever.textForVerses(Array(note.note.verses))
 
                 notesText.append(contentsOf: title + verses)
-                if (index != notes.count - 1) {
-                    notesText.append(contentsOf: ["","",""])
+                if index != notes.count - 1 {
+                    notesText.append(contentsOf: ["", "", ""])
                 }
             }
             return notesText.joined(separator: "\n")


### PR DESCRIPTION
1.  Fixes #666, 
I think maybe Apple changed the locale keys in the new update ? The docs say it uses [BCP-47](https://developer.apple.com/documentation/foundation/locale/2293563-init). So updated the string to use [this](https://www.techonthenet.com/js/language_tags.php).

2. Refactors the sharing abit to make it more consistent, since sometimes English and Arabic would be on the same line, now we add newlines properly I think.

3. Updates the ayah sharing to use the same logic as [copy](https://github.com/quran/quran-ios/blob/c40fb5c958ff0f572e085e1b1ec67c716b68ca78/Features/AyahMenuFeature/AyahMenuViewModel.swift#L136-L145). Before copy would have newlines and sharing didn't but now they should both have it.

<div style="display: flex; gap: 10px;">
    <img src="https://github.com/user-attachments/assets/11ae9559-f13f-48a3-bdbd-eaf14c49ba2f" alt="Image 7630" width="200">
    <img src="https://github.com/user-attachments/assets/9908f6be-8ca1-4551-82a7-226c120028f1" alt="Image 7631" width="200">
</div>
