### PR TITLE
Fix sorting surahs persistence #733

### DIFF
--- a/Features/HomeFeature/HomePreferences.swift
+++ b/Features/HomeFeature/HomePreferences.swift
@@ -1,0 +1,26 @@
+//
+//  HomePreferences.swift
+//
+//
+//  Created by QuranEngine on 2024.
+//
+
+import Foundation
+import Preferences
+
+struct HomePreferences {
+    // MARK: Lifecycle
+
+    private init() {}
+
+    // MARK: Internal
+
+    static let shared = HomePreferences()
+
+    @TransformedPreference(surahSortOrder, transformer: .rawRepresentable(defaultValue: .ascending))
+    var surahSortOrder: SurahSortOrder
+
+    // MARK: Private
+
+    private static let surahSortOrder = PreferenceKey<Int>(key: "surahSortOrder", defaultValue: SurahSortOrder.ascending.rawValue)
+}

--- a/Features/HomeFeature/HomeViewModel.swift
+++ b/Features/HomeFeature/HomeViewModel.swift
@@ -9,6 +9,7 @@ import AnnotationsService
 import Combine
 import Crashing
 import Foundation
+import Preferences
 import QuranAnnotations
 import QuranKit
 import QuranText
@@ -42,6 +43,9 @@ final class HomeViewModel: ObservableObject {
         self.navigateToPage = navigateToPage
         self.navigateToSura = navigateToSura
         self.navigateToQuarter = navigateToQuarter
+
+        HomePreferences.shared.$surahSortOrder
+            .assign(to: &$surahSortOrder)
     }
 
     // MARK: Internal
@@ -50,7 +54,7 @@ final class HomeViewModel: ObservableObject {
     @Published var quarters: [QuarterItem] = []
     @Published var lastPages: [LastPage] = []
 
-    @Published var surahSortOrder: SurahSortOrder = .ascending
+    @Published var surahSortOrder: SurahSortOrder = HomePreferences.shared.surahSortOrder
 
     @Published var type = HomeViewType.suras {
         didSet {
@@ -78,7 +82,7 @@ final class HomeViewModel: ObservableObject {
     }
 
     func toggleSurahSortOrder() {
-        surahSortOrder = surahSortOrder == .ascending ? .descending : .ascending
+        HomePreferences.shared.surahSortOrder = surahSortOrder == .ascending ? .descending : .ascending
     }
 
     // MARK: Private

--- a/Package.swift
+++ b/Package.swift
@@ -678,6 +678,7 @@ private func featuresTargets() -> [[Target]] {
             "ReadingSelectorFeature",
             "AnnotationsService",
             "FeaturesSupport",
+            "Preferences",
         ]),
 
         target(type, name: "QuranViewFeature", hasTests: false, dependencies: [


### PR DESCRIPTION
## Description
This PR fixes the issue where the Surah sorting preference was not persisting across app launches.

## Changes
- **Package.swift**: Added `Preferences` dependency to `HomeFeature`.
- **HomePreferences.swift**: Created a new service to handle persistence of `surahSortOrder` using the app's `Preferences` module.
- **HomeViewModel.swift**: Updated to use `HomePreferences` instead of local state.

## Issue
Fixes #733

## Verification
- Launch the app.
- Change Surah sort order.
- Restart the app.
- Verify the sort order is preserved.