### PR TITLE
OAuth Support

### DIFF
--- a/Data/OAuthClient/Sources/AppAuthOAuthClient.swift
+++ b/Data/OAuthClient/Sources/AppAuthOAuthClient.swift
@@ -28,7 +28,8 @@ public final class AppAuthOAuthClient: OAuthClient {
             throw OAuthClientError.oauthClientHasNotBeenSet
         }
 
-        // Quran.com relies on dicovering the configuration from the issuer, and not using a static configuration.
+        // Quran.com relies on dicovering the service configuration from the issuer,
+        // and not using a static configuration.
         let serviceConfiguration = try await discoverConfiguration(forIssuer: configuration.authorizationIssuerURL)
         try await login(withConfiguration: serviceConfiguration,
                         appConfiguration: configuration,

--- a/Data/OAuthClient/Sources/AppAuthOAuthClient.swift
+++ b/Data/OAuthClient/Sources/AppAuthOAuthClient.swift
@@ -9,10 +9,13 @@ import Foundation
 import UIKit
 import AppAuth
 
-public class AppAuthOAuthClient: OAuthClient {
+public final class AppAuthOAuthClient: OAuthClient {
 
+    // TODO: Do we need to maintain that?
     private var authFlow: (any OIDExternalUserAgentSession)?
     private var appConfiguration: OAuthAppConfiguration?
+
+    public init() {}
 
     public func set(appConfiguration: OAuthAppConfiguration) {
         self.appConfiguration = appConfiguration

--- a/Data/OAuthClient/Sources/AppAuthOAuthClient.swift
+++ b/Data/OAuthClient/Sources/AppAuthOAuthClient.swift
@@ -7,14 +7,71 @@
 
 import Foundation
 import UIKit
+import AppAuth
 
 public class AppAuthOAuthClient: OAuthClient {
-    
-    public func set(clientID: String) {
-        
+
+    private var authFlow: (any OIDExternalUserAgentSession)?
+    private var appConfiguration: OAuthAppConfiguration?
+
+    public func set(appConfiguration: OAuthAppConfiguration) {
+        self.appConfiguration = appConfiguration
     }
-    
+
     public func login(on viewController: UIViewController) async throws {
-        
+        guard let configuration = self.appConfiguration else {
+            throw OAuthClientError.oauthClientHasNotBeenSet
+        }
+
+        let serviceConfiguration = try await discoverConfiguration(forIssuer: configuration.authorizationHost)
+        try await login(withConfiguration: serviceConfiguration,
+                        appConfiguration: configuration,
+                        on: viewController)
+    }
+
+    private func discoverConfiguration(forIssuer issuer: URL) async throws -> OIDServiceConfiguration {
+        try await withCheckedThrowingContinuation { continuation in
+            OIDAuthorizationService
+                .discoverConfiguration(forIssuer: issuer) { configuration, error in
+                    guard error != nil else {
+                        continuation.resume(throwing: OAuthClientError.errorFetchingConfiguration(error))
+                        return
+                    }
+                    guard let configuration = configuration else {
+                        // This should not happen
+                        continuation.resume(throwing: OAuthClientError.errorFetchingConfiguration(nil))
+                        return
+                    }
+                    continuation.resume(returning: configuration)
+                }
+        }
+    }
+
+    private func login(withConfiguration configuration: OIDServiceConfiguration,
+                       appConfiguration: OAuthAppConfiguration,
+                       on viewController: UIViewController) async throws {
+        let scopes = [OIDScopeOpenID, OIDScopeProfile] + appConfiguration.scopes
+        let request = OIDAuthorizationRequest(configuration: configuration,
+                                              clientId: appConfiguration.clientID,
+                                              clientSecret: nil,
+                                              scopes: scopes,
+                                              redirectURL: appConfiguration.redirectURL,
+                                              responseType: OIDResponseTypeCode,
+                                              additionalParameters: [:])
+
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+            self.authFlow = OIDAuthState.authState(byPresenting: request,
+                                                   presenting: viewController) { state, error in
+                guard error == nil else {
+                    continuation.resume(throwing: OAuthClientError.errorAuthenticating(error))
+                    return
+                }
+                guard let state = state else {
+                    continuation.resume(throwing: OAuthClientError.errorAuthenticating(nil))
+                    return
+                }
+                continuation.resume()
+            }
+        }
     }
 }

--- a/Data/OAuthClient/Sources/AppAuthOAuthClient.swift
+++ b/Data/OAuthClient/Sources/AppAuthOAuthClient.swift
@@ -106,5 +106,5 @@ public final class AppAuthOAuthClient: OAuthClient {
                 }
             }
         }
-    } 
+    }
 }

--- a/Data/OAuthClient/Sources/AppAuthOAuthClient.swift
+++ b/Data/OAuthClient/Sources/AppAuthOAuthClient.swift
@@ -1,0 +1,20 @@
+//
+//  File.swift
+//  QuranEngine
+//
+//  Created by Mohannad Hassan on 23/12/2024.
+//
+
+import Foundation
+import UIKit
+
+public class AppAuthOAuthClient: OAuthClient {
+    
+    public func set(clientID: String) {
+        
+    }
+    
+    public func login(on viewController: UIViewController) async throws {
+        
+    }
+}

--- a/Data/OAuthClient/Sources/AppAuthOAuthClient.swift
+++ b/Data/OAuthClient/Sources/AppAuthOAuthClient.swift
@@ -1,29 +1,28 @@
 //
-//  File.swift
+//  AppAuthOAuthClient.swift
 //  QuranEngine
 //
 //  Created by Mohannad Hassan on 23/12/2024.
 //
 
+import AppAuth
 import Foundation
 import UIKit
-import AppAuth
 import VLogging
 
 public final class AppAuthOAuthClient: OAuthClient {
-
-    // Needed mainly for retention.
-    private var authFlow: (any OIDExternalUserAgentSession)?
-    private var appConfiguration: OAuthAppConfiguration?
+    // MARK: Lifecycle
 
     public init() {}
+
+    // MARK: Public
 
     public func set(appConfiguration: OAuthAppConfiguration) {
         self.appConfiguration = appConfiguration
     }
 
     public func login(on viewController: UIViewController) async throws {
-        guard let configuration = self.appConfiguration else {
+        guard let configuration = appConfiguration else {
             logger.error("login invoked without OAuth client configurations being set")
             throw OAuthClientError.oauthClientHasNotBeenSet
         }
@@ -31,10 +30,20 @@ public final class AppAuthOAuthClient: OAuthClient {
         // Quran.com relies on dicovering the service configuration from the issuer,
         // and not using a static configuration.
         let serviceConfiguration = try await discoverConfiguration(forIssuer: configuration.authorizationIssuerURL)
-        try await login(withConfiguration: serviceConfiguration,
-                        appConfiguration: configuration,
-                        on: viewController)
+        try await login(
+            withConfiguration: serviceConfiguration,
+            appConfiguration: configuration,
+            on: viewController
+        )
     }
+
+    // MARK: Private
+
+    // Needed mainly for retention.
+    private var authFlow: (any OIDExternalUserAgentSession)?
+    private var appConfiguration: OAuthAppConfiguration?
+
+    // MARK: - Authenication Flow
 
     private func discoverConfiguration(forIssuer issuer: URL) async throws -> OIDServiceConfiguration {
         logger.info("Discovering configuration for OAuth")
@@ -46,7 +55,7 @@ public final class AppAuthOAuthClient: OAuthClient {
                         continuation.resume(throwing: OAuthClientError.errorFetchingConfiguration(error))
                         return
                     }
-                    guard let configuration = configuration else {
+                    guard let configuration else {
                         // This should not happen
                         logger.error("Error fetching OAuth configuration: no cofniguration was loaded. An unexpected situtation.")
                         continuation.resume(throwing: OAuthClientError.errorFetchingConfiguration(nil))
@@ -58,17 +67,21 @@ public final class AppAuthOAuthClient: OAuthClient {
         }
     }
 
-    private func login(withConfiguration configuration: OIDServiceConfiguration,
-                       appConfiguration: OAuthAppConfiguration,
-                       on viewController: UIViewController) async throws {
+    private func login(
+        withConfiguration configuration: OIDServiceConfiguration,
+        appConfiguration: OAuthAppConfiguration,
+        on viewController: UIViewController
+    ) async throws {
         let scopes = [OIDScopeOpenID, OIDScopeProfile] + appConfiguration.scopes
-        let request = OIDAuthorizationRequest(configuration: configuration,
-                                              clientId: appConfiguration.clientID,
-                                              clientSecret: nil,
-                                              scopes: scopes,
-                                              redirectURL: appConfiguration.redirectURL,
-                                              responseType: OIDResponseTypeCode,
-                                              additionalParameters: [:])
+        let request = OIDAuthorizationRequest(
+            configuration: configuration,
+            clientId: appConfiguration.clientID,
+            clientSecret: nil,
+            scopes: scopes,
+            redirectURL: appConfiguration.redirectURL,
+            responseType: OIDResponseTypeCode,
+            additionalParameters: [:]
+        )
 
         logger.info("Starting OAuth flow")
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
@@ -78,7 +91,7 @@ public final class AppAuthOAuthClient: OAuthClient {
                     continuation.resume(throwing: OAuthClientError.errorAuthenticating(error))
                     return
                 }
-                guard let state = state else {
+                guard let _ = state else {
                     logger.error("Error authenticating: no state returned. An unexpected situtation.")
                     continuation.resume(throwing: OAuthClientError.errorAuthenticating(nil))
                     return
@@ -90,14 +103,18 @@ public final class AppAuthOAuthClient: OAuthClient {
     }
 
     /// Executes the request on the main actor.
-    private func fire(loginRequest: OIDAuthorizationRequest,
-                      on viewController: UIViewController,
-                      callback: @escaping OIDAuthStateAuthorizationCallback) {
+    private func fire(
+        loginRequest: OIDAuthorizationRequest,
+        on viewController: UIViewController,
+        callback: @escaping OIDAuthStateAuthorizationCallback
+    ) {
         Task {
             await MainActor.run {
-                self.authFlow = OIDAuthState.authState(byPresenting: loginRequest,
-                                                       presenting: viewController) { state, error in
-                    self.authFlow = nil
+                authFlow = OIDAuthState.authState(
+                    byPresenting: loginRequest,
+                    presenting: viewController
+                ) { [weak self] state, error in
+                    self?.authFlow = nil
                     callback(state, error)
                 }
             }

--- a/Data/OAuthClient/Sources/OAuthClient.swift
+++ b/Data/OAuthClient/Sources/OAuthClient.swift
@@ -6,13 +6,13 @@
 //
 
 import Foundation
-
+import UIKit
 
 // TODO: Need to add functions for authenticating the requests and getting the profile information.
-public final protocol OAuthClient {
+public protocol OAuthClient {
     
-    public func set(clientID: String)
+    func set(clientID: String)
     
     // TODO: May return the profile information
-    public func login(on viewController: UIViewController) async throws
+    func login(on viewController: UIViewController) async throws
 }

--- a/Data/OAuthClient/Sources/OAuthClient.swift
+++ b/Data/OAuthClient/Sources/OAuthClient.swift
@@ -8,11 +8,23 @@
 import Foundation
 import UIKit
 
-// TODO: Need to add functions for authenticating the requests and getting the profile information.
+public enum OAuthClientError: Error {
+    case oauthClientHasNotBeenSet
+    case errorFetchingConfiguration(Error?)
+    case errorAuthenticating(Error?)
+}
+
+public struct OAuthAppConfiguration {
+    public let clientID: String
+    public let redirectURL: URL
+    public let scopes: [String]
+    public let authorizationHost: URL
+}
+
 public protocol OAuthClient {
     
-    func set(clientID: String)
-    
+    func set(appConfiguration: OAuthAppConfiguration)
+
     // TODO: May return the profile information
     func login(on viewController: UIViewController) async throws
 }

--- a/Data/OAuthClient/Sources/OAuthClient.swift
+++ b/Data/OAuthClient/Sources/OAuthClient.swift
@@ -17,21 +17,29 @@ public enum OAuthClientError: Error {
 public struct OAuthAppConfiguration {
     public let clientID: String
     public let redirectURL: URL
+    /// Indicates the Quran.com specific scopes to be requested by the app.
+    /// The client requests the `offline` and `openid` scopes by default.
     public let scopes: [String]
-    public let authorizationHost: URL
+    public let authorizationIssuerURL: URL
 
-    public init(clientID: String, redirectURL: URL, scopes: [String], authorizationHost: URL) {
+    public init(clientID: String, redirectURL: URL, scopes: [String], authorizationIssuerURL: URL) {
         self.clientID = clientID
         self.redirectURL = redirectURL
         self.scopes = scopes
-        self.authorizationHost = authorizationHost
+        self.authorizationIssuerURL = authorizationIssuerURL
     }
 }
 
+/// Handles the OAuth flow to Quran.com
+///
+/// Note that the connection relies on dicvoering the configuration from the issuer service.
 public protocol OAuthClient {
-    
+
     func set(appConfiguration: OAuthAppConfiguration)
 
-    // TODO: May return the profile information
+    /// Performs the login flow to Quran.com
+    ///
+    /// - Parameter viewController: The view controller to be used as base for presenting the login flow.
+    /// - Returns: Nothing is returned for now. The client may return the profile infromation in the future.
     func login(on viewController: UIViewController) async throws
 }

--- a/Data/OAuthClient/Sources/OAuthClient.swift
+++ b/Data/OAuthClient/Sources/OAuthClient.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  OAuthClient.swift
 //  QuranEngine
 //
 //  Created by Mohannad Hassan on 19/12/2024.
@@ -34,7 +34,6 @@ public struct OAuthAppConfiguration {
 ///
 /// Note that the connection relies on dicvoering the configuration from the issuer service.
 public protocol OAuthClient {
-
     func set(appConfiguration: OAuthAppConfiguration)
 
     /// Performs the login flow to Quran.com

--- a/Data/OAuthClient/Sources/OAuthClient.swift
+++ b/Data/OAuthClient/Sources/OAuthClient.swift
@@ -19,6 +19,13 @@ public struct OAuthAppConfiguration {
     public let redirectURL: URL
     public let scopes: [String]
     public let authorizationHost: URL
+
+    public init(clientID: String, redirectURL: URL, scopes: [String], authorizationHost: URL) {
+        self.clientID = clientID
+        self.redirectURL = redirectURL
+        self.scopes = scopes
+        self.authorizationHost = authorizationHost
+    }
 }
 
 public protocol OAuthClient {

--- a/Data/OAuthClient/Sources/OAuthClient.swift
+++ b/Data/OAuthClient/Sources/OAuthClient.swift
@@ -1,0 +1,18 @@
+//
+//  File.swift
+//  QuranEngine
+//
+//  Created by Mohannad Hassan on 19/12/2024.
+//
+
+import Foundation
+
+
+// TODO: Need to add functions for authenticating the requests and getting the profile information.
+public final protocol OAuthClient {
+    
+    public func set(clientID: String)
+    
+    // TODO: May return the profile information
+    public func login(on viewController: UIViewController) async throws
+}

--- a/Domain/QuranProfileService/Sources/QuranProfileService.swift
+++ b/Domain/QuranProfileService/Sources/QuranProfileService.swift
@@ -1,15 +1,14 @@
 //
-//  File.swift
+//  QuranProfileService.swift
 //  QuranEngine
 //
 //  Created by Mohannad Hassan on 23/12/2024.
 //
 
-import UIKit
 import OAuthClient
+import UIKit
 
 public class QuranProfileService {
-
     private let oauthClient: OAuthClient
 
     public init(oauthClient: OAuthClient) {
@@ -24,4 +23,3 @@ public class QuranProfileService {
         try await oauthClient.login(on: viewController)
     }
 }
-

--- a/Domain/QuranProfileService/Sources/QuranProfileService.swift
+++ b/Domain/QuranProfileService/Sources/QuranProfileService.swift
@@ -16,6 +16,10 @@ public class QuranProfileService {
         self.oauthClient = oauthClient
     }
 
+    /// Performs the login flow to Quran.com
+    ///
+    /// - Parameter viewController: The view controller to be used as base for presenting the login flow.
+    /// - Returns: Nothing is returned for now. The client may return the profile infromation in the future.
     public func login(on viewController: UIViewController) async throws {
         try await oauthClient.login(on: viewController)
     }

--- a/Domain/QuranProfileService/Sources/QuranProfileService.swift
+++ b/Domain/QuranProfileService/Sources/QuranProfileService.swift
@@ -1,0 +1,23 @@
+//
+//  File.swift
+//  QuranEngine
+//
+//  Created by Mohannad Hassan on 23/12/2024.
+//
+
+import UIKit
+import OAuthClient
+
+public class QuranProfileService {
+
+    private let oauthClient: OAuthClient
+
+    public init(oauthClient: OAuthClient) {
+        self.oauthClient = oauthClient
+    }
+
+    public func login(on viewController: UIViewController) async throws {
+        try await oauthClient.login(on: viewController)
+    }
+}
+

--- a/Example/QuranEngineApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/QuranEngineApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "appauth-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/openid/AppAuth-iOS.git",
+      "state" : {
+        "revision" : "2781038865a80e2c425a1da12cc1327bcd56501f",
+        "version" : "1.7.6"
+      }
+    },
+    {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",

--- a/Example/QuranEngineApp/Classes/Container.swift
+++ b/Example/QuranEngineApp/Classes/Container.swift
@@ -15,6 +15,7 @@ import LastPagePersistence
 import NotePersistence
 import PageBookmarkPersistence
 import ReadingService
+import OAuthClient
 import UIKit
 
 /// Hosts singleton dependencies
@@ -35,6 +36,13 @@ class Container: AppDependencies {
     private(set) lazy var lastPagePersistence: LastPagePersistence = CoreDataLastPagePersistence(stack: coreDataStack)
     private(set) lazy var pageBookmarkPersistence: PageBookmarkPersistence = CoreDataPageBookmarkPersistence(stack: coreDataStack)
     private(set) lazy var notePersistence: NotePersistence = CoreDataNotePersistence(stack: coreDataStack)
+    private(set) lazy var oauthClient: any OAuthClient = {
+        let client = AppAuthOAuthClient()
+        if let config = Constant.QuranOAuthAppConfigurations {
+            client.set(appConfiguration: config)
+        }
+        return client
+    }()
 
     private(set) lazy var downloadManager: DownloadManager = {
         let configuration = URLSessionConfiguration.background(withIdentifier: "DownloadsBackgroundIdentifier")
@@ -78,4 +86,11 @@ private enum Constant {
 
     static let databasesURL = FileManager.documentsURL
         .appendingPathComponent("databases", isDirectory: true)
+
+    static let QuranOAuthAppConfigurations: OAuthAppConfiguration? = OAuthAppConfiguration(
+        clientID: "954eb549-3566-4f9a-b65f-fa61bf9a9e37",
+        redirectURL: URL(validURL: "com.example.app:/oauth2redirect/example-provider"),
+        scopes: [],
+        authorizationHost: URL(validURL: "https://staging-oauth2.quran.foundation")
+    )
 }

--- a/Example/QuranEngineApp/Classes/Container.swift
+++ b/Example/QuranEngineApp/Classes/Container.swift
@@ -13,9 +13,9 @@ import CoreDataPersistence
 import Foundation
 import LastPagePersistence
 import NotePersistence
+import OAuthClient
 import PageBookmarkPersistence
 import ReadingService
-import OAuthClient
 import UIKit
 
 /// Hosts singleton dependencies

--- a/Example/QuranEngineApp/Classes/Container.swift
+++ b/Example/QuranEngineApp/Classes/Container.swift
@@ -87,10 +87,6 @@ private enum Constant {
     static let databasesURL = FileManager.documentsURL
         .appendingPathComponent("databases", isDirectory: true)
 
-    static let QuranOAuthAppConfigurations: OAuthAppConfiguration? = OAuthAppConfiguration(
-        clientID: "954eb549-3566-4f9a-b65f-fa61bf9a9e37",
-        redirectURL: URL(validURL: "com.example.app:/oauth2redirect/example-provider"),
-        scopes: [],
-        authorizationHost: URL(validURL: "https://staging-oauth2.quran.foundation")
-    )
+    /// If set, the Quran.com login will be enabled.
+    static let QuranOAuthAppConfigurations: OAuthAppConfiguration? = nil
 }

--- a/Features/AppDependencies/AppDependencies.swift
+++ b/Features/AppDependencies/AppDependencies.swift
@@ -15,6 +15,7 @@ import PageBookmarkPersistence
 import QuranResources
 import QuranTextKit
 import ReadingService
+import OAuthClient
 
 public protocol AppDependencies {
     var databasesURL: URL { get }
@@ -35,6 +36,8 @@ public protocol AppDependencies {
     var lastPagePersistence: LastPagePersistence { get }
     var notePersistence: NotePersistence { get }
     var pageBookmarkPersistence: PageBookmarkPersistence { get }
+
+    var oauthClient: OAuthClient { get }
 }
 
 extension AppDependencies {

--- a/Features/AppDependencies/AppDependencies.swift
+++ b/Features/AppDependencies/AppDependencies.swift
@@ -11,11 +11,11 @@ import BatchDownloader
 import Foundation
 import LastPagePersistence
 import NotePersistence
+import OAuthClient
 import PageBookmarkPersistence
 import QuranResources
 import QuranTextKit
 import ReadingService
-import OAuthClient
 
 public protocol AppDependencies {
     var databasesURL: URL { get }

--- a/Features/SettingsFeature/SettingsBuilder.swift
+++ b/Features/SettingsFeature/SettingsBuilder.swift
@@ -11,6 +11,7 @@ import AudioDownloadsFeature
 import Localization
 import ReadingSelectorFeature
 import SettingsService
+import QuranProfileService
 import SwiftUI
 import TranslationsFeature
 import UIKit
@@ -29,6 +30,7 @@ public struct SettingsBuilder {
         let viewModel = SettingsRootViewModel(
             analytics: container.analytics,
             reviewService: ReviewService(analytics: container.analytics),
+            quranProfileService: QuranProfileService(oauthClient: container.oauthClient),
             audioDownloadsBuilder: AudioDownloadsBuilder(container: container),
             translationsListBuilder: TranslationsListBuilder(container: container),
             readingSelectorBuilder: ReadingSelectorBuilder(container: container),

--- a/Features/SettingsFeature/SettingsBuilder.swift
+++ b/Features/SettingsFeature/SettingsBuilder.swift
@@ -9,9 +9,9 @@
 import AppDependencies
 import AudioDownloadsFeature
 import Localization
+import QuranProfileService
 import ReadingSelectorFeature
 import SettingsService
-import QuranProfileService
 import SwiftUI
 import TranslationsFeature
 import UIKit

--- a/Features/SettingsFeature/SettingsRootView.swift
+++ b/Features/SettingsFeature/SettingsRootView.swift
@@ -25,7 +25,8 @@ struct SettingsRootView: View {
             shareApp: { viewModel.shareApp() },
             writeReview: { viewModel.writeReview() },
             contactUs: { viewModel.contactUs() },
-            navigateToDiagnotics: { viewModel.navigateToDiagnotics() }
+            navigateToDiagnotics: { viewModel.navigateToDiagnotics() },
+            loginAction: { await viewModel.loginToQuranCom() }
         )
     }
 }
@@ -41,6 +42,7 @@ private struct SettingsRootViewUI: View {
     let writeReview: AsyncAction
     let contactUs: AsyncAction
     let navigateToDiagnotics: AsyncAction
+    let loginAction: AsyncAction
 
     var body: some View {
         NoorList {
@@ -110,6 +112,13 @@ private struct SettingsRootViewUI: View {
 
             NoorBasicSection {
                 NoorListItem(
+                    title: .text(l("Login with Quran.com")),
+                    action: loginAction
+                )
+            }
+
+            NoorBasicSection {
+                NoorListItem(
                     image: .init(.debug),
                     title: .text(l("diagnostics.title")),
                     accessory: .disclosureIndicator,
@@ -135,7 +144,8 @@ struct SettingsRootView_Previews: PreviewProvider {
                 shareApp: {},
                 writeReview: {},
                 contactUs: {},
-                navigateToDiagnotics: {}
+                navigateToDiagnotics: {},
+                loginAction: {}
             )
         }
     }

--- a/Features/SettingsFeature/SettingsRootView.swift
+++ b/Features/SettingsFeature/SettingsRootView.swift
@@ -33,6 +33,7 @@ struct SettingsRootView: View {
 
 private struct SettingsRootViewUI: View {
     @Binding var theme: Theme
+
     let audioEnd: String
     let navigateToAudioEndSelector: AsyncAction
     let navigateToAudioManager: AsyncAction

--- a/Features/SettingsFeature/SettingsRootView.swift
+++ b/Features/SettingsFeature/SettingsRootView.swift
@@ -110,6 +110,7 @@ private struct SettingsRootViewUI: View {
                 )
             }
 
+            // TODO: Pending translations, and hiding if OAuth is not configured.
             NoorBasicSection {
                 NoorListItem(
                     title: .text(l("Login with Quran.com")),

--- a/Features/SettingsFeature/SettingsRootViewModel.swift
+++ b/Features/SettingsFeature/SettingsRootViewModel.swift
@@ -14,6 +14,7 @@ import QuranAudio
 import QuranAudioKit
 import ReadingSelectorFeature
 import SettingsService
+import QuranProfileService
 import TranslationsFeature
 import UIKit
 import UIx
@@ -26,6 +27,7 @@ final class SettingsRootViewModel: ObservableObject {
     init(
         analytics: AnalyticsLibrary,
         reviewService: ReviewService,
+        quranProfileService: QuranProfileService,
         audioDownloadsBuilder: AudioDownloadsBuilder,
         translationsListBuilder: TranslationsListBuilder,
         readingSelectorBuilder: ReadingSelectorBuilder,
@@ -36,6 +38,7 @@ final class SettingsRootViewModel: ObservableObject {
         audioEnd = audioPreferences.audioEnd
         self.analytics = analytics
         self.reviewService = reviewService
+        self.quranProfileService = quranProfileService
         self.audioDownloadsBuilder = audioDownloadsBuilder
         self.translationsListBuilder = translationsListBuilder
         self.readingSelectorBuilder = readingSelectorBuilder
@@ -50,6 +53,7 @@ final class SettingsRootViewModel: ObservableObject {
 
     let analytics: AnalyticsLibrary
     let reviewService: ReviewService
+    private let quranProfileService: QuranProfileService
     let audioDownloadsBuilder: AudioDownloadsBuilder
     let translationsListBuilder: TranslationsListBuilder
     let readingSelectorBuilder: ReadingSelectorBuilder
@@ -126,6 +130,18 @@ final class SettingsRootViewModel: ObservableObject {
         logger.info("Settings: navigateToDiagnotics")
         let viewController = diagnosticsBuilder.build(navigationController: navigationController)
         navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    func loginToQuranCom() async {
+        guard let viewController = navigationController else {
+            return
+        }
+        do {
+            try await self.quranProfileService.login(on: viewController)
+            print("Login seems successful")
+        } catch {
+            logger.error("Failed to login to Quran.com: \(error)")
+        }
     }
 
     // MARK: Private

--- a/Features/SettingsFeature/SettingsRootViewModel.swift
+++ b/Features/SettingsFeature/SettingsRootViewModel.swift
@@ -12,9 +12,9 @@ import Localization
 import NoorUI
 import QuranAudio
 import QuranAudioKit
+import QuranProfileService
 import ReadingSelectorFeature
 import SettingsService
-import QuranProfileService
 import TranslationsFeature
 import UIKit
 import UIx
@@ -51,19 +51,19 @@ final class SettingsRootViewModel: ObservableObject {
 
     // MARK: Internal
 
-    private let analytics: AnalyticsLibrary
-    private let reviewService: ReviewService
-    private let quranProfileService: QuranProfileService
-    private let audioDownloadsBuilder: AudioDownloadsBuilder
-    private let translationsListBuilder: TranslationsListBuilder
-    private let readingSelectorBuilder: ReadingSelectorBuilder
-    private let diagnosticsBuilder: DiagnosticsBuilder
+    let analytics: AnalyticsLibrary
+    let reviewService: ReviewService
+    let quranProfileService: QuranProfileService
+    let audioDownloadsBuilder: AudioDownloadsBuilder
+    let translationsListBuilder: TranslationsListBuilder
+    let readingSelectorBuilder: ReadingSelectorBuilder
+    let diagnosticsBuilder: DiagnosticsBuilder
 
-    private let contactUsService = ContactUsService()
-    private let themeService = ThemeService.shared
-    private let audioPreferences = AudioPreferences.shared
+    let contactUsService = ContactUsService()
+    let themeService = ThemeService.shared
+    let audioPreferences = AudioPreferences.shared
 
-    private weak var navigationController: UINavigationController?
+    weak var navigationController: UINavigationController?
 
     @Published var audioEnd: AudioEnd
 
@@ -138,7 +138,7 @@ final class SettingsRootViewModel: ObservableObject {
             return
         }
         do {
-            try await self.quranProfileService.login(on: viewController)
+            try await quranProfileService.login(on: viewController)
             // TODO: Replace with the needed UI changes.
             print("Login seems successful")
         } catch {

--- a/Features/SettingsFeature/SettingsRootViewModel.swift
+++ b/Features/SettingsFeature/SettingsRootViewModel.swift
@@ -133,11 +133,13 @@ final class SettingsRootViewModel: ObservableObject {
     }
 
     func loginToQuranCom() async {
+        logger.info("Settings: Login to Quran.com")
         guard let viewController = navigationController else {
             return
         }
         do {
             try await self.quranProfileService.login(on: viewController)
+            // TODO: Replace with the needed UI changes.
             print("Login seems successful")
         } catch {
             logger.error("Failed to login to Quran.com: \(error)")

--- a/Features/SettingsFeature/SettingsRootViewModel.swift
+++ b/Features/SettingsFeature/SettingsRootViewModel.swift
@@ -51,19 +51,19 @@ final class SettingsRootViewModel: ObservableObject {
 
     // MARK: Internal
 
-    let analytics: AnalyticsLibrary
-    let reviewService: ReviewService
+    private let analytics: AnalyticsLibrary
+    private let reviewService: ReviewService
     private let quranProfileService: QuranProfileService
-    let audioDownloadsBuilder: AudioDownloadsBuilder
-    let translationsListBuilder: TranslationsListBuilder
-    let readingSelectorBuilder: ReadingSelectorBuilder
-    let diagnosticsBuilder: DiagnosticsBuilder
+    private let audioDownloadsBuilder: AudioDownloadsBuilder
+    private let translationsListBuilder: TranslationsListBuilder
+    private let readingSelectorBuilder: ReadingSelectorBuilder
+    private let diagnosticsBuilder: DiagnosticsBuilder
 
-    let contactUsService = ContactUsService()
-    let themeService = ThemeService.shared
-    let audioPreferences = AudioPreferences.shared
+    private let contactUsService = ContactUsService()
+    private let themeService = ThemeService.shared
+    private let audioPreferences = AudioPreferences.shared
 
-    weak var navigationController: UINavigationController?
+    private weak var navigationController: UINavigationController?
 
     @Published var audioEnd: AudioEnd
 

--- a/Package.swift
+++ b/Package.swift
@@ -485,6 +485,7 @@ private func featuresTargets() -> [[Target]] {
             "LastPagePersistence",
             "ReadingService",
             "QuranResources",
+            "OAuthClient",
         ]),
 
         target(type, name: "FeaturesSupport", hasTests: false, dependencies: [
@@ -668,6 +669,7 @@ private func featuresTargets() -> [[Target]] {
             "ReadingSelectorFeature",
             "Preferences",
             "Zip",
+            "QuranProfileService",
         ]),
 
         target(type, name: "AppStructureFeature", hasTests: false, dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
 
         // Async
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "0.1.0"),
-        
+
         // OAuth
         .package(url: "https://github.com/openid/AppAuth-iOS", .upToNextMajor(from: "1.3.0")),
 
@@ -298,11 +298,12 @@ private func dataTargets() -> [[Target]] {
             "BatchDownloader",
             "NetworkSupportFake",
         ]),
-        
+
         // MARK: - Quran.com OAuth
+
         target(type, name: "OAuthClient", hasTests: false, dependencies: [
             .product(name: "AppAuth", package: "AppAuth-iOS"),
-        ])
+        ]),
     ]
 }
 
@@ -469,7 +470,7 @@ private func domainTargets() -> [[Target]] {
 
         target(type, name: "QuranProfileService", hasTests: false, dependencies: [
             "OAuthClient",
-        ])
+        ]),
     ]
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -302,6 +302,7 @@ private func dataTargets() -> [[Target]] {
         // MARK: - Quran.com OAuth
 
         target(type, name: "OAuthClient", hasTests: false, dependencies: [
+            "VLogging",
             .product(name: "AppAuth", package: "AppAuth-iOS"),
         ]),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -47,6 +47,9 @@ let package = Package(
 
         // Async
         .package(url: "https://github.com/apple/swift-async-algorithms", from: "0.1.0"),
+        
+        // OAuth
+        .package(url: "https://github.com/openid/AppAuth-iOS", .upToNextMajor(from: "1.3.0")),
 
         // UI
         .package(url: "https://github.com/GenericDataSource/GenericDataSource", from: "3.1.3"),
@@ -295,6 +298,11 @@ private func dataTargets() -> [[Target]] {
             "BatchDownloader",
             "NetworkSupportFake",
         ]),
+        
+        // MARK: - Quran.com OAuth
+        target(type, name: "OAuthClient", hasTests: false, dependencies: [
+            .product(name: "AppAuth", package: "AppAuth-iOS"),
+        ])
     ]
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -466,6 +466,10 @@ private func domainTargets() -> [[Target]] {
             "Utilities",
 
         ]),
+
+        target(type, name: "QuranProfileService", hasTests: false, dependencies: [
+            "OAuthClient",
+        ])
     ]
 }
 


### PR DESCRIPTION
Introduces the basic infra for authenticating the user to their Quran.com account, and the basic UI for login. Will be expanded upon in following tasks.
- `Data/OAuthClient` handles the actual request. This is the _starting point_ to handle authenticating requests and refreshing the tokens. The persistance of the tokens is yet to be handled. 
- `Domain/QuranProfileService` is the service counterpart. Will, probably, only expose the profile information. 
- `openid/AppAuth-iOS` was added as a dependency. Cuts down on much nuisance in OpenID communications. 