### PR TITLE
Add bookmark collection sync wrapper

### DIFF
--- a/Data/MobileSyncSupport/Sources/BookmarkCollectionService.swift
+++ b/Data/MobileSyncSupport/Sources/BookmarkCollectionService.swift
@@ -1,0 +1,54 @@
+//
+//  BookmarkCollectionService.swift
+//
+//
+//  Created by Ahmed Nabil on 2026-04-22.
+//
+
+#if QURAN_SYNC
+    import Foundation
+    import MobileSync
+    import QuranKit
+
+    public struct BookmarkCollectionService {
+        // MARK: Lifecycle
+
+        public init(syncService: SyncService) {
+            self.syncService = syncService
+        }
+
+        // MARK: Public
+
+        public func createCollection(named name: String) async throws {
+            try await syncService.createCollection(named: name)
+        }
+
+        @discardableResult
+        public func addAyahBookmark(_ ayah: AyahNumber, toCollectionLocalId collectionLocalId: String) async throws -> Bookmark {
+            let bookmark = try await syncService.addAyahBookmark(
+                sura: Int32(ayah.sura.suraNumber),
+                ayah: Int32(ayah.ayah)
+            )
+            try await addBookmark(bookmark, toCollectionLocalId: collectionLocalId)
+            return bookmark
+        }
+
+        public func addBookmark(_ bookmark: Bookmark, toCollectionLocalId collectionLocalId: String) async throws {
+            try await syncService.addBookmarkToCollection(
+                collectionLocalId: collectionLocalId,
+                bookmark: bookmark
+            )
+        }
+
+        public func removeBookmark(_ bookmark: Bookmark, fromCollectionLocalId collectionLocalId: String) async throws {
+            try await syncService.removeBookmarkFromCollection(
+                collectionLocalId: collectionLocalId,
+                bookmark: bookmark
+            )
+        }
+
+        // MARK: Private
+
+        private let syncService: SyncService
+    }
+#endif

--- a/Example/QuranEngineApp/Classes/Container.swift
+++ b/Example/QuranEngineApp/Classes/Container.swift
@@ -47,6 +47,10 @@ class Container: AppDependencies {
     }()
 
     private(set) lazy var notePersistence: NotePersistence = CoreDataNotePersistence(stack: coreDataStack)
+    #if QURAN_SYNC
+        private(set) lazy var syncService: SyncService? = mobileSyncServices?.syncService
+    #endif
+
     private(set) lazy var authenticationClient: (any AuthenticationClient)? = {
         #if QURAN_SYNC
             if let authService = mobileSyncServices?.authService {

--- a/Features/AppDependencies/AppDependencies.swift
+++ b/Features/AppDependencies/AppDependencies.swift
@@ -11,6 +11,10 @@ import AuthenticationClient
 import BatchDownloader
 import Foundation
 import LastPagePersistence
+#if QURAN_SYNC
+    import MobileSync
+    import MobileSyncSupport
+#endif
 import NotePersistence
 import PageBookmarkPersistence
 import QuranResources
@@ -38,6 +42,11 @@ public protocol AppDependencies {
     var notePersistence: NotePersistence { get }
     var pageBookmarkPersistence: PageBookmarkPersistence { get }
 
+    #if QURAN_SYNC
+        var syncService: SyncService? { get }
+        var bookmarkCollectionService: BookmarkCollectionService? { get }
+    #endif
+
     var authenticationClient: (any AuthenticationClient)? { get }
 }
 
@@ -50,6 +59,13 @@ extension AppDependencies {
             quranFileURL: quranUthmaniV2Database
         )
     }
+
+    #if QURAN_SYNC
+        public var bookmarkCollectionService: BookmarkCollectionService? {
+            syncService.map { BookmarkCollectionService(syncService: $0) }
+        }
+
+    #endif
 
     public func noteService() -> NoteService {
         NoteService(

--- a/Package.swift
+++ b/Package.swift
@@ -229,6 +229,11 @@ private func dataTargets() -> [[Target]] {
             "AsyncUtilitiesForTesting",
         ]),
 
+        target(type, name: "MobileSyncSupport", hasTests: false, dependencies: [
+            "QuranKit",
+            .product(name: "MobileSync", package: "mobile-sync-spm"),
+        ]),
+
         // MARK: - Core Data
 
         target(type, name: "LastPagePersistence", dependencies: [
@@ -538,6 +543,8 @@ private func featuresTargets() -> [[Target]] {
             "ReadingService",
             "QuranResources",
             "AuthenticationClient",
+            "MobileSyncSupport",
+            .product(name: "MobileSync", package: "mobile-sync-spm"),
         ]),
 
         target(type, name: "FeaturesSupport", hasTests: false, dependencies: [


### PR DESCRIPTION
## Summary
Add a thin Mobile Sync collection wrapper only.

## Scope
- add `MobileSyncSupport`
- add `BookmarkCollectionService`
- wire it through `AppDependencies` / `Container` under `QURAN_SYNC`

## Out of scope
- no highlights UI
- no ayah menu changes
- no Quran page rendering changes
- no note/highlight behavior changes

## Notes
This keeps the new sync integration isolated from older modules and avoids mixing data and UI in the same PR.