### PR TITLE
Add Surah Number to Search Preview

### DIFF
--- a/Features/SearchFeature/SearchView.swift
+++ b/Features/SearchFeature/SearchView.swift
@@ -126,7 +126,7 @@ private struct SearchViewUI: View {
                         let localizedVerse = item.ayah.localizedName
                         let arabicSuraName = item.ayah.sura.arabicSuraName
                         NoorListItem(
-                            subheading: "\(localizedVerse) \(sura: arabicSuraName)",
+                            subheading: "(\(String(item.ayah.sura.suraNumber))) \(localizedVerse) \(sura: arabicSuraName)",
                             title: searchResultText(of: item),
                             accessory: .text(NumberFormatter.shared.format(item.ayah.page.pageNumber))
                         ) {


### PR DESCRIPTION
## Summary
Extends the surah search preview to include the surah number in brackets for each search result.

## Motivation
closes #711 

## Testing
Ran local build on my device (iOS 26) and confirmed the labels appear correctly:

<table>
  <tr>
    <td align="center" valign="top">
      <h3>Before</h3>
     <img width="250" src="https://github.com/user-attachments/assets/4a471ab0-3d43-4a8a-beec-352fd1e485dd" />
    </td>
    <td align="center" valign="top">
      <h3>After</h3>
      <img src="https://github.com/user-attachments/assets/7c7a7123-7b22-410e-9bf2-911a00d163d0" alt="After" width="250" />
    </td>
  </tr>
</table>
