### PR TITLE
Avoid removing pages when possible

### DIFF
--- a/Domain/ReadingService/Sources/ReadingRemoteResources.swift
+++ b/Domain/ReadingService/Sources/ReadingRemoteResources.swift
@@ -19,6 +19,7 @@ public struct RemoteResource {
 
     public init(url: URL, reading: Reading, version: Int) {
         self.url = url
+        self.reading = reading
         self.version = version
         downloadDestination = Reading.readingsPath.appendingPathComponent(reading.localPath, isDirectory: true)
     }
@@ -30,6 +31,7 @@ public struct RemoteResource {
     // MARK: Internal
 
     let url: URL
+    let reading: Reading
     let version: Int
 
     var zipFile: RelativeFilePath {
@@ -40,8 +42,19 @@ public struct RemoteResource {
         downloadDestination.appendingPathComponent("success-v\(version).txt", isDirectory: false)
     }
 
+    var extractedVersionFilePath: RelativeFilePath? {
+        guard let width = reading.imageAssetWidth else {
+            return nil
+        }
+        return downloadDestination
+            .appendingPathComponent("images_\(width)", isDirectory: true)
+            .appendingPathComponent("width_\(width)", isDirectory: true)
+            .appendingPathComponent(".v\(version)", isDirectory: false)
+    }
+
     public func isDownloaded(fileSystem: FileSystem = DefaultFileSystem()) -> Bool {
-        fileSystem.fileExists(at: successFilePath)
+        fileSystem.fileExists(at: successFilePath) ||
+            extractedVersionFilePath.map { fileSystem.fileExists(at: $0) } == true
     }
 }
 
@@ -50,6 +63,23 @@ private extension Reading {
 }
 
 extension Reading {
+    var imageAssetWidth: Int? {
+        switch self {
+        case .hafs_1421:
+            return 1120
+        case .hafs_1440:
+            return 1352
+        case .hafs_1439:
+            return 1080
+        case .hafs_1441:
+            return 1440
+        case .tajweed:
+            return 1280
+        case .hafs_1405:
+            return nil
+        }
+    }
+
     public var localPath: String {
         switch self {
         case .hafs_1405: return "hafs_1405"

--- a/Domain/ReadingService/Sources/ReadingResourcesService.swift
+++ b/Domain/ReadingService/Sources/ReadingResourcesService.swift
@@ -114,7 +114,7 @@ public actor ReadingResourcesService {
             return .ready
         }
 
-        if fileManager.fileExists(at: remoteResource.successFilePath) {
+        if remoteResource.isDownloaded(fileSystem: fileManager) {
             logger.info("Resources: Reading \(reading) has been downloaded and saved locally before")
             return .ready
         }

--- a/Domain/ReadingService/Tests/ReadingResourcesServiceTests.swift
+++ b/Domain/ReadingService/Tests/ReadingResourcesServiceTests.swift
@@ -89,12 +89,13 @@ final class ReadingResourcesServiceTests: XCTestCase {
         XCTAssertEqual(fileManager.files, [])
     }
 
-    func test_resourceDownloadedAndUnzipped() async throws {
+    func test_resourceDownloadedWhenExtractedVersionFileExists() async throws {
         // Given
         let reading = Reading.tajweed
         let remoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
         ReadingPreferences.shared.reading = reading
-        fileManager.files.insert(remoteResource.successFilePath.url)
+        let extractedVersionFilePath = try XCTUnwrap(remoteResource.extractedVersionFilePath?.url)
+        fileManager.files = [remoteResource.downloadDestination.url, extractedVersionFilePath]
 
         // Test
         await service.startLoadingResources()
@@ -102,6 +103,8 @@ final class ReadingResourcesServiceTests: XCTestCase {
 
         // Then
         XCTAssertEqual(collector.items, [.ready])
+        XCTAssertFalse(fileManager.removedItems.contains(remoteResource.downloadDestination.url))
+        XCTAssertEqual(zipper.unzippedFiles, [])
     }
 
     func test_remoteResourceIsDownloadedWhenSuccessFileExists() throws {
@@ -109,6 +112,14 @@ final class ReadingResourcesServiceTests: XCTestCase {
         let remoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
 
         fileManager.files.insert(remoteResource.successFilePath.url)
+
+        XCTAssertTrue(remoteResource.isDownloaded(fileSystem: fileManager))
+    }
+
+    func test_remoteResourceIsDownloadedWhenExtractedVersionFileExists() throws {
+        let reading = Reading.hafs_1441
+        let remoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
+        fileManager.files.insert(try XCTUnwrap(remoteResource.extractedVersionFilePath?.url))
 
         XCTAssertTrue(remoteResource.isDownloaded(fileSystem: fileManager))
     }
@@ -171,6 +182,55 @@ final class ReadingResourcesServiceTests: XCTestCase {
         // Then
         try await completeRunningDownload(initial: false)
         XCTAssertEqual(collector.items.last, .ready)
+        try assertDownloadedFiles(reading)
+    }
+
+    func test_downloadUpgrade_skipsRedownloadWhenExtractedVersionFileExists() async throws {
+        // Given
+        let reading = Reading.hafs_1440
+        ReadingPreferences.shared.reading = reading
+        remoteResources.versions[reading] = 1
+        let initialRemoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
+
+        fileManager.files.insert(initialRemoteResource.successFilePath.url)
+        await service.startLoadingResources()
+        await finishLoadingNoDownload()
+        XCTAssertEqual(collector.items.last, .ready)
+        collector.items = []
+
+        // Test upgrade
+        remoteResources.versions[reading] = 2
+        let upgradedRemoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
+        fileManager.files.insert(try XCTUnwrap(upgradedRemoteResource.extractedVersionFilePath?.url))
+        await service.retry()
+        await finishLoadingNoDownload(initial: false)
+
+        // Then
+        XCTAssertEqual(collector.items.last, .ready)
+        XCTAssertFalse(fileManager.removedItems.contains(upgradedRemoteResource.downloadDestination.url))
+        XCTAssertEqual(zipper.unzippedFiles, [])
+    }
+
+    func test_downloadUpgrade_doesNotSkipForWrongExtractedVersionFile() async throws {
+        // Given
+        let reading = Reading.hafs_1440
+        ReadingPreferences.shared.reading = reading
+        remoteResources.versions[reading] = 2
+        let remoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
+        let wrongVersionMarker = remoteResource.downloadDestination
+            .appendingPathComponent("images_1352", isDirectory: true)
+            .appendingPathComponent("width_1352", isDirectory: true)
+            .appendingPathComponent(".v1", isDirectory: false)
+        fileManager.files = [remoteResource.downloadDestination.url, wrongVersionMarker.url]
+
+        // Test
+        await service.startLoadingResources()
+        try await completeRunningDownload()
+
+        // Then
+        await waitForReady()
+        XCTAssertEqual(collector.items.last, .ready)
+        XCTAssertEqual(zipper.unzippedFiles, [remoteResource.zipFile.url])
         try assertDownloadedFiles(reading)
     }
 


### PR DESCRIPTION
Sometimes, when the version of Readings is updated, the mobile phone
already has the newest version (because of the time delta between when
the readings were updated on the server and when they are updated in the
app). This patch lets the app first check for the marker file - if it's
there, there is no need to remove and re-download, since the current
version of the files is already present.
