### PR TITLE
Page Bookmarks – Model Migrations

### DIFF
--- a/Data/CoreDataModel/Quran.xcdatamodeld/.xccurrentversion
+++ b/Data/CoreDataModel/Quran.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>_XCCurrentVersionName</key>
+	<string>Quran_1.1.xcdatamodel</string>
+</dict>
+</plist>

--- a/Data/CoreDataModel/Quran.xcdatamodeld/Quran_1.1.xcdatamodel/contents
+++ b/Data/CoreDataModel/Quran.xcdatamodeld/Quran_1.1.xcdatamodel/contents
@@ -17,6 +17,7 @@
         <attribute name="createdOn" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="modifiedOn" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="page" optional="YES" attributeType="Integer 32" usesScalarValueType="YES"/>
+        <attribute name="remoteID" optional="YES" attributeType="String"/>
     </entity>
     <entity name="MO_Verse" representedClassName="MO_Verse" syncable="YES" codeGenerationType="class">
         <attribute name="ayah" optional="YES" attributeType="Integer 32" usesScalarValueType="YES"/>

--- a/Data/CoreDataModel/Schema.swift
+++ b/Data/CoreDataModel/Schema.swift
@@ -17,7 +17,7 @@ public enum Schema {
     }
 
     public enum PageBookmark: String, CoreDataKey {
-        case color, createdOn, modifiedOn, page
+        case color, createdOn, modifiedOn, page, remoteID
     }
 
     public enum LastPage: String, CoreDataKey {

--- a/Data/CoreDataPersistence/Sources/CoreDataStack.swift
+++ b/Data/CoreDataPersistence/Sources/CoreDataStack.swift
@@ -52,6 +52,10 @@ public class CoreDataStack {
         description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
         description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
 
+        // Enables automatic data migration.
+        description.shouldMigrateStoreAutomatically = true
+        description.shouldInferMappingModelAutomatically = true
+
         container.loadPersistentStores(completionHandler: { _, error in
             guard let error = error as NSError? else { return }
             fatalError("###\(#function): Failed to load persistent store: \(error)")

--- a/Data/PageBookmarkPersistence/Sources/CoreDataPageBookmarkPersistence.swift
+++ b/Data/PageBookmarkPersistence/Sources/CoreDataPageBookmarkPersistence.swift
@@ -66,5 +66,6 @@ private extension PageBookmarkPersistenceModel {
     init(_ other: MO_PageBookmark) {
         creationDate = other.createdOn ?? Date()
         page = Int(other.page)
+        remoteID = other.remoteID
     }
 }

--- a/Data/PageBookmarkPersistence/Sources/PageBookmarkPersistenceModel.swift
+++ b/Data/PageBookmarkPersistence/Sources/PageBookmarkPersistenceModel.swift
@@ -11,4 +11,5 @@ import Foundation
 public struct PageBookmarkPersistenceModel {
     public let page: Int
     public let creationDate: Date
+    public let remoteID: String?
 }

--- a/Domain/AnnotationsService/Sources/PageBookmarkService.swift
+++ b/Domain/AnnotationsService/Sources/PageBookmarkService.swift
@@ -43,7 +43,8 @@ private extension PageBookmark {
     init(quran: Quran, _ other: PageBookmarkPersistenceModel) {
         self.init(
             page: Page(quran: quran, pageNumber: Int(other.page))!,
-            creationDate: other.creationDate
+            creationDate: other.creationDate,
+            remoteID: other.remoteID
         )
     }
 }

--- a/Model/QuranAnnotations/PageBookmark.swift
+++ b/Model/QuranAnnotations/PageBookmark.swift
@@ -11,15 +11,17 @@ import QuranKit
 public struct PageBookmark: Equatable, Identifiable {
     // MARK: Lifecycle
 
-    public init(page: Page, creationDate: Date) {
+    public init(page: Page, creationDate: Date, remoteID: String? = nil) {
         self.page = page
         self.creationDate = creationDate
+        self.remoteID = remoteID
     }
 
     // MARK: Public
 
     public let page: Page
     public let creationDate: Date
+    public let remoteID: String?
 
     public var id: Page { page }
 }


### PR DESCRIPTION
This PR introduces the needed changes in the page bookmarks table: adding an optional `remoteID`. This will be used to identify the bookmarks in APIs with the backend. 

Additionally, the PR enables automatic data migrations for the model. The changes are simple, so the automatic migration is sufficient. 

*Not in this PR*: the tracking of local mutations; either the table that tracks unsynced mutations or the any model or service changes.