### PR TITLE
Check that files exist on image upgrade

### DIFF
--- a/Domain/ReadingService/Sources/ReadingRemoteResources.swift
+++ b/Domain/ReadingService/Sources/ReadingRemoteResources.swift
@@ -28,6 +28,13 @@ public struct RemoteResource {
 
     public let downloadDestination: RelativeFilePath
 
+    public func isDownloaded(fileSystem: FileSystem = DefaultFileSystem()) -> Bool {
+        if hasSuccessFile(fileSystem: fileSystem) {
+            return true
+        }
+        return canRecoverSuccessFile(fileSystem: fileSystem)
+    }
+
     // MARK: Internal
 
     let url: URL
@@ -42,19 +49,42 @@ public struct RemoteResource {
         downloadDestination.appendingPathComponent("success-v\(version).txt", isDirectory: false)
     }
 
-    var extractedVersionFilePath: RelativeFilePath? {
-        guard let width = reading.imageAssetWidth else {
-            return nil
-        }
-        return downloadDestination
-            .appendingPathComponent("images_\(width)", isDirectory: true)
-            .appendingPathComponent("width_\(width)", isDirectory: true)
-            .appendingPathComponent(".v\(version)", isDirectory: false)
+    var extractedVersionFileURL: URL {
+        reading.imagesDirectory(in: downloadDestination.url)
+            .appendingPathComponent(".v\(version)")
     }
 
-    public func isDownloaded(fileSystem: FileSystem = DefaultFileSystem()) -> Bool {
-        fileSystem.fileExists(at: successFilePath) ||
-            extractedVersionFilePath.map { fileSystem.fileExists(at: $0) } == true
+    func hasSuccessFile(fileSystem: FileSystem = DefaultFileSystem()) -> Bool {
+        fileSystem.fileExists(at: successFilePath)
+    }
+
+    func canRecoverSuccessFile(fileSystem: FileSystem = DefaultFileSystem()) -> Bool {
+        // The CDN can serve a newer dataset under the same URL before the app
+        // updates its bundled version number. A matching .vN marker tells us
+        // that newer dataset landed, and any older success-vK.txt confirms a
+        // prior unzip completed successfully on this device.
+        guard fileSystem.fileExists(at: extractedVersionFileURL) else {
+            return false
+        }
+        return hasSuccessFile(forAnyVersionBefore: version, fileSystem: fileSystem)
+    }
+
+    // MARK: Private
+
+    private func hasSuccessFile(forAnyVersionBefore version: Int, fileSystem: FileSystem) -> Bool {
+        guard version > 1 else {
+            return false
+        }
+        for previousVersion in 1 ..< version {
+            if fileSystem.fileExists(at: successFilePath(for: previousVersion)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func successFilePath(for version: Int) -> RelativeFilePath {
+        downloadDestination.appendingPathComponent("success-v\(version).txt", isDirectory: false)
     }
 }
 
@@ -63,23 +93,6 @@ private extension Reading {
 }
 
 extension Reading {
-    var imageAssetWidth: Int? {
-        switch self {
-        case .hafs_1421:
-            return 1120
-        case .hafs_1440:
-            return 1352
-        case .hafs_1439:
-            return 1080
-        case .hafs_1441:
-            return 1440
-        case .tajweed:
-            return 1280
-        case .hafs_1405:
-            return nil
-        }
-    }
-
     public var localPath: String {
         switch self {
         case .hafs_1405: return "hafs_1405"

--- a/Domain/ReadingService/Sources/ReadingResourcesService.swift
+++ b/Domain/ReadingService/Sources/ReadingResourcesService.swift
@@ -114,8 +114,13 @@ public actor ReadingResourcesService {
             return .ready
         }
 
-        if remoteResource.isDownloaded(fileSystem: fileManager) {
+        if remoteResource.hasSuccessFile(fileSystem: fileManager) {
             logger.info("Resources: Reading \(reading) has been downloaded and saved locally before")
+            return .ready
+        }
+
+        if recoverDownloadedResourceIfNeeded(remoteResource) {
+            logger.info("Resources: Reading \(reading) has extracted resources and a previous success marker. Regenerated success marker.")
             return .ready
         }
 
@@ -135,6 +140,22 @@ public actor ReadingResourcesService {
             crasher.recordError(error, reason: "Failed to download \(reading). Error: \(error)")
             return .error(error as NSError)
         }
+    }
+
+    private func recoverDownloadedResourceIfNeeded(_ remoteResource: RemoteResource) -> Bool {
+        guard remoteResource.canRecoverSuccessFile(fileSystem: fileManager) else {
+            return false
+        }
+
+        do {
+            try fileManager.writeToFile(at: remoteResource.successFilePath.url, content: "Downloaded")
+        } catch {
+            crasher.recordError(
+                error,
+                reason: "Cannot write recovered success marker for '\(remoteResource.successFilePath.url)'"
+            )
+        }
+        return true
     }
 
     private func unzipFileIfNeeded(_ remoteResource: RemoteResource) throws {

--- a/Domain/ReadingService/Tests/ReadingResourcesServiceTests.swift
+++ b/Domain/ReadingService/Tests/ReadingResourcesServiceTests.swift
@@ -89,13 +89,13 @@ final class ReadingResourcesServiceTests: XCTestCase {
         XCTAssertEqual(fileManager.files, [])
     }
 
-    func test_resourceDownloadedWhenExtractedVersionFileExists() async throws {
+    func test_resourceDownloadedWhenExtractedVersionFileExistsAndPreviousSuccessFileExists() async throws {
         // Given
         let reading = Reading.tajweed
+        remoteResources.versions[reading] = 2
         let remoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
         ReadingPreferences.shared.reading = reading
-        let extractedVersionFilePath = try XCTUnwrap(remoteResource.extractedVersionFilePath?.url)
-        fileManager.files = [remoteResource.downloadDestination.url, extractedVersionFilePath]
+        fileManager.files = [remoteResource.extractedVersionFileURL, successFileURL(for: remoteResource, version: 1)]
 
         // Test
         await service.startLoadingResources()
@@ -105,10 +105,12 @@ final class ReadingResourcesServiceTests: XCTestCase {
         XCTAssertEqual(collector.items, [.ready])
         XCTAssertFalse(fileManager.removedItems.contains(remoteResource.downloadDestination.url))
         XCTAssertEqual(zipper.unzippedFiles, [])
+        XCTAssertTrue(fileManager.files.contains(remoteResource.successFilePath.url))
     }
 
     func test_remoteResourceIsDownloadedWhenSuccessFileExists() throws {
         let reading = Reading.hafs_1441
+        remoteResources.versions[reading] = 2
         let remoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
 
         fileManager.files.insert(remoteResource.successFilePath.url)
@@ -118,14 +120,34 @@ final class ReadingResourcesServiceTests: XCTestCase {
 
     func test_remoteResourceIsDownloadedWhenExtractedVersionFileExists() throws {
         let reading = Reading.hafs_1441
+        remoteResources.versions[reading] = 2
         let remoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
-        fileManager.files.insert(try XCTUnwrap(remoteResource.extractedVersionFilePath?.url))
+        fileManager.files = [remoteResource.extractedVersionFileURL, successFileURL(for: remoteResource, version: 1)]
 
         XCTAssertTrue(remoteResource.isDownloaded(fileSystem: fileManager))
     }
 
+    func test_remoteResourceIsDownloadedWhenExtractedVersionFileExistsAndAnyOlderSuccessFileExists() throws {
+        let reading = Reading.hafs_1441
+        remoteResources.versions[reading] = 7
+        let remoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
+        fileManager.files = [remoteResource.extractedVersionFileURL, successFileURL(for: remoteResource, version: 3)]
+
+        XCTAssertTrue(remoteResource.isDownloaded(fileSystem: fileManager))
+    }
+
+    func test_remoteResourceIsNotDownloadedWhenExtractedVersionFileExistsWithoutPreviousSuccessFile() throws {
+        let reading = Reading.hafs_1441
+        remoteResources.versions[reading] = 2
+        let remoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
+        fileManager.files = [remoteResource.extractedVersionFileURL]
+
+        XCTAssertFalse(remoteResource.isDownloaded(fileSystem: fileManager))
+    }
+
     func test_remoteResourceIsNotDownloadedWithoutSuccessFile() throws {
         let reading = Reading.hafs_1441
+        remoteResources.versions[reading] = 2
         let remoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
 
         XCTAssertFalse(remoteResource.isDownloaded(fileSystem: fileManager))
@@ -201,7 +223,7 @@ final class ReadingResourcesServiceTests: XCTestCase {
         // Test upgrade
         remoteResources.versions[reading] = 2
         let upgradedRemoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
-        fileManager.files.insert(try XCTUnwrap(upgradedRemoteResource.extractedVersionFilePath?.url))
+        fileManager.files.insert(upgradedRemoteResource.extractedVersionFileURL)
         await service.retry()
         await finishLoadingNoDownload(initial: false)
 
@@ -209,6 +231,53 @@ final class ReadingResourcesServiceTests: XCTestCase {
         XCTAssertEqual(collector.items.last, .ready)
         XCTAssertFalse(fileManager.removedItems.contains(upgradedRemoteResource.downloadDestination.url))
         XCTAssertEqual(zipper.unzippedFiles, [])
+        XCTAssertTrue(fileManager.files.contains(upgradedRemoteResource.successFilePath.url))
+    }
+
+    func test_downloadUpgrade_skipsRedownloadWhenExtractedVersionFileExistsAndOlderSuccessFileExists() async throws {
+        // Given
+        let reading = Reading.hafs_1440
+        ReadingPreferences.shared.reading = reading
+        remoteResources.versions[reading] = 3
+        let initialRemoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
+
+        fileManager.files.insert(initialRemoteResource.successFilePath.url)
+        await service.startLoadingResources()
+        await finishLoadingNoDownload()
+        XCTAssertEqual(collector.items.last, .ready)
+        collector.items = []
+
+        // Test upgrade
+        remoteResources.versions[reading] = 7
+        let upgradedRemoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
+        fileManager.files.insert(upgradedRemoteResource.extractedVersionFileURL)
+        await service.retry()
+        await finishLoadingNoDownload(initial: false)
+
+        // Then
+        XCTAssertEqual(collector.items.last, .ready)
+        XCTAssertFalse(fileManager.removedItems.contains(upgradedRemoteResource.downloadDestination.url))
+        XCTAssertEqual(zipper.unzippedFiles, [])
+        XCTAssertTrue(fileManager.files.contains(upgradedRemoteResource.successFilePath.url))
+    }
+
+    func test_downloadResource_redownloadsWhenExtractedVersionFileExistsWithoutPreviousSuccessFile() async throws {
+        // Given
+        let reading = Reading.hafs_1440
+        ReadingPreferences.shared.reading = reading
+        remoteResources.versions[reading] = 2
+        let remoteResource = try XCTUnwrap(remoteResources.resource(for: reading))
+        fileManager.files = [remoteResource.extractedVersionFileURL]
+
+        // Test
+        await service.startLoadingResources()
+        try await completeRunningDownload()
+
+        // Then
+        await waitForReady()
+        XCTAssertEqual(collector.items.last, .ready)
+        XCTAssertEqual(zipper.unzippedFiles, [remoteResource.zipFile.url])
+        try assertDownloadedFiles(reading)
     }
 
     func test_downloadUpgrade_doesNotSkipForWrongExtractedVersionFile() async throws {
@@ -411,6 +480,12 @@ final class ReadingResourcesServiceTests: XCTestCase {
                                          remoteResource.downloadDestination.url]
         downloadedFiles.formUnion(zipper.zipContents(remoteResource.zipFile.url))
         XCTAssertEqual(fileManager.files, downloadedFiles, file: file, line: line)
+    }
+
+    private func successFileURL(for remoteResource: RemoteResource, version: Int) -> URL {
+        remoteResource.downloadDestination
+            .appendingPathComponent("success-v\(version).txt", isDirectory: false)
+            .url
     }
 
     private func waitForReady(file: StaticString = #filePath, line: UInt = #line) async {

--- a/Features/QuranImageFeature/ContentImageBuilder.swift
+++ b/Features/QuranImageFeature/ContentImageBuilder.swift
@@ -59,7 +59,7 @@ public struct ContentImageBuilder {
         let readingDirectory = Self.readingDirectory(reading, container: container)
         return ImageDataService(
             ayahInfoDatabase: reading.ayahInfoDatabase(in: readingDirectory),
-            imagesURL: reading.images(in: readingDirectory)
+            imagesURL: reading.imagesDirectory(in: readingDirectory)
         )
     }
 
@@ -88,40 +88,6 @@ public struct ContentImageBuilder {
 }
 
 private extension Reading {
-    func ayahInfoDatabase(in directory: URL) -> URL {
-        switch self {
-        case .hafs_1405:
-            return directory.appendingPathComponent("images_1920/databases/ayahinfo_1920.db")
-        case .hafs_1421:
-            return directory.appendingPathComponent("images_1120/databases/ayahinfo_1120.db")
-        case .hafs_1440:
-            return directory.appendingPathComponent("images_1352/databases/ayahinfo_1352.db")
-        case .hafs_1439:
-            return directory.appendingPathComponent("images_1080/databases/ayahinfo_1080.db")
-        case .hafs_1441:
-            return directory.appendingPathComponent("images_1440/databases/ayahinfo_1440.db")
-        case .tajweed:
-            return directory.appendingPathComponent("images_1280/databases/ayahinfo_1280.db")
-        }
-    }
-
-    func images(in directory: URL) -> URL {
-        switch self {
-        case .hafs_1405:
-            return directory.appendingPathComponent("images_1920/width_1920")
-        case .hafs_1421:
-            return directory.appendingPathComponent("images_1120/width_1120")
-        case .hafs_1440:
-            return directory.appendingPathComponent("images_1352/width_1352")
-        case .hafs_1439:
-            return directory.appendingPathComponent("images_1080/width_1080")
-        case .hafs_1441:
-            return directory.appendingPathComponent("images_1440/width_1440")
-        case .tajweed:
-            return directory.appendingPathComponent("images_1280/width_1280")
-        }
-    }
-
     // TODO: Add cropInsets back
     var cropInsets: UIEdgeInsets {
         switch self {

--- a/Model/QuranKit/Sources/Reading.swift
+++ b/Model/QuranKit/Sources/Reading.swift
@@ -5,6 +5,8 @@
 //  Created by Mohamed Afifi on 2023-02-14.
 //
 
+import Foundation
+
 public enum Reading: Int {
     case hafs_1405 = 0
     case hafs_1440 = 1
@@ -51,6 +53,23 @@ public enum Reading: Int {
         }
     }
 
+    public var imageAssetWidth: Int {
+        switch self {
+        case .hafs_1405:
+            return 1920
+        case .hafs_1421:
+            return 1120
+        case .hafs_1440:
+            return 1352
+        case .hafs_1439:
+            return 1080
+        case .hafs_1441:
+            return 1440
+        case .tajweed:
+            return 1280
+        }
+    }
+
     public var usesBlueLinePageChrome: Bool {
         self == .hafs_1439
     }
@@ -62,5 +81,20 @@ public enum Reading: Int {
         case .hafs_1405, .hafs_1421:
             return false
         }
+    }
+
+    public func ayahInfoDatabase(in directory: URL) -> URL {
+        let width = imageAssetWidth
+        return directory
+            .appendingPathComponent("images_\(width)")
+            .appendingPathComponent("databases")
+            .appendingPathComponent("ayahinfo_\(width).db")
+    }
+
+    public func imagesDirectory(in directory: URL) -> URL {
+        let width = imageAssetWidth
+        return directory
+            .appendingPathComponent("images_\(width)")
+            .appendingPathComponent("width_\(width)")
     }
 }


### PR DESCRIPTION
When the image version is upgraded within the app, it's likely that the
person using the app may already have the newest images. We can find out
by checking for the version file within the zip file's extractions. This
patch makes the logic safer by ensuring that zip files that got
extracted incompletely (due to some file system error, out of space,
etc) are not also presumed to be downloaded.
