### PR TITLE
Upgrade to Xcode 26 and fix compatibility issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,13 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setting up Xcode
-      run: sudo xcode-select -s "/Applications/Xcode_16.4.app"
+      run: sudo xcode-select -s "/Applications/Xcode_26.1.1.app"
+
+    - name: Install xcpretty
+      run: gem install xcpretty
 
     - name: Run tests
-      run: |
-        gem install xcpretty
-        set -o pipefail && xcrun xcodebuild build test -scheme QuranEngine-Package -sdk "iphonesimulator" -destination "name=iPhone 16,OS=18.4" | xcpretty
+      run: make test
 
     - uses: codecov/codecov-action@v4
       with:
@@ -32,12 +33,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setting up Xcode
-        run: sudo xcode-select -s "/Applications/Xcode_16.4.app"
+        run: sudo xcode-select -s "/Applications/Xcode_26.1.1.app"
+
+      - name: Install xcpretty
+        run: gem install xcpretty
       
       - name: Build
-        run: |
-          gem install xcpretty
-          set -o pipefail &&  xcrun xcodebuild build -project Example/QuranEngineApp.xcodeproj -scheme QuranEngineApp -sdk "iphonesimulator" -destination 'generic/platform=iOS' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
+        run: make build-example
 
   SwiftFormat:
     runs-on: macos-15
@@ -46,7 +48,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setting up Xcode
-        run: sudo xcode-select -s "/Applications/Xcode_16.4.app"
+        run: sudo xcode-select -s "/Applications/Xcode_26.1.1.app"
       
       - name: SwiftFormat
         run: make format-lint

--- a/.swiftpm/xcode/xcshareddata/xcschemes/OAuthServiceAppAuthImpl.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/OAuthServiceAppAuthImpl.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "OAuthServiceAppAuthImpl"
+               BuildableName = "OAuthServiceAppAuthImpl"
+               BlueprintName = "OAuthServiceAppAuthImpl"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "OAuthServiceAppAuthImpl"
+            BuildableName = "OAuthServiceAppAuthImpl"
+            BlueprintName = "OAuthServiceAppAuthImpl"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Core/QueuePlayer/QueuePlayer.swift
+++ b/Core/QueuePlayer/QueuePlayer.swift
@@ -33,7 +33,7 @@ public class QueuePlayer {
     // MARK: Lifecycle
 
     public init() {
-        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.defaultToSpeaker, .allowBluetooth])
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.defaultToSpeaker, .allowBluetoothHFP])
     }
 
     // MARK: Open

--- a/Data/CoreDataPersistence/Sources/CoreDataStack.swift
+++ b/Data/CoreDataPersistence/Sources/CoreDataStack.swift
@@ -119,5 +119,3 @@ public class CoreDataStack {
         }
     }
 }
-
-extension NSManagedObjectContext: @retroactive @unchecked Sendable {}

--- a/Domain/AnnotationsService/Sources/NoteService.swift
+++ b/Domain/AnnotationsService/Sources/NoteService.swift
@@ -90,8 +90,8 @@ public struct NoteService {
     private var lastUsedHighlightColor: Note.Color
 
     private func textDictionaryForVerses(_ verses: [AyahNumber]) async throws -> [AyahNumber: String] {
-        let translatedVerses: TranslatedVerses = try await textService.textForVerses(verses, translations: [])
-        return Dictionary(zip(verses, translatedVerses.verses).map { ($0, $1.arabicText) }, uniquingKeysWith: { x, _ in x })
+        let verseTexts = try await textService.textForVerses(verses, translations: [])
+        return verseTexts.mapValues(\.arabicText)
     }
 }
 

--- a/Domain/QuranAudioKit/Tests/AudioRequest+Extension.swift
+++ b/Domain/QuranAudioKit/Tests/AudioRequest+Extension.swift
@@ -8,7 +8,15 @@
 import Foundation
 @testable import QueuePlayer
 
-extension AudioRequest: Encodable {
+struct EncodableAudioRequest: Encodable {
+    // MARK: Lifecycle
+
+    init(request: AudioRequest) {
+        self.request = request
+    }
+
+    // MARK: Internal
+
     enum CodingKeys: String, CodingKey {
         case files
         case endTime
@@ -16,44 +24,84 @@ extension AudioRequest: Encodable {
         case requestRuns
     }
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(files, forKey: .files)
-        try container.encode(endTime, forKey: .endTime)
-        try container.encode(frameRuns, forKey: .frameRuns)
-        try container.encode(requestRuns, forKey: .requestRuns)
+        try container.encode(request.files.map(EncodableAudioFile.init), forKey: .files)
+        try container.encode(request.endTime, forKey: .endTime)
+        try container.encode(EncodableRuns(runs: request.frameRuns), forKey: .frameRuns)
+        try container.encode(EncodableRuns(runs: request.requestRuns), forKey: .requestRuns)
     }
+
+    // MARK: Private
+
+    private let request: AudioRequest
 }
 
-extension AudioFile: Encodable {
+private struct EncodableAudioFile: Encodable {
+    // MARK: Lifecycle
+
+    init(file: AudioFile) {
+        self.file = file
+    }
+
+    // MARK: Internal
+
     enum CodingKeys: String, CodingKey {
         case frames
         case url
     }
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(frames, forKey: .frames)
-        try container.encode(url.path.replacingOccurrences(of: FileManager.documentsPath, with: ""), forKey: .url)
+        try container.encode(file.frames.map(EncodableAudioFrame.init), forKey: .frames)
+        try container.encode(file.url.path.replacingOccurrences(of: FileManager.documentsPath, with: ""), forKey: .url)
     }
+
+    // MARK: Private
+
+    private let file: AudioFile
 }
 
-extension AudioFrame: Encodable {
+private struct EncodableAudioFrame: Encodable {
+    // MARK: Lifecycle
+
+    init(frame: AudioFrame) {
+        self.frame = frame
+    }
+
+    // MARK: Internal
+
     enum CodingKeys: String, CodingKey {
         case startTime
         case endTime
     }
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(startTime, forKey: .startTime)
-        try container.encode(endTime, forKey: .endTime)
+        try container.encode(frame.startTime, forKey: .startTime)
+        try container.encode(frame.endTime, forKey: .endTime)
     }
+
+    // MARK: Private
+
+    private let frame: AudioFrame
 }
 
-extension Runs: Encodable {
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(maxRuns)
+private struct EncodableRuns: Encodable {
+    // MARK: Lifecycle
+
+    init(runs: Runs) {
+        self.runs = runs
     }
+
+    // MARK: Internal
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(runs.maxRuns)
+    }
+
+    // MARK: Private
+
+    private let runs: Runs
 }

--- a/Domain/QuranAudioKit/Tests/QueuePlayerFake.swift
+++ b/Domain/QuranAudioKit/Tests/QueuePlayerFake.swift
@@ -83,3 +83,29 @@ class QueuePlayerFake: QueuingPlayer {
     func setRate(_ rate: Float) {
     }
 }
+
+extension QueuePlayerFake.PlayingState {
+    private enum CaseCodingKeys: String, CodingKey {
+        case playing
+        case paused
+        case stopped
+    }
+
+    private enum AssociatedValueCodingKeys: String, CodingKey {
+        case _0
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CaseCodingKeys.self)
+        switch self {
+        case .playing(let request):
+            var nested = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .playing)
+            try nested.encode(EncodableAudioRequest(request: request), forKey: ._0)
+        case .paused(let request):
+            var nested = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .paused)
+            try nested.encode(EncodableAudioRequest(request: request), forKey: ._0)
+        case .stopped:
+            _ = container.nestedContainer(keyedBy: AssociatedValueCodingKeys.self, forKey: .stopped)
+        }
+    }
+}

--- a/Domain/QuranTextKit/Tests/CompositeSearcherTests.swift
+++ b/Domain/QuranTextKit/Tests/CompositeSearcherTests.swift
@@ -158,7 +158,7 @@ class CompositeSearcherTests: XCTestCase {
         let result = try await searcher.search(for: term, quran: quran)
 
         // assert the text
-        assertSnapshot(matching: result, as: .json, record: record, testName: testName)
+        assertSnapshot(matching: EncodableSearchResults(results: result), as: .json, record: record, testName: testName)
     }
 
     private func enumerateAllSuras(_ block: (Sura, Language) async throws -> Void) async rethrows {

--- a/Domain/QuranTextKit/Tests/Encoding.swift
+++ b/Domain/QuranTextKit/Tests/Encoding.swift
@@ -7,44 +7,77 @@
 
 import QuranText
 
-extension SearchResults: Encodable {
-    enum CodingKeys: String, CodingKey {
-        case source
-        case items
-    }
+struct EncodableSearchResults: Encodable {
+    // MARK: Internal
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(source, forKey: .source)
-        try container.encode(items, forKey: .items)
-    }
-}
+    let results: [SearchResults]
 
-extension SearchResults.Source: Encodable {
-    enum CodingKeys: String, CodingKey {
-        case rawKey
-    }
+    // MARK: Encodable
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        switch self {
-        case .quran:
-            try container.encode(name.lowercased(), forKey: .rawKey)
-        case .translation(let translation):
-            try container.encode("\(name.lowercased()): \(translation.id)", forKey: .rawKey)
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.unkeyedContainer()
+        for result in results {
+            try container.encode(EncodableSearchResult(result: result))
         }
     }
 }
 
-extension SearchResult: Encodable {
-    enum CodingKeys: String, CodingKey {
+private struct EncodableSearchResult: Encodable {
+    // MARK: Internal
+
+    let result: SearchResults
+
+    // MARK: Private
+
+    private enum CodingKeys: String, CodingKey {
+        case source
+        case items
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(EncodableSearchSource(source: result.source), forKey: .source)
+        try container.encode(result.items.map(EncodableSearchResultItem.init), forKey: .items)
+    }
+}
+
+private struct EncodableSearchSource: Encodable {
+    // MARK: Internal
+
+    let source: SearchResults.Source
+
+    // MARK: Private
+
+    private enum CodingKeys: String, CodingKey {
+        case rawKey
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch source {
+        case .quran:
+            try container.encode(source.name.lowercased(), forKey: .rawKey)
+        case .translation(let translation):
+            try container.encode("\(source.name.lowercased()): \(translation.id)", forKey: .rawKey)
+        }
+    }
+}
+
+private struct EncodableSearchResultItem: Encodable {
+    // MARK: Internal
+
+    let result: SearchResult
+
+    // MARK: Private
+
+    private enum CodingKeys: String, CodingKey {
         case text
         case ayah
     }
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(text, forKey: .text)
-        try container.encode(ayah, forKey: .ayah)
+        try container.encode(result.text, forKey: .text)
+        try container.encode(result.ayah, forKey: .ayah)
     }
 }

--- a/Domain/QuranTextKit/Tests/QuranTextDataServiceTests.swift
+++ b/Domain/QuranTextKit/Tests/QuranTextDataServiceTests.swift
@@ -49,7 +49,7 @@ final class QuranTextDataServiceTests: XCTestCase {
             [quran.suras[1].verses[0]],
         ]
         for verses in tests {
-            let versesText: TranslatedVerses = try await textService.textForVerses(verses, translations: [])
+            let versesText = try await textService.textForVerses(verses, translations: [])
 
             let expectedVerses = verses.map {
                 VerseText(
@@ -59,7 +59,7 @@ final class QuranTextDataServiceTests: XCTestCase {
                     arabicSuffix: []
                 )
             }
-            let expected = TranslatedVerses(translations: [], verses: expectedVerses)
+            let expected = Dictionary(uniqueKeysWithValues: zip(verses, expectedVerses))
             XCTAssertEqual(expected, versesText)
         }
     }
@@ -70,7 +70,7 @@ final class QuranTextDataServiceTests: XCTestCase {
             [quran.suras[0].verses[1], quran.suras[0].verses[2]],
         ]
         for verses in tests {
-            let versesText = try await textService.textForVerses(verses)
+            let versesText = try await textService.textForVerses(verses, translations: translations)
 
             let expectedVerses = verses.map { verse in
                 VerseText(
@@ -82,7 +82,7 @@ final class QuranTextDataServiceTests: XCTestCase {
                     arabicSuffix: []
                 )
             }
-            let expected = TranslatedVerses(translations: translations, verses: expectedVerses)
+            let expected = Dictionary(uniqueKeysWithValues: zip(verses, expectedVerses))
             XCTAssertEqual(expected, versesText)
         }
     }
@@ -92,7 +92,7 @@ final class QuranTextDataServiceTests: XCTestCase {
         try await localTranslationsFake.setTranslations(translations)
 
         let verse = quran.suras[0].verses[5]
-        let versesText = try await textService.textForVerses([verse])
+        let versesText = try await textService.textForVerses([verse], translations: translations)
 
         let translationText = TestData.translationTextAt(translations[0], verse)
         let textWithoutFootnotes = "Guide us to the Straight Way.  {ABC} [1] {DE} [2] FG"
@@ -117,7 +117,7 @@ final class QuranTextDataServiceTests: XCTestCase {
             arabicPrefix: [],
             arabicSuffix: []
         )
-        let expected = TranslatedVerses(translations: translations, verses: [expectedVerse])
+        let expected = [verse: expectedVerse]
         XCTAssertEqual(expected, versesText)
     }
 

--- a/Domain/QuranTextKit/Tests/ShareableVerseTextRetrieverTests.swift
+++ b/Domain/QuranTextKit/Tests/ShareableVerseTextRetrieverTests.swift
@@ -29,7 +29,8 @@ final class ShareableVerseTextRetrieverTests: XCTestCase {
 
         shareableTextRetriever = ShareableVerseTextRetriever(
             textService: textService,
-            shareableVersePersistence: persistence
+            shareableVersePersistence: persistence,
+            localTranslationsRetriever: localtranslationsRetriever
         )
 
         let selectedTranslationsPreferences = SelectedTranslationsPreferences.shared

--- a/Features/QuranPagesFeature/PageGeometryActions.swift
+++ b/Features/QuranPagesFeature/PageGeometryActions.swift
@@ -9,11 +9,10 @@ import Foundation
 import QuranKit
 import SwiftUI
 
-@MainActor
 public struct PageGeometryActions: Equatable {
     let id: AnyHashable
-    public var word: (CGPoint) -> Word?
-    public var verse: (CGPoint) -> AyahNumber?
+    public var word: @MainActor (CGPoint) -> Word?
+    public var verse: @MainActor (CGPoint) -> AyahNumber?
 
     public init(id: some Hashable, word: @escaping (CGPoint) -> Word?, verse: @escaping (CGPoint) -> AyahNumber?) {
         self.id = id

--- a/Features/WordPointerFeature/WordPointerViewController.swift
+++ b/Features/WordPointerFeature/WordPointerViewController.swift
@@ -147,7 +147,7 @@ public final class WordPointerViewController: UIViewController {
 
     private var borderInsets: NSDirectionalEdgeInsets {
         // TODO: Use the containing window
-        UIApplication.shared.windows.first?.directionalSafeAreaInsets ?? .zero
+        view.window?.directionalSafeAreaInsets ?? .zero
     }
 
     private var minX: CGFloat {

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,32 @@
+SHELL=/bin/bash
+
 BUILD_TOOLS_DIR=./BuildTools
+
+PACKAGE_SCHEME ?= QuranEngine-Package
+PACKAGE_SDK ?= iphonesimulator
+PACKAGE_DESTINATION ?= name=iPhone 16,OS=18.5
+EXAMPLE_PROJECT ?= Example/QuranEngineApp.xcodeproj
+EXAMPLE_SCHEME ?= QuranEngineApp
+EXAMPLE_SDK ?= iphonesimulator
+EXAMPLE_DESTINATION ?= generic/platform=iOS
 
 SWIFT_FORMAT_REPO=https://github.com/nicklockwood/SwiftFormat
 SWIFT_FORMAT_VERSION=0.54.3
 SWIFT_FORMAT_DIR=$(BUILD_TOOLS_DIR)/SwiftFormat
 SWIFT_FORMAT_BIN=$(SWIFT_FORMAT_DIR)/.build/release/swiftformat
+
+CURRENT_TARGET=$(if $(TARGET),$(TARGET),$(PACKAGE_SCHEME))
+
+.PHONY: test build build-example clone-swiftformat build-swiftformat force-build-swiftformat clean-swiftformat format-lint format-autocorrect install-swiftlint build-for-analyzer swiftlint-analyzer
+
+test:
+	set -o pipefail; xcrun xcodebuild build test -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" | xcpretty
+
+build:
+	set -o pipefail; xcrun xcodebuild build -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" | xcpretty
+
+build-example:
+	set -o pipefail; xcrun xcodebuild build -project $(EXAMPLE_PROJECT) -scheme $(EXAMPLE_SCHEME) -sdk "$(EXAMPLE_SDK)" -destination "$(EXAMPLE_DESTINATION)" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcpretty
 
 clone-swiftformat:
 	@mkdir -p $(BUILD_TOOLS_DIR)

--- a/Package.swift
+++ b/Package.swift
@@ -133,6 +133,7 @@ private func coreTargets() -> [[Target]] {
 
         target(type, name: "SecurePersistence", hasTests: false, dependencies: [
             "SystemDependencies",
+            "VLogging",
         ]),
 
         target(type, name: "OAuthServiceAppAuthImpl", hasTests: false, dependencies: [
@@ -188,6 +189,9 @@ private func uiTargets() -> [[Target]] {
             "NoorFont",
             "VLogging",
             .product(name: "GenericDataSources", package: "GenericDataSource"),
+        ], resources: [
+            .process("Colors/Colors.xcassets"),
+            .process("Images/Images.xcassets"),
         ]),
     ]
 }

--- a/UI/NoorUI/Components/AppStoreDownloadButton.swift
+++ b/UI/NoorUI/Components/AppStoreDownloadButton.swift
@@ -41,21 +41,17 @@ struct AppStoreDownloadButton: View {
 }
 
 struct CircularPendingView: View {
-    // MARK: Internal
-
     var body: some View {
         Arc(circlePercentage: 0.94)
             .stroke(Color.accentColor, lineWidth: lineWidth)
-            .rotationEffect(.degrees(rotationAngle))
-            .animation(.linear(duration: 1).repeatForever(autoreverses: false))
+            .rotationEffect(.degrees(isAnimating ? 360 : 0))
+            .animation(.linear(duration: 1).repeatForever(autoreverses: false), value: isAnimating)
             .onAppear {
-                rotationAngle = 360
+                isAnimating = true
             }
     }
 
-    // MARK: Private
-
-    @State private var rotationAngle: Double = 0
+    @State private var isAnimating = false
     @ScaledMetric private var lineWidth: Double = 1
 }
 

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,12 @@
+# QuranEngine
+
+## Make commands
+
+The Makefile exposes a few helpful commands:
+
+1. Use `make build` to compile `QuranEngine-Package` (or override with `make build TARGET=NoorUI`).
+2. Use `make test` for package tests, also honoring `TARGET` to point at another scheme/target.
+3. Use `make build-example` to build the Example app.
+4. Run `make format-lint` for SwiftFormat checks.
+
+Keeping these commands green locally should keep the CI workflow green as well.

--- a/claude.md
+++ b/claude.md
@@ -1,0 +1,1 @@
+agents.md


### PR DESCRIPTION
- Update CI workflow to use Xcode 26.1.1 for Package job
- Refactor Makefile with configurable build targets and improved structure
- Fix concurrency warnings in OAuthServiceAppAuthImpl with @MainActor annotations
- Remove deprecated methods from QuranTextDataService
- Remove unnecessary NSManagedObjectContext Sendable conformance extension
- Update Package.swift with missing dependencies and resource declarations
- Fix test files for Xcode 26 compatibility
- Add build configuration improvements for CI/CD