### PR TITLE
Fix bug where tajweed mushaf would be tinted

### DIFF
--- a/Features/QuranImageFeature/ContentImageView.swift
+++ b/Features/QuranImageFeature/ContentImageView.swift
@@ -19,6 +19,7 @@ struct ContentImageView: View {
             ContentImageViewBody(
                 decorations: viewModel.decorations,
                 image: viewModel.imagePage?.image,
+                renderingMode: viewModel.imageRenderingMode,
                 quarterName: viewModel.page.localizedQuarterName,
                 suraNames: viewModel.page.suraNames(),
                 page: viewModel.page.localizedNumber,
@@ -44,6 +45,7 @@ struct ContentImageView: View {
 private struct ContentImageViewBody: View {
     let decorations: ImageDecorations
     let image: UIImage?
+    let renderingMode: QuranThemedImage.RenderingMode
     let quarterName: String
     let suraNames: MultipartText
     let page: String
@@ -53,7 +55,7 @@ private struct ContentImageViewBody: View {
     let onGlobalFrameChange: (CGRect) -> Void
 
     var body: some View {
-        AdaptiveImageScrollView(decorations: decorations) {
+        AdaptiveImageScrollView(decorations: decorations, renderingMode: renderingMode) {
             image
         } onScaleChange: {
             onScaleChange($0)
@@ -81,6 +83,7 @@ private struct ContentImageViewBody: View {
             highlights: [:]
         ),
         image: UIImage(contentsOfFile: testResourceURL("images/page604.png").absoluteString)!,
+        renderingMode: .tinted,
         quarterName: "ABC",
         suraNames: "ABC",
         page: "604",

--- a/Features/QuranImageFeature/ContentImageViewModel.swift
+++ b/Features/QuranImageFeature/ContentImageViewModel.swift
@@ -50,6 +50,10 @@ class ContentImageViewModel: ObservableObject {
     @Published var scale: WordFrameScale = .zero
     @Published var imageFrame: CGRect = .zero
 
+    var imageRenderingMode: QuranThemedImage.RenderingMode {
+        reading == .tajweed ? .invertInDarkMode : .tinted
+    }
+
     var decorations: ImageDecorations {
         // Add verse highlights
         var frameHighlights: [WordFrame: Color] = [:]

--- a/Features/ReadingSelectorFeature/View/ReadingImageView.swift
+++ b/Features/ReadingSelectorFeature/View/ReadingImageView.swift
@@ -14,9 +14,10 @@ struct ReadingImageView: View {
     let image: UIImage
     let suraHeaders: [SuraHeaderLocation]
     let ayahNumbers: [AyahNumberLocation]
+    let renderingMode: QuranThemedImage.RenderingMode
 
     var body: some View {
-        AdaptiveImageScrollView(decorations: decorations) {
+        AdaptiveImageScrollView(decorations: decorations, renderingMode: renderingMode) {
             image
         } onScaleChange: { _ in
         } onGlobalFrameChange: { _ in

--- a/Features/ReadingSelectorFeature/View/ReadingSelector.swift
+++ b/Features/ReadingSelectorFeature/View/ReadingSelector.swift
@@ -26,6 +26,7 @@ struct ReadingSelector: View {
             start: { await viewModel.start() },
             retry: { }
         )
+        .populateThemeStyle()
     }
 
     // MARK: Private
@@ -34,8 +35,13 @@ struct ReadingSelector: View {
         ReadingImageView(
             image: UIImage(named: reading.value.imageName)!,
             suraHeaders: reading.value.suraHeaders,
-            ayahNumbers: reading.value.ayahNumbers
+            ayahNumbers: reading.value.ayahNumbers,
+            renderingMode: renderingMode(for: reading.value)
         )
+    }
+
+    private func renderingMode(for reading: Reading) -> QuranThemedImage.RenderingMode {
+        reading == .tajweed ? .invertInDarkMode : .tinted
     }
 }
 

--- a/UI/NoorUI/Features/Quran/AdaptiveImageScrollView.swift
+++ b/UI/NoorUI/Features/Quran/AdaptiveImageScrollView.swift
@@ -16,6 +16,7 @@ public struct AdaptiveImageScrollView<Header: View, Footer: View>: View {
 
     public init(
         decorations: ImageDecorations,
+        renderingMode: QuranThemedImage.RenderingMode = .tinted,
         image: () -> UIImage?,
         onScaleChange: @escaping (WordFrameScale) -> Void,
         onGlobalFrameChange: @escaping (CGRect) -> Void,
@@ -24,6 +25,7 @@ public struct AdaptiveImageScrollView<Header: View, Footer: View>: View {
     ) {
         self.decorations = decorations
         self.image = image()
+        self.renderingMode = renderingMode
         self.header = header()
         self.footer = footer()
         self.onScaleChange = onScaleChange
@@ -41,7 +43,7 @@ public struct AdaptiveImageScrollView<Header: View, Footer: View>: View {
 
                     Group {
                         if let image {
-                            QuranThemedImage(image: image)
+                            QuranThemedImage(image: image, renderingMode: renderingMode)
                                 .background(
                                     ImageDecorationsView(
                                         imageSize: image.size,
@@ -74,6 +76,7 @@ public struct AdaptiveImageScrollView<Header: View, Footer: View>: View {
     private let header: Header
     private let footer: Footer
     private let image: UIImage?
+    private let renderingMode: QuranThemedImage.RenderingMode
     private let decorations: ImageDecorations
     private let onScaleChange: (WordFrameScale) -> Void
     private let onGlobalFrameChange: (CGRect) -> Void


### PR DESCRIPTION
- Add RenderingMode enum to QuranThemedImage with tinted and invertInDarkMode options
- Pass rendering mode through AdaptiveImageScrollView and content views
- Use invertInDarkMode for tajweed reading, tinted for others
- Refactor image processing to support different rendering modes