### PR TITLE
Make Husary the default reciter

### DIFF
--- a/Domain/ReciterService/Sources/ReciterPreferences.swift
+++ b/Domain/ReciterService/Sources/ReciterPreferences.swift
@@ -30,7 +30,7 @@ public class ReciterPreferences {
 
     // MARK: Private
 
-    private static let lastSelectedReciterId = PreferenceKey<Int>(key: "LastSelectedQariId", defaultValue: 41)
+    private static let lastSelectedReciterId = PreferenceKey<Int>(key: "LastSelectedQariId", defaultValue: 1)
     private static let recentReciterIds = PreferenceKey<[Int]>(key: "recentRecitersIdsKey", defaultValue: [])
     private static let recentReciterIdsTransfomer = PreferenceTransformer<[Int], OrderedSet<Int>>(
         rawToValue: { OrderedSet($0) },

--- a/Example/QuranEngineApp/Resources/reciters.plist
+++ b/Example/QuranEngineApp/Resources/reciters.plist
@@ -22,17 +22,17 @@
 		<key>category</key>
 		<string>arabic</string>
 		<key>databaseName</key>
-		<string>mishari_alafasy</string>
+		<string>husary</string>
 		<key>hasGaplessAlternative</key>
 		<false/>
 		<key>id</key>
-		<integer>41</integer>
+		<integer>1</integer>
 		<key>name</key>
-		<string>qari_afasy_gapless</string>
+		<string>qari_husary_gapless</string>
 		<key>path</key>
-		<string>mishari_alafasy</string>
+		<string>husary</string>
 		<key>url</key>
-		<string>https://download.quranicaudio.com/quran/mishaari_raashid_al_3afaasee/</string>
+		<string>https://download.quranicaudio.com/quran/mahmood_khaleel_al-husaree/</string>
 	</dict>
 	<dict>
 		<key>category</key>


### PR DESCRIPTION
- Set the default persisted reciter preference id to Husary.
- Update the primary reciters plist entry to Husary gapless metadata and source URL.