### PR TITLE
Add synced highlights UI

### DIFF
--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -120,6 +120,14 @@
 "notes.verses-count" = "(+%d آيات)";
 "notes.delete.alert.title" = "حذف الإشارة المرجعية";
 "notes.delete.alert.body" = "سيتم حذف الملاحظة أيضًا.";
+"highlights.title" = "التحديدات";
+"highlights.no-data.title" = "لا توجد تحديدات بعد";
+"highlights.no-data.text" = "قم بتحديد آية لتظهر هنا.";
+"highlights.color.red" = "أحمر";
+"highlights.color.green" = "أخضر";
+"highlights.color.blue" = "أزرق";
+"highlights.color.yellow" = "أصفر";
+"highlights.color.purple" = "بنفسجي";
 "notes.icloud.alert.title" = "مزامنة iCloud";
 "notes.icloud.alert.body" = "يستخدم التطبيق iCloud لمزامنة الإشارات المرجعية والملاحظات عبر أجهزتك. يمكنك تعطيله من جهازك من خلال إعدادات iCloud.";
 

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -129,6 +129,14 @@
 "notes.verses-count" = "(+%d ayat)";
 "notes.delete.alert.title" = "Delete Highlight";
 "notes.delete.alert.body" = "The associated note will also be deleted.";
+"highlights.title" = "Highlights";
+"highlights.no-data.title" = "No Highlights Yet";
+"highlights.no-data.text" = "Highlight an ayah to see it here.";
+"highlights.color.red" = "Red";
+"highlights.color.green" = "Green";
+"highlights.color.blue" = "Blue";
+"highlights.color.yellow" = "Yellow";
+"highlights.color.purple" = "Purple";
 "notes.icloud.alert.title" = "iCloud Sync";
 "notes.icloud.alert.body" = "The app uses iCloud to sync bookmarks & notes across your devices. You can disable it from your device's iCloud settings.";
 

--- a/Features/AyahMenuFeature/SyncedAyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/SyncedAyahMenuBuilder.swift
@@ -1,0 +1,75 @@
+#if QURAN_SYNC
+    import AppDependencies
+    import FeaturesSupport
+    import MobileSync
+    import MobileSyncSupport
+    import QuranAnnotations
+    import QuranKit
+    import QuranTextKit
+    import UIKit
+
+    public struct SyncedAyahMenuInput {
+        // MARK: Lifecycle
+
+        public init(
+            sourceView: UIView,
+            pointInView: CGPoint,
+            verses: [AyahNumber],
+            notes: [QuranAnnotations.Note],
+            syncHighlightColor: HighlightColor?,
+            hasSyncHighlight: Bool
+        ) {
+            self.sourceView = sourceView
+            self.pointInView = pointInView
+            self.verses = verses
+            self.notes = notes
+            self.syncHighlightColor = syncHighlightColor
+            self.hasSyncHighlight = hasSyncHighlight
+        }
+
+        // MARK: Internal
+
+        let sourceView: UIView
+        let pointInView: CGPoint
+        let verses: [AyahNumber]
+        let notes: [QuranAnnotations.Note]
+        let syncHighlightColor: HighlightColor?
+        let hasSyncHighlight: Bool
+    }
+
+    @MainActor
+    public struct SyncedAyahMenuBuilder {
+        // MARK: Lifecycle
+
+        public init(container: AppDependencies) {
+            self.container = container
+        }
+
+        // MARK: Public
+
+        public func build(withListener listener: SyncedAyahMenuListener, input: SyncedAyahMenuInput) -> UIViewController {
+            let textRetriever = ShareableVerseTextRetriever(
+                databasesURL: container.databasesURL,
+                quranFileURL: container.quranUthmaniV2Database
+            )
+            let deps = SyncedAyahMenuViewModel.Deps(
+                sourceView: input.sourceView,
+                pointInView: input.pointInView,
+                verses: input.verses,
+                notes: input.notes,
+                syncHighlightColor: input.syncHighlightColor,
+                hasSyncHighlight: input.hasSyncHighlight,
+                syncService: container.syncService,
+                bookmarkCollectionService: container.bookmarkCollectionService,
+                textRetriever: textRetriever
+            )
+            let viewModel = SyncedAyahMenuViewModel(deps: deps)
+            viewModel.listener = listener
+            return SyncedAyahMenuViewController(viewModel: viewModel)
+        }
+
+        // MARK: Private
+
+        private let container: AppDependencies
+    }
+#endif

--- a/Features/AyahMenuFeature/SyncedAyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/SyncedAyahMenuViewController.swift
@@ -1,0 +1,82 @@
+#if QURAN_SYNC
+    import NoorUI
+    import UIKit
+    import UIx
+
+    final class SyncedAyahMenuViewController: UIViewController {
+        // MARK: Lifecycle
+
+        init(viewModel: SyncedAyahMenuViewModel) {
+            self.viewModel = viewModel
+            super.init(nibName: nil, bundle: nil)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        // MARK: Public
+
+        override public func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
+            super.preferredContentSizeDidChange(forChildContentContainer: container)
+            preferredContentSize = container.preferredContentSize
+        }
+
+        // MARK: Internal
+
+        override func viewDidLoad() {
+            super.viewDidLoad()
+
+            let deleteHighlightAction: AsyncAction? = if viewModel.canDeleteHighlight {
+                { [weak self] in
+                    guard let self else { return }
+                    await viewModel.deleteHighlight()
+                }
+            } else {
+                nil
+            }
+
+            let deleteNoteAction: AsyncAction? = if viewModel.canDeleteNote {
+                { [weak self] in
+                    guard let self else { return }
+                    await viewModel.deleteNote()
+                }
+            } else {
+                nil
+            }
+
+            let actions = SyncedAyahMenuUI.Actions(
+                play: { [weak self] in self?.viewModel.play() },
+                repeatVerses: { [weak self] in self?.viewModel.repeatVerses() },
+                highlight: { [weak self] color in await self?.viewModel.updateHighlight(color: color) },
+                addNote: { [weak self] in await self?.viewModel.editNote() },
+                deleteHighlight: deleteHighlightAction,
+                deleteNote: deleteNoteAction,
+                showTranslation: { [weak self] in self?.viewModel.showTranslation() },
+                copy: { [weak self] in self?.viewModel.copy() },
+                share: { [weak self] in self?.viewModel.share() }
+            )
+            let dataObject = SyncedAyahMenuUI.DataObject(
+                highlightingColor: viewModel.highlightingColor,
+                hasHighlight: viewModel.hasHighlight,
+                hasNoteText: viewModel.hasNoteText,
+                playSubtitle: viewModel.playSubtitle,
+                repeatSubtitle: viewModel.repeatSubtitle,
+                actions: actions,
+                isTranslationView: viewModel.isTranslationView
+            )
+            showAyahMenu(dataObject)
+        }
+
+        // MARK: Private
+
+        private let viewModel: SyncedAyahMenuViewModel
+
+        private func showAyahMenu(_ dataObject: SyncedAyahMenuUI.DataObject) {
+            let view = SyncedAyahMenuView(dataObject: dataObject)
+            let hostingController = AutoUpdatingPreferredContentSizeHostingController(rootView: view)
+            addFullScreenChild(hostingController)
+        }
+    }
+#endif

--- a/Features/AyahMenuFeature/SyncedAyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/SyncedAyahMenuViewModel.swift
@@ -1,0 +1,200 @@
+#if QURAN_SYNC
+    import Crashing
+    import FeaturesSupport
+    import Localization
+    import MobileSync
+    import MobileSyncSupport
+    import QuranAnnotations
+    import QuranAudioKit
+    import QuranKit
+    import QuranTextKit
+    import ReadingService
+    import UIKit
+    import VLogging
+
+    @MainActor
+    public protocol SyncedAyahMenuListener: AyahMenuListener {
+        func deleteSyncHighlights(_ verses: [AyahNumber]) async
+    }
+
+    @MainActor
+    final class SyncedAyahMenuViewModel {
+        struct Deps {
+            let sourceView: UIView
+            let pointInView: CGPoint
+            let verses: [AyahNumber]
+            let notes: [QuranAnnotations.Note]
+            let syncHighlightColor: HighlightColor?
+            let hasSyncHighlight: Bool
+            let syncService: SyncService?
+            let bookmarkCollectionService: BookmarkCollectionService?
+            let textRetriever: ShareableVerseTextRetriever
+            let quranContentStatePreferences = QuranContentStatePreferences.shared
+        }
+
+        // MARK: Lifecycle
+
+        init(deps: Deps) {
+            self.deps = deps
+        }
+
+        // MARK: Internal
+
+        weak var listener: SyncedAyahMenuListener?
+
+        var isTranslationView: Bool {
+            deps.quranContentStatePreferences.quranMode == .translation
+        }
+
+        var highlightingColor: HighlightColor {
+            deps.syncHighlightColor ?? .red
+        }
+
+        var playSubtitle: String {
+            if deps.verses.count > 1 {
+                return l("ayah.menu.selected-verses")
+            }
+            switch audioPreferences.audioEnd {
+            case .juz: return l("ayah.menu.play-end-juz")
+            case .sura: return l("ayah.menu.play-end-surah")
+            case .page: return l("ayah.menu.play-end-page")
+            case .quran: return l("ayah.menu.play-end-quran")
+            }
+        }
+
+        var repeatSubtitle: String {
+            if deps.verses.count == 1 {
+                return l("ayah.menu.selected-verse")
+            }
+            return l("ayah.menu.selected-verses")
+        }
+
+        var hasHighlight: Bool {
+            deps.hasSyncHighlight
+        }
+
+        var hasNoteText: Bool {
+            deps.notes.contains { !(($0.note ?? "").isEmpty) }
+        }
+
+        var canDeleteHighlight: Bool {
+            hasHighlight
+        }
+
+        var canDeleteNote: Bool {
+            hasNoteText
+        }
+
+        func play() {
+            logger.info("AyahMenu: play tapped. Verses: \(deps.verses)")
+            listener?.dismissAyahMenu()
+
+            let verses = deps.verses
+            let lastVerse = verses.count == 1 ? nil : verses.last
+            listener?.playAudio(verses[0], to: lastVerse, repeatVerses: false)
+        }
+
+        func repeatVerses() {
+            logger.info("AyahMenu: repeat verses tapped. Verses: \(deps.verses)")
+            listener?.dismissAyahMenu()
+
+            let verses = deps.verses
+            listener?.playAudio(verses[0], to: verses.last, repeatVerses: true)
+        }
+
+        func deleteHighlight() async {
+            logger.info("AyahMenu: delete highlight. Verses: \(deps.verses)")
+            listener?.dismissAyahMenu()
+            await listener?.deleteSyncHighlights(deps.verses)
+        }
+
+        func deleteNote() async {
+            logger.info("AyahMenu: delete note. Verses: \(deps.verses)")
+            listener?.dismissAyahMenu()
+            await listener?.deleteNotes(deps.notes, verses: deps.verses)
+        }
+
+        func editNote() async {
+            logger.info("AyahMenu: edit notes. Verses: \(deps.verses)")
+            if let note = deps.notes.first(where: { !(($0.note ?? "").isEmpty) }) {
+                listener?.editNote(note)
+            } else {
+                listener?.editNote(newLocalNoteDraft())
+            }
+        }
+
+        func updateHighlight(color: HighlightColor) async {
+            logger.info("AyahMenu: update verse highlights. Verses: \(deps.verses)")
+            listener?.dismissAyahMenu()
+
+            guard let syncService = deps.syncService, let bookmarkCollectionService = deps.bookmarkCollectionService else {
+                return
+            }
+
+            do {
+                try await HighlightCollection.setHighlight(
+                    verses: deps.verses,
+                    color: color,
+                    syncService: syncService,
+                    bookmarkCollectionService: bookmarkCollectionService
+                )
+            } catch {
+                crasher.recordError(error, reason: "Failed to update synced highlights")
+            }
+        }
+
+        func showTranslation() {
+            logger.info("AyahMenu: showTranslation. Verses: \(deps.verses)")
+            listener?.showTranslation(deps.verses)
+        }
+
+        func copy() {
+            logger.info("AyahMenu: copy. Verses: \(deps.verses)")
+            listener?.dismissAyahMenu()
+            Task {
+                if let lines = try? await retrieveSelectedAyahText() {
+                    UIPasteboard.general.string = lines.joined(separator: "\n")
+                }
+            }
+        }
+
+        func share() {
+            logger.info("AyahMenu: share. Verses: \(deps.verses)")
+            Task {
+                if let lines = try? await retrieveSelectedAyahText() {
+                    listener?.shareText([lines.joined(separator: "\n")], in: deps.sourceView, at: deps.pointInView)
+                }
+            }
+        }
+
+        // MARK: Private
+
+        private let audioPreferences = AudioPreferences.shared
+        private let deps: Deps
+
+        private func newLocalNoteDraft() -> QuranAnnotations.Note {
+            QuranAnnotations.Note(
+                verses: Set(deps.verses),
+                modifiedDate: Date(),
+                note: nil,
+                color: noteColor(from: highlightingColor)
+            )
+        }
+
+        private func noteColor(from color: HighlightColor) -> QuranAnnotations.Note.Color {
+            switch color {
+            case .red: .red
+            case .green: .green
+            case .blue: .blue
+            case .yellow: .yellow
+            case .purple: .purple
+            }
+        }
+
+        private func retrieveSelectedAyahText() async throws -> [String] {
+            try await crasher.recordError("Failed to update highlights") {
+                try await deps.textRetriever.textForVerses(deps.verses)
+            }
+        }
+    }
+#endif

--- a/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
@@ -26,10 +26,12 @@ public struct BookmarksBuilder {
         let viewModel = BookmarksViewModel(
             analytics: container.analytics,
             service: service,
+            highlightCollectionsUpdates: makeHighlightCollectionsUpdates(),
             authenticationClient: container.authenticationClient,
             navigateTo: { [weak listener] page in
                 listener?.navigateTo(page: page, lastPage: nil, highlightingSearchAyah: nil)
-            }
+            },
+            makeHighlightsController: makeHighlightsController(listener: listener)
         )
         let viewController = BookmarksViewController(viewModel: viewModel)
         return viewController
@@ -38,4 +40,34 @@ public struct BookmarksBuilder {
     // MARK: Internal
 
     let container: AppDependencies
+
+    // MARK: Private
+
+    private func makeHighlightsController(listener: QuranNavigator) -> (() -> UIViewController)? {
+        #if QURAN_SYNC
+            guard container.syncService != nil else {
+                return nil
+            }
+
+            return { [container] in
+                HighlightsBuilder(container: container, listener: listener).build()
+            }
+        #else
+            return nil
+        #endif
+    }
+
+    private func makeHighlightCollectionsUpdates() -> (() -> AsyncThrowingStream<[HighlightCollectionSnapshot], Error>)? {
+        #if QURAN_SYNC
+            guard let syncService = container.syncService else {
+                return nil
+            }
+
+            return {
+                HighlightCollection.updates(from: syncService)
+            }
+        #else
+            return nil
+        #endif
+    }
 }

--- a/Features/BookmarksFeature/Sources/BookmarksView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksView.swift
@@ -22,8 +22,12 @@ struct BookmarksView: View {
             error: $viewModel.error,
             bookmarks: viewModel.bookmarks,
             shouldShowSyncBanner: viewModel.shouldShowSyncBanner,
+            shouldShowHighlights: viewModel.shouldShowHighlights,
+            highlightCount: viewModel.highlightCount,
             start: { await viewModel.start() },
+            observeHighlights: { await viewModel.observeHighlights() },
             selectAction: { viewModel.navigateTo($0) },
+            selectHighlightsAction: { viewModel.showHighlights() },
             deleteAction: { await viewModel.deleteItem($0) },
             dismissSyncBanner: { viewModel.dismissSyncBanner() },
             signInAction: { await viewModel.loginToQuranCom() }
@@ -40,9 +44,13 @@ private struct BookmarksViewUI: View {
 
     let bookmarks: [PageBookmark]
     let shouldShowSyncBanner: Bool
+    let shouldShowHighlights: Bool
+    let highlightCount: Int
 
     let start: AsyncAction
+    let observeHighlights: AsyncAction
     let selectAction: ItemAction<PageBookmark>
+    let selectHighlightsAction: () -> Void
     let deleteAction: AsyncItemAction<PageBookmark>
     let dismissSyncBanner: () -> Void
     let signInAction: @MainActor () async -> Void
@@ -60,6 +68,11 @@ private struct BookmarksViewUI: View {
                             }
                         }
                     #endif
+                    if shouldShowHighlights {
+                        NoorBasicSection {
+                            highlightsItem
+                        }
+                    }
                     NoorSection(bookmarks) { bookmark in
                         listItem(bookmark)
                     }
@@ -68,23 +81,43 @@ private struct BookmarksViewUI: View {
             }
         }
         .task { await start() }
+        .task { await observeHighlights() }
         .errorAlert(error: $error)
         .environment(\.editMode, $editMode)
     }
 
     // MARK: Private
 
+    @ViewBuilder
     private var emptyState: some View {
-        VStack(spacing: 16) {
-            #if QURAN_SYNC
-                if shouldShowSyncBanner {
-                    syncBanner
-                        .padding(.horizontal)
-                        .padding(.top, 12)
-                }
-            #endif
+        if showsTopSections {
+            VStack(spacing: 16) {
+                NoorList {
+                    #if QURAN_SYNC
+                        if shouldShowSyncBanner {
+                            NoorBasicSection {
+                                syncBanner
+                            }
+                        }
+                    #endif
 
-            noData
+                    if shouldShowHighlights {
+                        NoorBasicSection {
+                            highlightsItem
+                        }
+                    }
+                }
+                .padding(.horizontal)
+                .padding(.top, ContentDimension.interPageSpacing)
+
+                noData
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            }
+            .background(Color.systemGroupedBackground)
+        } else {
+            VStack(spacing: 16) {
+                noData
+            }
         }
     }
 
@@ -103,6 +136,24 @@ private struct BookmarksViewUI: View {
         )
     }
 
+    private var showsTopSections: Bool {
+        #if QURAN_SYNC
+            shouldShowSyncBanner || shouldShowHighlights
+        #else
+            shouldShowHighlights
+        #endif
+    }
+
+    private var highlightsItem: some View {
+        NoorListItem(
+            leadingView: AnyView(HighlightPaletteIcon()),
+            title: .text(l("highlights.title")),
+            accessory: .textWithDisclosureIndicator(NumberFormatter.shared.format(highlightCount))
+        ) {
+            selectHighlightsAction()
+        }
+    }
+
     private func listItem(_ bookmark: PageBookmark) -> some View {
         let ayah = bookmark.page.firstVerse
         return NoorListItem(
@@ -118,12 +169,12 @@ private struct BookmarksViewUI: View {
 
 @MainActor
 private struct BookmarksSyncBanner: View {
-    @ScaledMetric private var closeButtonInset = 8.0
+    @ScaledMetric private var closeButtonInset = ContentDimension.interSpacing
     @ScaledMetric private var containerCornerRadius = Dimensions.cornerRadius
-    @ScaledMetric private var containerPadding = 16.0
-    @ScaledMetric private var contentSpacing = 12.0
-    @ScaledMetric private var titleSpacing = 4.0
-    @ScaledMetric private var trailingSpacing = 8.0
+    @ScaledMetric private var containerPadding = ContentDimension.interPageSpacing + (ContentDimension.interSpacing / 2)
+    @ScaledMetric private var contentSpacing = ContentDimension.interPageSpacing
+    @ScaledMetric private var titleSpacing = ContentDimension.interSpacing / 2
+    @ScaledMetric private var trailingSpacing = ContentDimension.interSpacing
 
     let dismiss: () -> Void
     let signInAction: @MainActor () async -> Void
@@ -193,8 +244,12 @@ struct BookmarksView_Previews: PreviewProvider {
                     error: $error,
                     bookmarks: items,
                     shouldShowSyncBanner: true,
+                    shouldShowHighlights: true,
+                    highlightCount: 6,
                     start: {},
+                    observeHighlights: {},
                     selectAction: { _ in },
+                    selectHighlightsAction: {},
                     deleteAction: { item in items = items.filter { $0 != item } },
                     dismissSyncBanner: {},
                     signInAction: {}

--- a/Features/BookmarksFeature/Sources/BookmarksViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksViewModel.swift
@@ -24,13 +24,17 @@ final class BookmarksViewModel: ObservableObject {
     init(
         analytics: AnalyticsLibrary,
         service: PageBookmarkService,
+        highlightCollectionsUpdates: (() -> AsyncThrowingStream<[HighlightCollectionSnapshot], Error>)?,
         authenticationClient: (any AuthenticationClient)?,
-        navigateTo: @escaping (Page) -> Void
+        navigateTo: @escaping (Page) -> Void,
+        makeHighlightsController: (() -> UIViewController)?
     ) {
         self.analytics = analytics
         self.service = service
+        self.highlightCollectionsUpdates = highlightCollectionsUpdates
         self.authenticationClient = authenticationClient
         self.navigateTo = navigateTo
+        self.makeHighlightsController = makeHighlightsController
         isSyncBannerDismissed = preferences.isSyncBannerDismissed
     }
 
@@ -41,11 +45,16 @@ final class BookmarksViewModel: ObservableObject {
     @Published var bookmarks: [PageBookmark] = []
     @Published var isAuthenticated: Bool = false
     @Published var isSyncBannerDismissed: Bool
+    @Published var highlightCount: Int = 0
 
     weak var presenter: UIViewController?
 
     var shouldShowSyncBanner: Bool {
         !isAuthenticated && !isSyncBannerDismissed
+    }
+
+    var shouldShowHighlights: Bool {
+        highlightCollectionsUpdates != nil
     }
 
     func start() async {
@@ -69,10 +78,32 @@ final class BookmarksViewModel: ObservableObject {
         }
     }
 
+    func observeHighlights() async {
+        guard let highlightCollectionsUpdates else {
+            return
+        }
+
+        do {
+            for try await collections in highlightCollectionsUpdates() {
+                highlightCount = HighlightCollection.count(in: collections)
+            }
+        } catch {
+            self.error = error
+        }
+    }
+
     func navigateTo(_ item: PageBookmark) {
         logger.info("Bookmarks: select bookmark at \(item.page)")
         analytics.openingQuran(from: .bookmarks)
         navigateTo(item.page)
+    }
+
+    func showHighlights() {
+        logger.info("Bookmarks: show highlights")
+        guard let makeHighlightsController else {
+            return
+        }
+        presenter?.navigationController?.pushViewController(makeHighlightsController(), animated: true)
     }
 
     func deleteItem(_ pageBookmark: PageBookmark) async {
@@ -119,7 +150,9 @@ final class BookmarksViewModel: ObservableObject {
     private let navigateTo: (Page) -> Void
     private let analytics: AnalyticsLibrary
     private let service: PageBookmarkService
+    private let highlightCollectionsUpdates: (() -> AsyncThrowingStream<[HighlightCollectionSnapshot], Error>)?
     private let authenticationClient: (any AuthenticationClient)?
+    private let makeHighlightsController: (() -> UIViewController)?
     private let readingPreferences = ReadingPreferences.shared
     private let preferences = BookmarksPreferences.shared
 

--- a/Features/BookmarksFeature/Sources/HighlightsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/HighlightsBuilder.swift
@@ -1,0 +1,55 @@
+import AppDependencies
+import FeaturesSupport
+import UIKit
+
+@MainActor
+struct HighlightsBuilder {
+    init(container: AppDependencies, listener: QuranNavigator) {
+        self.container = container
+        self.listener = listener
+    }
+
+    func build() -> UIViewController {
+        #if QURAN_SYNC
+            guard let syncService = container.syncService,
+                  let bookmarkCollectionService = container.bookmarkCollectionService
+            else {
+                preconditionFailure("Highlights require sync services")
+            }
+
+            let highlightCollectionsUpdates = {
+                HighlightCollection.updates(from: syncService)
+            }
+
+            let viewModel = HighlightsViewModel(
+                highlightCollectionsUpdates: highlightCollectionsUpdates,
+                makeColorController: { [container, weak listener] collection in
+                    let detailViewModel = HighlightsColorViewModel(
+                        collection: collection,
+                        highlightCollectionsUpdates: highlightCollectionsUpdates,
+                        noteService: container.noteService(),
+                        removeHighlight: { ayah in
+                            try await HighlightCollection.removeHighlights(
+                                verses: [ayah],
+                                syncService: syncService,
+                                bookmarkCollectionService: bookmarkCollectionService
+                            )
+                        },
+                        navigateTo: { [weak listener] verse in
+                            listener?.navigateTo(page: verse.page, lastPage: nil, highlightingSearchAyah: nil)
+                        }
+                    )
+                    return HighlightColorViewController(collection: collection, viewModel: detailViewModel)
+                }
+            )
+            let viewController = HighlightsViewController(viewModel: viewModel)
+            viewModel.presenter = viewController
+            return viewController
+        #else
+            preconditionFailure("Highlights require QURAN_SYNC")
+        #endif
+    }
+
+    private let container: AppDependencies
+    private weak var listener: QuranNavigator?
+}

--- a/Features/BookmarksFeature/Sources/HighlightsView.swift
+++ b/Features/BookmarksFeature/Sources/HighlightsView.swift
@@ -1,0 +1,66 @@
+import FeaturesSupport
+import Localization
+import NoorUI
+import QuranAnnotations
+import QuranKit
+import SwiftUI
+import UIx
+
+struct HighlightsView: View {
+    @StateObject var viewModel: HighlightsViewModel
+
+    var body: some View {
+        NoorList {
+            NoorSection(viewModel.items) { item in
+                NoorListItem(
+                    image: .init(.bookmark, color: item.collection.color.color),
+                    title: .text(l(item.collection.localizationKey)),
+                    accessory: .textWithDisclosureIndicator(NumberFormatter.shared.format(item.count))
+                ) {
+                    viewModel.showDetails(item)
+                }
+            }
+        }
+        .task { await viewModel.start() }
+        .errorAlert(error: $viewModel.error)
+    }
+}
+
+struct HighlightColorView: View {
+    @StateObject var viewModel: HighlightsColorViewModel
+
+    var body: some View {
+        Group {
+            if viewModel.items.isEmpty {
+                DataUnavailableView(
+                    title: l("highlights.no-data.title"),
+                    text: l("highlights.no-data.text"),
+                    image: .bookmark
+                )
+            } else {
+                NoorList {
+                    NoorSection(viewModel.items) { item in
+                        highlightRow(item)
+                    }
+                    .onDelete(action: viewModel.deleteItem)
+                }
+            }
+        }
+        .task { await viewModel.start() }
+        .errorAlert(error: $viewModel.error)
+    }
+
+    private func highlightRow(_ item: HighlightsColorViewModel.Item) -> some View {
+        let verse = item.ayah
+        let lineColor = viewModel.collection.color.color.opacity(QuranHighlights.opacity)
+        return AnnotationListItem(
+            subheading: "\(verse.localizedName) \(sura: verse.sura.arabicSuraName)",
+            verseText: "\(verse: item.verseText, color: lineColor, lineLimit: 2)",
+            noteText: nil,
+            modifiedDateText: item.modifiedDate.timeAgo(),
+            pageNumberText: NumberFormatter.shared.format(verse.page.pageNumber)
+        ) {
+            viewModel.navigateTo(item)
+        }
+    }
+}

--- a/Features/BookmarksFeature/Sources/HighlightsViewController.swift
+++ b/Features/BookmarksFeature/Sources/HighlightsViewController.swift
@@ -1,0 +1,32 @@
+import FeaturesSupport
+import Localization
+import SwiftUI
+import UIx
+
+final class HighlightsViewController: UIHostingController<HighlightsView> {
+    init(viewModel: HighlightsViewModel) {
+        super.init(rootView: HighlightsView(viewModel: viewModel))
+        title = l("highlights.title")
+        addCloudSyncInfo()
+    }
+
+    @available(*, unavailable)
+    @MainActor
+    dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+final class HighlightColorViewController: UIHostingController<HighlightColorView> {
+    init(collection: HighlightCollection, viewModel: HighlightsColorViewModel) {
+        super.init(rootView: HighlightColorView(viewModel: viewModel))
+        title = l(collection.localizationKey)
+        addCloudSyncInfo()
+    }
+
+    @available(*, unavailable)
+    @MainActor
+    dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Features/BookmarksFeature/Sources/HighlightsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/HighlightsViewModel.swift
@@ -1,0 +1,160 @@
+import AnnotationsService
+import Crashing
+import FeaturesSupport
+import Foundation
+import QuranKit
+import ReadingService
+import UIKit
+import VLogging
+
+@MainActor
+final class HighlightsViewModel: ObservableObject {
+    struct Item: Equatable, Identifiable {
+        let collection: HighlightCollection
+        let count: Int
+
+        var id: HighlightCollection.ID { collection.id }
+    }
+
+    init(
+        highlightCollectionsUpdates: @escaping () -> AsyncThrowingStream<[HighlightCollectionSnapshot], Error>,
+        makeColorController: @escaping (HighlightCollection) -> UIViewController
+    ) {
+        self.highlightCollectionsUpdates = highlightCollectionsUpdates
+        self.makeColorController = makeColorController
+        items = HighlightCollection.allCases.map { Item(collection: $0, count: 0) }
+    }
+
+    @Published var items: [Item]
+    @Published var error: Error?
+
+    weak var presenter: UIViewController?
+
+    func start() async {
+        guard !didStart else {
+            return
+        }
+
+        didStart = true
+        defer { didStart = false }
+
+        do {
+            for try await collections in highlightCollectionsUpdates() {
+                items = HighlightCollection.allCases.map { collection in
+                    Item(collection: collection, count: collection.count(in: collections))
+                }
+            }
+        } catch is CancellationError {
+        } catch {
+            self.error = error
+        }
+    }
+
+    func showDetails(_ item: Item) {
+        logger.info("Highlights: show \(item.collection) highlights")
+        presenter?.navigationController?.pushViewController(makeColorController(item.collection), animated: true)
+    }
+
+    private let highlightCollectionsUpdates: () -> AsyncThrowingStream<[HighlightCollectionSnapshot], Error>
+    private let makeColorController: (HighlightCollection) -> UIViewController
+    private var didStart = false
+}
+
+@MainActor
+final class HighlightsColorViewModel: ObservableObject {
+    struct Item: Equatable, Identifiable {
+        let ayah: AyahNumber
+        let modifiedDate: Date
+        let verseText: String
+
+        var id: AyahNumber { ayah }
+    }
+
+    // MARK: Lifecycle
+
+    init(
+        collection: HighlightCollection,
+        highlightCollectionsUpdates: @escaping () -> AsyncThrowingStream<[HighlightCollectionSnapshot], Error>,
+        noteService: NoteService,
+        removeHighlight: @escaping (AyahNumber) async throws -> Void,
+        navigateTo: @escaping (AyahNumber) -> Void
+    ) {
+        self.collection = collection
+        self.highlightCollectionsUpdates = highlightCollectionsUpdates
+        self.noteService = noteService
+        self.removeHighlight = removeHighlight
+        navigateToVerse = navigateTo
+    }
+
+    // MARK: Internal
+
+    @Published var items: [Item] = []
+    @Published var error: Error?
+
+    let collection: HighlightCollection
+
+    func start() async {
+        guard !didStart else {
+            return
+        }
+
+        didStart = true
+        defer { didStart = false }
+
+        do {
+            for try await collections in highlightCollectionsUpdates() {
+                let currentQuran = readingPreferences.reading.quran
+                let bookmarks = collection.bookmarks(in: collections)
+                items = await makeItems(from: bookmarks, quran: currentQuran)
+            }
+        } catch is CancellationError {
+        } catch {
+            self.error = error
+        }
+    }
+
+    func navigateTo(_ item: Item) {
+        logger.info("Highlights: navigate to \(item.ayah)")
+        navigateToVerse(item.ayah)
+    }
+
+    func deleteItem(_ item: Item) async {
+        logger.info("Highlights: delete \(item.ayah) from \(collection)")
+        do {
+            try await removeHighlight(item.ayah)
+        } catch {
+            self.error = error
+        }
+    }
+
+    // MARK: Private
+
+    private let highlightCollectionsUpdates: () -> AsyncThrowingStream<[HighlightCollectionSnapshot], Error>
+    private let noteService: NoteService
+    private let removeHighlight: (AyahNumber) async throws -> Void
+    private let navigateToVerse: (AyahNumber) -> Void
+    private let readingPreferences = ReadingPreferences.shared
+    private var didStart = false
+
+    private func makeItems(
+        from bookmarks: [HighlightBookmarkSnapshot],
+        quran: Quran
+    ) async -> [Item] {
+        await withTaskGroup(of: Item.self) { group in
+            for bookmark in bookmarks {
+                group.addTask {
+                    let ayah = AyahNumber(quran: quran, sura: bookmark.sura, ayah: bookmark.ayah)!
+                    do {
+                        let verseText = try await self.noteService.textForVerses([ayah])
+                        return Item(ayah: ayah, modifiedDate: bookmark.modifiedDate, verseText: verseText)
+                    } catch {
+                        crasher.recordError(error, reason: "HighlightColorViewModel.textForVerses")
+                        return Item(ayah: ayah, modifiedDate: bookmark.modifiedDate, verseText: ayah.localizedName)
+                    }
+                }
+            }
+            return await group.collect()
+                .sorted { $0.modifiedDate > $1.modifiedDate }
+        }
+    }
+}

--- a/Features/BookmarksFeature/Tests/BookmarksViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarksViewModelTests.swift
@@ -2,6 +2,7 @@ import Analytics
 import AnnotationsService
 import AuthenticationClient
 import Combine
+import FeaturesSupport
 import Foundation
 import MobileSync
 import PageBookmarkPersistence
@@ -47,6 +48,23 @@ final class BookmarksViewModelTests: XCTestCase {
         task.cancel()
     }
 
+    func test_observeHighlights_updatesHighlightCount() async {
+        let highlightCollections = HighlightCollectionsUpdatesSpy()
+        highlightCollections.send([
+            HighlightCollectionSnapshot(
+                name: "red",
+                bookmarks: [
+                    HighlightBookmarkSnapshot(sura: 1, ayah: 1, modifiedDate: Date()),
+                ]
+            ),
+        ])
+        let sut = makeSUT(authenticationClient: nil, highlightCollections: highlightCollections)
+
+        let task = Task { await sut.observeHighlights() }
+        await waitUntil { sut.highlightCount == 1 }
+        task.cancel()
+    }
+
     func test_loginToQuranCom_setsAuthenticated_whenLoginSucceeds() async {
         let client = AuthenticationClientSpy()
         let sut = makeSUT(authenticationClient: client)
@@ -75,13 +93,18 @@ final class BookmarksViewModelTests: XCTestCase {
 
     // MARK: Private
 
-    private func makeSUT(authenticationClient: (any AuthenticationClient)?) -> BookmarksViewModel {
+    private func makeSUT(
+        authenticationClient: (any AuthenticationClient)?,
+        highlightCollections: HighlightCollectionsUpdatesSpy? = HighlightCollectionsUpdatesSpy()
+    ) -> BookmarksViewModel {
         let service = PageBookmarkService(persistence: PageBookmarkPersistenceSpy())
         return BookmarksViewModel(
             analytics: AnalyticsSpy(),
             service: service,
+            highlightCollectionsUpdates: highlightCollections?.updates,
             authenticationClient: authenticationClient,
-            navigateTo: { _ in }
+            navigateTo: { _ in },
+            makeHighlightsController: { UIViewController() }
         )
     }
 
@@ -113,6 +136,23 @@ private struct PageBookmarkPersistenceSpy: PageBookmarkPersistence {
     func insertPageBookmark(_: Int) async throws {}
     func removePageBookmark(_: Int) async throws {}
     func removeAllPageBookmarks() async throws {}
+}
+
+private final class HighlightCollectionsUpdatesSpy {
+    private var currentCollections: [HighlightCollectionSnapshot] = []
+    private var continuation: AsyncThrowingStream<[HighlightCollectionSnapshot], Error>.Continuation?
+
+    func updates() -> AsyncThrowingStream<[HighlightCollectionSnapshot], Error> {
+        AsyncThrowingStream { continuation in
+            self.continuation = continuation
+            continuation.yield(self.currentCollections)
+        }
+    }
+
+    func send(_ collections: [HighlightCollectionSnapshot]) {
+        currentCollections = collections
+        continuation?.yield(collections)
+    }
 }
 
 private final class AuthenticationClientSpy: AuthenticationClient {

--- a/Features/BookmarksFeature/Tests/HighlightsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/HighlightsViewModelTests.swift
@@ -1,0 +1,177 @@
+import Analytics
+import Combine
+import FeaturesSupport
+import Foundation
+import QuranAnnotations
+import QuranKit
+import QuranTextKit
+import UIKit
+import XCTest
+@testable import AnnotationsService
+@testable import BookmarksFeature
+@testable import NotePersistence
+
+@MainActor
+final class HighlightsViewModelTests: XCTestCase {
+    // MARK: Internal
+
+    func test_start_refreshesWhenStartedAgain_afterPreviousTaskIsCancelled() async {
+        let updates = HighlightCollectionsUpdatesSpy()
+        let sut = HighlightsViewModel(
+            highlightCollectionsUpdates: updates.updates,
+            makeColorController: { _ in UIViewController() }
+        )
+
+        let startTask = Task { await sut.start() }
+        await Task.yield()
+        startTask.cancel()
+        _ = await startTask.value
+
+        updates.send([
+            HighlightCollectionSnapshot(
+                name: "blue",
+                bookmarks: [HighlightBookmarkSnapshot(sura: 1, ayah: 1, modifiedDate: Date())]
+            ),
+        ])
+
+        let restartedTask = Task { await sut.start() }
+        await waitUntil { sut.items.first(where: { $0.collection == .blue })?.count == 1 }
+        restartedTask.cancel()
+    }
+
+    func test_colorStart_refreshesWhenStartedAgain_afterPreviousTaskIsCancelled() async {
+        let updates = HighlightCollectionsUpdatesSpy()
+        let sut = HighlightsColorViewModel(
+            collection: .blue,
+            highlightCollectionsUpdates: updates.updates,
+            noteService: makeNoteService(),
+            removeHighlight: { _ in },
+            navigateTo: { _ in }
+        )
+
+        let startTask = Task { await sut.start() }
+        await Task.yield()
+        startTask.cancel()
+        _ = await startTask.value
+
+        updates.send([
+            HighlightCollectionSnapshot(
+                name: "blue",
+                bookmarks: [HighlightBookmarkSnapshot(sura: 1, ayah: 1, modifiedDate: Date())]
+            ),
+        ])
+
+        let restartedTask = Task { await sut.start() }
+        await waitUntil(timeoutIterations: 1000) { sut.items.count == 1 }
+        restartedTask.cancel()
+    }
+
+    func test_deleteItem_removesHighlightForSelectedAyah() async {
+        let updates = HighlightCollectionsUpdatesSpy()
+        let remover = HighlightRemoverSpy()
+        let sut = HighlightsColorViewModel(
+            collection: .blue,
+            highlightCollectionsUpdates: updates.updates,
+            noteService: makeNoteService(),
+            removeHighlight: remover.removeHighlight,
+            navigateTo: { _ in }
+        )
+        let item = HighlightsColorViewModel.Item(
+            ayah: AyahNumber(quran: .hafs_1421, sura: 1, ayah: 1)!,
+            modifiedDate: Date(),
+            verseText: "text"
+        )
+
+        await sut.deleteItem(item)
+
+        XCTAssertEqual(remover.removedAyahs, [item.ayah])
+        XCTAssertNil(sut.error)
+    }
+
+    // MARK: Private
+
+    private func makeNoteService() -> NoteService {
+        let quranFileURL = repositoryRoot()
+            .appendingPathComponent("Domain/QuranResources/Databases/quran.ar.uthmani.v2.db")
+        return NoteService(
+            persistence: NotePersistenceSpy(),
+            textService: QuranTextDataService(
+                databasesURL: quranFileURL.deletingLastPathComponent(),
+                quranFileURL: quranFileURL
+            ),
+            analytics: AnalyticsSpy()
+        )
+    }
+
+    private func repositoryRoot() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private func waitUntil(
+        timeoutIterations: Int = 100,
+        condition: @escaping @MainActor () -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        for _ in 0 ..< timeoutIterations {
+            if condition() {
+                return
+            }
+            await Task.yield()
+        }
+        XCTFail("Condition was not met in time", file: file, line: line)
+    }
+}
+
+private final class HighlightCollectionsUpdatesSpy {
+    private var currentCollections: [HighlightCollectionSnapshot] = []
+    private var continuation: AsyncThrowingStream<[HighlightCollectionSnapshot], Error>.Continuation?
+
+    func updates() -> AsyncThrowingStream<[HighlightCollectionSnapshot], Error> {
+        AsyncThrowingStream { continuation in
+            self.continuation = continuation
+            continuation.yield(self.currentCollections)
+        }
+    }
+
+    func send(_ collections: [HighlightCollectionSnapshot]) {
+        currentCollections = collections
+        continuation?.yield(collections)
+    }
+}
+
+private final class HighlightRemoverSpy {
+    private(set) var removedAyahs: [AyahNumber] = []
+
+    func removeHighlight(_ ayah: AyahNumber) async throws {
+        removedAyahs.append(ayah)
+    }
+}
+
+private struct AnalyticsSpy: AnalyticsLibrary {
+    func logEvent(_: String, value _: String) {}
+}
+
+private final class NotePersistenceSpy: NotePersistence {
+    func notes() -> AnyPublisher<[NotePersistenceModel], Never> {
+        Just([]).eraseToAnyPublisher()
+    }
+
+    func setNote(_: String?, verses _: [VersePersistenceModel], color _: Int) async throws -> NotePersistenceModel {
+        NotePersistenceModel(nil, color: 0, modifiedDate: Date())
+    }
+
+    func removeNotes(with _: [VersePersistenceModel]) async throws -> [NotePersistenceModel] {
+        []
+    }
+}
+
+private extension NotePersistenceModel {
+    init(_ text: String?, color: Int, modifiedDate: Date, verses: Set<VersePersistenceModel> = []) {
+        self.init(verses: verses, modifiedDate: modifiedDate, note: text, color: color)
+    }
+}

--- a/Features/BookmarksFeature/Tests/HighlightsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/HighlightsViewModelTests.swift
@@ -77,7 +77,7 @@ final class HighlightsViewModelTests: XCTestCase {
             navigateTo: { _ in }
         )
         let item = HighlightsColorViewModel.Item(
-            ayah: AyahNumber(quran: .hafs_1421, sura: 1, ayah: 1)!,
+            ayah: AyahNumber(quran: Reading.hafs_1421.quran, sura: 1, ayah: 1)!,
             modifiedDate: Date(),
             verseText: "text"
         )

--- a/Features/FeaturesSupport/HighlightCollection.swift
+++ b/Features/FeaturesSupport/HighlightCollection.swift
@@ -1,0 +1,308 @@
+import Foundation
+import QuranAnnotations
+import QuranKit
+
+#if QURAN_SYNC
+    import MobileSync
+    import MobileSyncSupport
+#endif
+
+public struct HighlightBookmarkSnapshot: Equatable, Hashable, Sendable {
+    public init(sura: Int, ayah: Int, modifiedDate: Date) {
+        self.sura = sura
+        self.ayah = ayah
+        self.modifiedDate = modifiedDate
+    }
+
+    public let sura: Int
+    public let ayah: Int
+    public let modifiedDate: Date
+}
+
+public struct HighlightCollectionSnapshot: Equatable, Sendable {
+    public init(name: String, bookmarks: [HighlightBookmarkSnapshot]) {
+        self.name = name
+        self.bookmarks = bookmarks
+    }
+
+    public let name: String
+    public let bookmarks: [HighlightBookmarkSnapshot]
+}
+
+public enum HighlightCollection: Int, CaseIterable, Identifiable, Sendable {
+    case red
+    case green
+    case blue
+    case yellow
+    case purple
+
+    // MARK: Lifecycle
+
+    public init(color: HighlightColor) {
+        switch color {
+        case .red: self = .red
+        case .green: self = .green
+        case .blue: self = .blue
+        case .yellow: self = .yellow
+        case .purple: self = .purple
+        }
+    }
+
+    // MARK: Public
+
+    public var id: Int { rawValue }
+
+    public var color: HighlightColor {
+        switch self {
+        case .red: .red
+        case .green: .green
+        case .blue: .blue
+        case .yellow: .yellow
+        case .purple: .purple
+        }
+    }
+
+    public var localizationKey: String {
+        switch self {
+        case .red: "highlights.color.red"
+        case .green: "highlights.color.green"
+        case .blue: "highlights.color.blue"
+        case .yellow: "highlights.color.yellow"
+        case .purple: "highlights.color.purple"
+        }
+    }
+
+    public var collectionName: String {
+        switch self {
+        case .red: "red"
+        case .green: "green"
+        case .blue: "blue"
+        case .yellow: "yellow"
+        case .purple: "purple"
+        }
+    }
+
+    public static func count(in collections: [HighlightCollectionSnapshot]) -> Int {
+        allCases.reduce(0) { $0 + $1.count(in: collections) }
+    }
+
+    public static func collection(for name: String) -> HighlightCollection? {
+        let normalizedName = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return allCases.first { $0.collectionName == normalizedName }
+    }
+
+    public static func highlightColorsByVerse(
+        in collections: [HighlightCollectionSnapshot],
+        quran: Quran
+    ) -> [AyahNumber: HighlightColor] {
+        var colorsByVerse: [AyahNumber: HighlightColor] = [:]
+        for collection in collections {
+            guard let color = Self.collection(for: collection.name)?.color else {
+                continue
+            }
+            for bookmark in collection.bookmarks {
+                guard let ayah = AyahNumber(quran: quran, sura: bookmark.sura, ayah: bookmark.ayah) else {
+                    continue
+                }
+                colorsByVerse[ayah] = color
+            }
+        }
+        return colorsByVerse
+    }
+
+    public func count(in collections: [HighlightCollectionSnapshot]) -> Int {
+        bookmarks(in: collections).count
+    }
+
+    public func bookmarks(in collections: [HighlightCollectionSnapshot]) -> [HighlightBookmarkSnapshot] {
+        collections
+            .filter { Self.collection(for: $0.name) == self }
+            .flatMap(\.bookmarks)
+            .sorted { $0.modifiedDate > $1.modifiedDate }
+    }
+}
+
+#if QURAN_SYNC
+    extension HighlightCollection {
+        public static func updates(from syncService: SyncService) -> AsyncThrowingStream<[HighlightCollectionSnapshot], Error> {
+            AsyncThrowingStream { continuation in
+                let task = Task { @MainActor in
+                    do {
+                        for try await collections in syncService.collectionsWithBookmarksSequence() {
+                            continuation.yield(collections.map(snapshot(from:)))
+                        }
+                        continuation.finish()
+                    } catch is CancellationError {
+                        continuation.finish()
+                    } catch {
+                        continuation.finish(throwing: error)
+                    }
+                }
+
+                continuation.onTermination = { _ in
+                    task.cancel()
+                }
+            }
+        }
+
+        public static func setHighlight(
+            verses: [AyahNumber],
+            color: HighlightColor,
+            syncService: SyncService,
+            bookmarkCollectionService: BookmarkCollectionService
+        ) async throws {
+            guard !verses.isEmpty else {
+                return
+            }
+
+            let target = try await ensureCollection(
+                for: HighlightCollection(color: color),
+                syncService: syncService,
+                bookmarkCollectionService: bookmarkCollectionService
+            )
+            let collections = try await collectionsSnapshot(from: syncService)
+            let highlightCollections = collections.filter { collection(for: $0.collection.name) != nil }
+            let otherCollections = highlightCollections.filter { $0.collection.localId != target.collection.localId }
+
+            for verse in verses {
+                for collection in otherCollections {
+                    try await removeBookmarks(
+                        matching: verse,
+                        from: collection,
+                        bookmarkCollectionService: bookmarkCollectionService
+                    )
+                }
+
+                guard !target.contains(verse) else {
+                    continue
+                }
+                try await bookmarkCollectionService.addAyahBookmark(verse, toCollectionLocalId: target.collection.localId)
+            }
+        }
+
+        public static func removeHighlights(
+            verses: [AyahNumber],
+            syncService: SyncService,
+            bookmarkCollectionService: BookmarkCollectionService
+        ) async throws {
+            guard !verses.isEmpty else {
+                return
+            }
+
+            let collections = try await collectionsSnapshot(from: syncService)
+                .filter { collection(for: $0.collection.name) != nil }
+            for verse in verses {
+                for collection in collections {
+                    try await removeBookmarks(
+                        matching: verse,
+                        from: collection,
+                        bookmarkCollectionService: bookmarkCollectionService
+                    )
+                }
+            }
+        }
+
+        // MARK: Private
+
+        private enum HighlightCollectionError: Error {
+            case collectionUnavailable(String)
+        }
+
+        private static func ensureCollection(
+            for highlightCollection: HighlightCollection,
+            syncService: SyncService,
+            bookmarkCollectionService: BookmarkCollectionService
+        ) async throws -> CollectionWithBookmarks {
+            if let existing = try await findCollection(for: highlightCollection, syncService: syncService) {
+                return existing
+            }
+
+            try await bookmarkCollectionService.createCollection(named: highlightCollection.collectionName)
+
+            for _ in 0 ..< 5 {
+                if let created = try await findCollection(for: highlightCollection, syncService: syncService) {
+                    return created
+                }
+                await Task.yield()
+            }
+
+            if let created = try await findCollection(for: highlightCollection, syncService: syncService) {
+                return created
+            }
+            throw HighlightCollectionError.collectionUnavailable(highlightCollection.collectionName)
+        }
+
+        private static func findCollection(
+            for highlightCollection: HighlightCollection,
+            syncService: SyncService
+        ) async throws -> CollectionWithBookmarks? {
+            try await collectionsSnapshot(from: syncService)
+                .first { $0.collection.name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == highlightCollection.collectionName }
+        }
+
+        private static func collectionsSnapshot(from syncService: SyncService) async throws -> [CollectionWithBookmarks] {
+            for try await collections in syncService.collectionsWithBookmarksSequence() {
+                return collections
+            }
+            return []
+        }
+
+        private static func removeBookmarks(
+            matching verse: AyahNumber,
+            from collection: CollectionWithBookmarks,
+            bookmarkCollectionService: BookmarkCollectionService
+        ) async throws {
+            for case let bookmark as CollectionBookmark.AyahBookmark in collection.bookmarks where bookmark.matches(verse) {
+                try await bookmarkCollectionService.removeBookmark(
+                    bookmark.bookmark,
+                    fromCollectionLocalId: collection.collection.localId
+                )
+            }
+        }
+
+        private static func snapshot(from collection: CollectionWithBookmarks) -> HighlightCollectionSnapshot {
+            HighlightCollectionSnapshot(
+                name: collection.collection.name,
+                bookmarks: collection.bookmarks.compactMap(snapshot(from:))
+            )
+        }
+
+        private static func snapshot(from bookmark: CollectionBookmark) -> HighlightBookmarkSnapshot? {
+            guard let bookmark = bookmark as? CollectionBookmark.AyahBookmark else {
+                return nil
+            }
+
+            return HighlightBookmarkSnapshot(
+                sura: Int(bookmark.sura),
+                ayah: Int(bookmark.ayah),
+                modifiedDate: bookmark.lastUpdated
+            )
+        }
+    }
+
+    private extension CollectionWithBookmarks {
+        func contains(_ verse: AyahNumber) -> Bool {
+            bookmarks.contains { bookmark in
+                guard let bookmark = bookmark as? CollectionBookmark.AyahBookmark else {
+                    return false
+                }
+                return bookmark.matches(verse)
+            }
+        }
+    }
+
+    private extension CollectionBookmark.AyahBookmark {
+        var bookmark: Bookmark.AyahBookmark {
+            Bookmark.AyahBookmark(
+                sura: sura,
+                ayah: ayah,
+                lastUpdated: lastUpdated,
+                localId: bookmarkLocalId
+            )
+        }
+
+        func matches(_ verse: AyahNumber) -> Bool {
+            Int(sura) == verse.sura.suraNumber && Int(ayah) == verse.ayah
+        }
+    }
+#endif

--- a/Features/QuranContentFeature/ContentBuilder.swift
+++ b/Features/QuranContentFeature/ContentBuilder.swift
@@ -28,15 +28,28 @@ public struct ContentBuilder {
         let noteService = container.noteService()
         let lastPageService = LastPageService(persistence: container.lastPagePersistence)
         let lastPageUpdater = LastPageUpdater(service: lastPageService)
-        let interactorDeps = ContentViewModel.Deps(
-            analytics: container.analytics,
-            noteService: noteService,
-            lastPageUpdater: lastPageUpdater,
-            quran: quran,
-            highlightsService: highlightsService,
-            imageDataSourceBuilder: ContentImageBuilder(container: container, highlightsService: highlightsService),
-            translationDataSourceBuilder: ContentTranslationBuilder(container: container, highlightsService: highlightsService)
-        )
+        #if QURAN_SYNC
+            let interactorDeps = ContentViewModel.Deps(
+                analytics: container.analytics,
+                noteService: noteService,
+                lastPageUpdater: lastPageUpdater,
+                quran: quran,
+                syncService: container.syncService,
+                highlightsService: highlightsService,
+                imageDataSourceBuilder: ContentImageBuilder(container: container, highlightsService: highlightsService),
+                translationDataSourceBuilder: ContentTranslationBuilder(container: container, highlightsService: highlightsService)
+            )
+        #else
+            let interactorDeps = ContentViewModel.Deps(
+                analytics: container.analytics,
+                noteService: noteService,
+                lastPageUpdater: lastPageUpdater,
+                quran: quran,
+                highlightsService: highlightsService,
+                imageDataSourceBuilder: ContentImageBuilder(container: container, highlightsService: highlightsService),
+                translationDataSourceBuilder: ContentTranslationBuilder(container: container, highlightsService: highlightsService)
+            )
+        #endif
         let viewModel = ContentViewModel(deps: interactorDeps, input: input)
 
         let viewController = ContentViewController(viewModel: viewModel)

--- a/Features/QuranContentFeature/ContentViewModel.swift
+++ b/Features/QuranContentFeature/ContentViewModel.swift
@@ -10,7 +10,11 @@ import Analytics
 import AnnotationsService
 import Combine
 import Crashing
+import FeaturesSupport
 import QuranAnnotations
+#if QURAN_SYNC
+    import MobileSync
+#endif
 import QuranImageFeature
 import QuranKit
 import QuranPagesFeature
@@ -24,7 +28,14 @@ import VLogging
 @MainActor
 public protocol ContentListener: AnyObject {
     func userWillBeginDragScroll()
-    func presentAyahMenu(in sourceView: UIView, at point: CGPoint, verses: [AyahNumber])
+    func presentAyahMenu(
+        in sourceView: UIView,
+        at point: CGPoint,
+        verses: [AyahNumber],
+        notes: [QuranAnnotations.Note],
+        syncHighlightColor: HighlightColor?,
+        hasSyncHighlight: Bool
+    )
 }
 
 @MainActor
@@ -37,6 +48,9 @@ public final class ContentViewModel: ObservableObject {
         let noteService: NoteService
         let lastPageUpdater: LastPageUpdater
         let quran: Quran
+        #if QURAN_SYNC
+            let syncService: SyncService?
+        #endif
 
         let highlightsService: QuranHighlightsService
 
@@ -150,16 +164,37 @@ public final class ContentViewModel: ObservableObject {
         guard let longPressData, let selectedVerses else {
             return
         }
+        let syncHighlight = selectedSyncHighlight(in: selectedVerses)
         listener?.presentAyahMenu(
             in: longPressData.sourceView,
             at: longPressData.startPosition,
-            verses: selectedVerses
+            verses: selectedVerses,
+            notes: selectedNotes(in: selectedVerses),
+            syncHighlightColor: syncHighlight.color,
+            hasSyncHighlight: syncHighlight.hasHighlight
         )
     }
 
     func onViewLongPressCancelled() {
         longPressData = nil
     }
+
+    #if QURAN_SYNC
+        func observeSyncHighlightsIfNeeded() async {
+            guard let syncService = deps.syncService else {
+                return
+            }
+
+            do {
+                for try await collections in HighlightCollection.updates(from: syncService) {
+                    highlights.highlightColorsByVerse = HighlightCollection.highlightColorsByVerse(in: collections, quran: deps.quran)
+                }
+            } catch is CancellationError {
+            } catch {
+                crasher.recordError(error, reason: "Failed to observe synced highlights")
+            }
+        }
+    #endif
 
     // MARK: Private
 
@@ -191,6 +226,29 @@ public final class ContentViewModel: ObservableObject {
             dict[element.0] = element.1
         }
         return dict
+    }
+
+    private func selectedNotes(in verses: [AyahNumber]) -> [QuranAnnotations.Note] {
+        var notes: [QuranAnnotations.Note] = []
+        for verse in verses {
+            guard let note = highlights.noteVerses[verse], !notes.contains(note) else {
+                continue
+            }
+            notes.append(note)
+        }
+        return notes
+    }
+
+    private func selectedSyncHighlight(in verses: [AyahNumber]) -> (hasHighlight: Bool, color: HighlightColor?) {
+        let colors = verses.compactMap { highlights.highlightColorsByVerse[$0] }
+        let uniqueColors = Array(Set(colors))
+        if uniqueColors.isEmpty {
+            return (false, nil)
+        }
+        if uniqueColors.count == 1 {
+            return (true, uniqueColors[0])
+        }
+        return (true, nil)
     }
 
     private func configureInitialPage() {
@@ -225,7 +283,19 @@ public final class ContentViewModel: ObservableObject {
 
     private func loadNotes() {
         deps.noteService.notes(quran: deps.quran)
-            .map { notes in notes.flatMap { note in note.verses.map { ($0, note) } } }
+            .map { [deps] notes in
+                let visibleNotes: [QuranAnnotations.Note]
+                #if QURAN_SYNC
+                    if deps.syncService != nil {
+                        visibleNotes = notes.filter { !(($0.note ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) }
+                    } else {
+                        visibleNotes = notes
+                    }
+                #else
+                    visibleNotes = notes
+                #endif
+                return visibleNotes.flatMap { note in note.verses.map { ($0, note) } }
+            }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.highlights.noteVerses = Self.dictionaryFrom($0) }
             .store(in: &cancellables)

--- a/Features/QuranContentFeature/PagesView.swift
+++ b/Features/QuranContentFeature/PagesView.swift
@@ -5,6 +5,7 @@
 //  Created by Mohamed Afifi on 2024-10-06.
 //
 
+import AnnotationsService
 import QuranPagesFeature
 import QuranTextKit
 import SwiftUI
@@ -32,6 +33,9 @@ struct PagesView: View {
             .id(viewModel.quranMode)
         }
         .collectGeometryActions($viewModel.geometryActions)
+        #if QURAN_SYNC
+            .task { await viewModel.observeSyncHighlightsIfNeeded() }
+        #endif
     }
 
     private func pagingStrategy(with geometry: GeometryProxy) -> PagingStrategy {

--- a/Features/QuranViewFeature/QuranBuilder.swift
+++ b/Features/QuranViewFeature/QuranBuilder.swift
@@ -35,21 +35,42 @@ public struct QuranBuilder {
 
         let quran = ReadingPreferences.shared.reading.quran
         let pageBookmarkService = PageBookmarkService(persistence: container.pageBookmarkPersistence)
-        let interactorDeps = QuranInteractor.Deps(
-            quran: quran,
-            analytics: container.analytics,
-            pageBookmarkService: pageBookmarkService,
-            noteService: container.noteService(),
-            ayahMenuBuilder: AyahMenuBuilder(container: container),
-            moreMenuBuilder: MoreMenuBuilder(),
-            audioBannerBuilder: AudioBannerBuilder(container: container),
-            wordPointerBuilder: WordPointerBuilder(container: container),
-            noteEditorBuilder: NoteEditorBuilder(container: container),
-            contentBuilder: ContentBuilder(container: container, highlightsService: highlightsService),
-            translationsSelectionBuilder: TranslationsListBuilder(container: container),
-            translationVerseBuilder: TranslationVerseBuilder(container: container),
-            resources: container.readingResources
-        )
+        #if QURAN_SYNC
+            let interactorDeps = QuranInteractor.Deps(
+                quran: quran,
+                analytics: container.analytics,
+                pageBookmarkService: pageBookmarkService,
+                noteService: container.noteService(),
+                ayahMenuBuilder: AyahMenuBuilder(container: container),
+                syncedAyahMenuBuilder: SyncedAyahMenuBuilder(container: container),
+                moreMenuBuilder: MoreMenuBuilder(),
+                audioBannerBuilder: AudioBannerBuilder(container: container),
+                wordPointerBuilder: WordPointerBuilder(container: container),
+                noteEditorBuilder: NoteEditorBuilder(container: container),
+                contentBuilder: ContentBuilder(container: container, highlightsService: highlightsService),
+                translationsSelectionBuilder: TranslationsListBuilder(container: container),
+                translationVerseBuilder: TranslationVerseBuilder(container: container),
+                resources: container.readingResources,
+                syncService: container.syncService,
+                bookmarkCollectionService: container.bookmarkCollectionService
+            )
+        #else
+            let interactorDeps = QuranInteractor.Deps(
+                quran: quran,
+                analytics: container.analytics,
+                pageBookmarkService: pageBookmarkService,
+                noteService: container.noteService(),
+                ayahMenuBuilder: AyahMenuBuilder(container: container),
+                moreMenuBuilder: MoreMenuBuilder(),
+                audioBannerBuilder: AudioBannerBuilder(container: container),
+                wordPointerBuilder: WordPointerBuilder(container: container),
+                noteEditorBuilder: NoteEditorBuilder(container: container),
+                contentBuilder: ContentBuilder(container: container, highlightsService: highlightsService),
+                translationsSelectionBuilder: TranslationsListBuilder(container: container),
+                translationVerseBuilder: TranslationVerseBuilder(container: container),
+                resources: container.readingResources
+            )
+        #endif
         let interactor = QuranInteractor(deps: interactorDeps, input: input)
         let viewController = QuranViewController(interactor: interactor)
         return viewController

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -14,6 +14,10 @@ import Combine
 import Crashing
 import FeaturesSupport
 import MoreMenuFeature
+#if QURAN_SYNC
+    import MobileSync
+    import MobileSyncSupport
+#endif
 import NoorUI
 import NoteEditorFeature
 import QuranAnnotations
@@ -64,6 +68,9 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let pageBookmarkService: PageBookmarkService
         let noteService: NoteService
         let ayahMenuBuilder: AyahMenuBuilder
+        #if QURAN_SYNC
+            let syncedAyahMenuBuilder: SyncedAyahMenuBuilder?
+        #endif
         let moreMenuBuilder: MoreMenuBuilder
         let audioBannerBuilder: AudioBannerBuilder
         let wordPointerBuilder: WordPointerBuilder
@@ -72,6 +79,10 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let translationsSelectionBuilder: TranslationsListBuilder
         let translationVerseBuilder: TranslationVerseBuilder
         let resources: ReadingResourcesService
+        #if QURAN_SYNC
+            let syncService: SyncService?
+            let bookmarkCollectionService: BookmarkCollectionService?
+        #endif
     }
 
     // MARK: Lifecycle
@@ -101,7 +112,18 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     func start() {
         deps.noteService.notes(quran: deps.quran)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] in self?.notes = $0 }
+            .sink { [weak self] notes in
+                guard let self else { return }
+                #if QURAN_SYNC
+                    if deps.syncService != nil {
+                        self.notes = notes.filter { !(($0.note ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) }
+                    } else {
+                        self.notes = notes
+                    }
+                #else
+                    self.notes = notes
+                #endif
+            }
             .store(in: &cancellables)
 
         deps.pageBookmarkService.pageBookmarks(quran: deps.quran)
@@ -179,7 +201,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         }
     }
 
-    func deleteNotes(_ notes: [Note], verses: [AyahNumber]) async {
+    func deleteNotes(_ notes: [QuranAnnotations.Note], verses: [AyahNumber]) async {
         let containsText = notes.contains { note in
             !(note.note ?? "").isEmpty
         }
@@ -195,13 +217,34 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         }
     }
 
+    #if QURAN_SYNC
+        func deleteSyncHighlights(_ verses: [AyahNumber]) async {
+            contentViewModel?.removeAyahMenuHighlight()
+            do {
+                guard let syncService = deps.syncService,
+                      let bookmarkCollectionService = deps.bookmarkCollectionService
+                else {
+                    return
+                }
+
+                try await HighlightCollection.removeHighlights(
+                    verses: verses,
+                    syncService: syncService,
+                    bookmarkCollectionService: bookmarkCollectionService
+                )
+            } catch {
+                crasher.recordError(error, reason: "Failed to remove synced highlights")
+            }
+        }
+    #endif
+
     func shareText(_ lines: [String], in sourceView: UIView, at point: CGPoint) {
         logger.info("Quran: share text")
         dismissAyahMenu()
         presenter?.shareText(lines, in: sourceView, at: point, completion: {})
     }
 
-    func editNote(_ note: Note) {
+    func editNote(_ note: QuranAnnotations.Note) {
         dismissAyahMenu()
         presenter?.rotateToPortraitIfPhone()
         let viewController = deps.noteEditorBuilder.build(withListener: self, note: note)
@@ -231,9 +274,32 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         }
     }
 
-    func presentAyahMenu(in sourceView: UIView, at point: CGPoint, verses: [AyahNumber]) {
+    func presentAyahMenu(
+        in sourceView: UIView,
+        at point: CGPoint,
+        verses: [AyahNumber],
+        notes: [QuranAnnotations.Note],
+        syncHighlightColor: HighlightColor?,
+        hasSyncHighlight: Bool
+    ) {
         logger.info("Quran: present ayah menu, verses: \(verses)")
-        let notes = notesInteractingVerses(verses)
+        let notes = notes.isEmpty ? notesInteractingVerses(verses) : notes
+        #if QURAN_SYNC
+            if let syncedAyahMenuBuilder = deps.syncedAyahMenuBuilder, deps.syncService != nil {
+                let input = SyncedAyahMenuInput(
+                    sourceView: sourceView,
+                    pointInView: point,
+                    verses: verses,
+                    notes: notes,
+                    syncHighlightColor: syncHighlightColor,
+                    hasSyncHighlight: hasSyncHighlight
+                )
+                let ayahMenuViewController = syncedAyahMenuBuilder.build(withListener: self, input: input)
+                presenter?.presentAyahMenu(ayahMenuViewController, in: sourceView, at: point)
+                return
+            }
+        #endif
+
         let input = AyahMenuInput(
             sourceView: sourceView,
             pointInView: point,
@@ -313,7 +379,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     private let contentStatePreferences = QuranContentStatePreferences.shared
     private let selectedTranslationsPreferences = SelectedTranslationsPreferences.shared
 
-    private var notes: [Note] = []
+    private var notes: [QuranAnnotations.Note] = []
 
     private var deps: Deps
     private let input: QuranInput
@@ -361,7 +427,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         }
     }
 
-    private func forceDeleteNotes(_ notes: [Note], verses: [AyahNumber]) async {
+    private func forceDeleteNotes(_ notes: [QuranAnnotations.Note], verses: [AyahNumber]) async {
         contentViewModel?.removeAyahMenuHighlight()
         do {
             try await deps.noteService.removeNotes(with: verses)
@@ -370,7 +436,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         }
     }
 
-    private func notesInteractingVerses(_ verses: [AyahNumber]) -> [Note] {
+    private func notesInteractingVerses(_ verses: [AyahNumber]) -> [QuranAnnotations.Note] {
         let selectedVerses = Set(verses)
         return notes.filter { !selectedVerses.isDisjoint(with: $0.verses) }
     }
@@ -457,3 +523,7 @@ private extension AnalyticsLibrary {
         logEvent("BookmarkPage", value: page.pageNumber.description)
     }
 }
+
+#if QURAN_SYNC
+    extension QuranInteractor: SyncedAyahMenuListener { }
+#endif

--- a/Model/QuranAnnotations/HighlightColor.swift
+++ b/Model/QuranAnnotations/HighlightColor.swift
@@ -1,0 +1,16 @@
+//
+//  HighlightColor.swift
+//  Quran
+//
+//  Created by Ahmed Nabil on 4/25/26.
+//
+
+import Foundation
+
+public enum HighlightColor: Int, CaseIterable, Sendable {
+    case red
+    case green
+    case blue
+    case yellow
+    case purple
+}

--- a/Model/QuranAnnotations/QuranHighlights.swift
+++ b/Model/QuranAnnotations/QuranHighlights.swift
@@ -18,6 +18,7 @@ public struct QuranHighlights: Equatable {
     public var shareVerses: [AyahNumber] = []
     public var searchVerses: [AyahNumber] = []
     public var noteVerses: [AyahNumber: Note] = [:]
+    public var highlightColorsByVerse: [AyahNumber: HighlightColor] = [:]
 
     public var pointedWord: Word?
 }

--- a/Package.swift
+++ b/Package.swift
@@ -552,6 +552,10 @@ private func featuresTargets() -> [[Target]] {
             "Localization",
             "Analytics",
             "QuranAnnotations",
+            "QuranKit",
+            "AnnotationsService",
+            "MobileSyncSupport",
+            .product(name: "MobileSync", package: "mobile-sync-spm"),
             "NoorUI",
         ]),
 
@@ -565,6 +569,9 @@ private func featuresTargets() -> [[Target]] {
             "AppDependencies",
             "QuranAudioKit",
             "AnnotationsService",
+            "FeaturesSupport",
+            "MobileSyncSupport",
+            .product(name: "MobileSync", package: "mobile-sync-spm"),
             "NoorUI",
         ]),
 
@@ -630,6 +637,7 @@ private func featuresTargets() -> [[Target]] {
             "NoorUI",
             "Preferences",
             "ReadingService",
+            .product(name: "MobileSync", package: "mobile-sync-spm"),
         ], testDependencies: [
             "Analytics",
             "AnnotationsService",
@@ -674,6 +682,8 @@ private func featuresTargets() -> [[Target]] {
         target(type, name: "QuranContentFeature", hasTests: false, dependencies: [
             "QuranImageFeature",
             "QuranTranslationFeature",
+            "FeaturesSupport",
+            .product(name: "MobileSync", package: "mobile-sync-spm"),
         ]),
 
         target(type, name: "TranslationsFeature", hasTests: false, dependencies: [
@@ -726,6 +736,8 @@ private func featuresTargets() -> [[Target]] {
             "TranslationsFeature",
             "TranslationVerseFeature",
             "FeaturesSupport",
+            "MobileSyncSupport",
+            .product(name: "MobileSync", package: "mobile-sync-spm"),
         ]),
 
         target(type, name: "SettingsFeature", dependencies: [

--- a/UI/NoorUI/Components/List/NoorListItem.swift
+++ b/UI/NoorUI/Components/List/NoorListItem.swift
@@ -44,6 +44,7 @@ public struct NoorListItem: View {
 
     public init(
         leadingEdgeLineColor: Color? = nil,
+        leadingView: AnyView? = nil,
         image: ItemImage? = nil,
         heading: String? = nil,
         subheading: MultipartText? = nil,
@@ -55,6 +56,7 @@ public struct NoorListItem: View {
         action: AsyncAction? = nil
     ) {
         self.leadingEdgeLineColor = leadingEdgeLineColor
+        self.leadingView = leadingView
         self.image = image
         self.heading = heading
         self.subheading = subheading
@@ -75,6 +77,7 @@ public struct NoorListItem: View {
 
     public enum Accessory {
         case text(String)
+        case textWithDisclosureIndicator(String)
         case disclosureIndicator
         case download(DownloadType, action: AsyncAction)
         case image(NoorSystemImage, color: Color? = nil)
@@ -83,7 +86,7 @@ public struct NoorListItem: View {
 
         var actionable: Bool {
             switch self {
-            case .text: return false
+            case .text, .textWithDisclosureIndicator: return false
             case .download: return true
             case .disclosureIndicator: return false
             case .image: return false
@@ -110,6 +113,7 @@ public struct NoorListItem: View {
     // MARK: Internal
 
     let leadingEdgeLineColor: Color?
+    let leadingView: AnyView?
     let image: ItemImage?
     let heading: String?
     let subheading: MultipartText?
@@ -148,7 +152,9 @@ public struct NoorListItem: View {
                     .frame(width: 4)
             }
 
-            if let image {
+            if let leadingView {
+                leadingView
+            } else if let image {
                 if let color = image.color {
                     image.image.image
                         .foregroundColor(color)
@@ -205,6 +211,13 @@ public struct NoorListItem: View {
                         Text(text)
                             .foregroundColor(.secondaryLabel)
                             .fontWeight(.light)
+                    case .textWithDisclosureIndicator(let text):
+                        HStack(spacing: ContentDimension.interSpacing) {
+                            Text(text)
+                                .foregroundColor(.secondaryLabel)
+                                .fontWeight(.light)
+                            DisclosureIndicator()
+                        }
                     case .disclosureIndicator:
                         DisclosureIndicator()
                     case let .download(type, action):

--- a/UI/NoorUI/Features/AyahMenu/SyncedAyahMenuUI.swift
+++ b/UI/NoorUI/Features/AyahMenu/SyncedAyahMenuUI.swift
@@ -1,0 +1,74 @@
+import QuranAnnotations
+import UIx
+
+public enum SyncedAyahMenuUI {
+    public struct Actions {
+        // MARK: Lifecycle
+
+        public init(
+            play: @escaping AsyncAction,
+            repeatVerses: @escaping AsyncAction,
+            highlight: @Sendable @escaping (HighlightColor) async -> Void,
+            addNote: @escaping AsyncAction,
+            deleteHighlight: AsyncAction? = nil,
+            deleteNote: AsyncAction? = nil,
+            showTranslation: @escaping AsyncAction,
+            copy: @escaping AsyncAction,
+            share: @escaping AsyncAction
+        ) {
+            self.play = play
+            self.repeatVerses = repeatVerses
+            self.highlight = highlight
+            self.addNote = addNote
+            self.deleteHighlight = deleteHighlight
+            self.deleteNote = deleteNote
+            self.showTranslation = showTranslation
+            self.copy = copy
+            self.share = share
+        }
+
+        // MARK: Internal
+
+        let play: AsyncAction
+        let repeatVerses: AsyncAction
+        let highlight: @Sendable (HighlightColor) async -> Void
+        let addNote: AsyncAction
+        let deleteHighlight: AsyncAction?
+        let deleteNote: AsyncAction?
+        let showTranslation: AsyncAction
+        let copy: AsyncAction
+        let share: AsyncAction
+    }
+
+    public struct DataObject {
+        // MARK: Lifecycle
+
+        public init(
+            highlightingColor: HighlightColor,
+            hasHighlight: Bool,
+            hasNoteText: Bool,
+            playSubtitle: String,
+            repeatSubtitle: String,
+            actions: Actions,
+            isTranslationView: Bool
+        ) {
+            self.highlightingColor = highlightingColor
+            self.hasHighlight = hasHighlight
+            self.hasNoteText = hasNoteText
+            self.playSubtitle = playSubtitle
+            self.repeatSubtitle = repeatSubtitle
+            self.actions = actions
+            self.isTranslationView = isTranslationView
+        }
+
+        // MARK: Internal
+
+        let highlightingColor: HighlightColor
+        let hasHighlight: Bool
+        let hasNoteText: Bool
+        let actions: Actions
+        let playSubtitle: String
+        let repeatSubtitle: String
+        let isTranslationView: Bool
+    }
+}

--- a/UI/NoorUI/Features/AyahMenu/SyncedAyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/SyncedAyahMenuView.swift
@@ -1,0 +1,364 @@
+import Localization
+import QuranAnnotations
+import SwiftUI
+import UIx
+
+private enum SyncedMenuState {
+    case list
+    case highlights
+}
+
+public struct SyncedAyahMenuView: View {
+    // MARK: Lifecycle
+
+    public init(dataObject: SyncedAyahMenuUI.DataObject) {
+        self.dataObject = dataObject
+    }
+
+    // MARK: Public
+
+    public var body: some View {
+        switch state {
+        case .list:
+            ScrollView {
+                SyncedAyahMenuViewList(dataObject: dataObject) {
+                    withAnimation {
+                        state = .highlights
+                    }
+                }
+            }
+            .preferredContentSizeMatchesScrollView()
+            .transition(.opacity)
+        case .highlights:
+            ScrollView {
+                SyncedHighlightCircles(selectedColor: existingHighlightedColor, tapped: dataObject.actions.highlight)
+            }
+            .preferredContentSizeMatchesScrollView()
+            .transition(AnyTransition.scale(scale: 2.0).combined(with: .opacity))
+        }
+    }
+
+    // MARK: Internal
+
+    let dataObject: SyncedAyahMenuUI.DataObject
+
+    // MARK: Private
+
+    @State private var state: SyncedMenuState = .list
+
+    private var existingHighlightedColor: HighlightColor? {
+        dataObject.hasHighlight ? dataObject.highlightingColor : nil
+    }
+}
+
+private struct SyncedAyahMenuViewList: View {
+    let dataObject: SyncedAyahMenuUI.DataObject
+    let showHighlights: AsyncAction
+
+    var editNote: some View {
+        SyncedRow(title: l("ayah.menu.edit-note"), action: dataObject.actions.addNote) {
+            Image(systemName: "text.bubble.fill")
+                .foregroundColor(dataObject.highlightingColor.color)
+        }
+    }
+
+    var addNote: some View {
+        SyncedRow(title: l("ayah.menu.add-note"), action: dataObject.actions.addNote) {
+            Image(systemName: "plus.bubble.fill")
+                .foregroundColor(dataObject.highlightingColor.color)
+        }
+    }
+
+    var translation: some View {
+        SyncedMenuGroup {
+            Divider()
+            SyncedRow(title: l("menu.translation"), action: dataObject.actions.showTranslation) {
+                Image(systemName: "globe")
+            }
+            Divider()
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            SyncedMenuGroup {
+                SyncedRow(
+                    title: lAndroid("play"),
+                    subtitle: dataObject.playSubtitle,
+                    action: dataObject.actions.play
+                ) {
+                    NoorSystemImage.play.image
+                }
+                Divider()
+                SyncedRow(
+                    title: l("ayah.menu.repeat"),
+                    subtitle: dataObject.repeatSubtitle,
+                    action: dataObject.actions.repeatVerses
+                ) {
+                    Image(systemName: "repeat")
+                }
+                Divider()
+            }
+
+            SyncedMenuGroup {
+                Divider()
+
+                if !dataObject.hasHighlight {
+                    SyncedRow(
+                        title: l("ayah.menu.highlight"),
+                        action: {
+                            Task {
+                                await dataObject.actions.highlight(dataObject.highlightingColor)
+                            }
+                        }
+                    ) {
+                        SyncedIconCircle(color: dataObject.highlightingColor)
+                    }
+                    Divider()
+                        .padding(.leading)
+                }
+                SyncedRow(
+                    title: l("ayah.menu.highlight"),
+                    subtitle: l("ayah.menu.highlight-select-color"),
+                    action: showHighlights
+                ) {
+                    SyncedIconCircles()
+                }
+                Divider()
+                    .padding(.leading)
+
+                if dataObject.hasNoteText {
+                    editNote
+                } else {
+                    addNote
+                }
+
+                if let deleteHighlight = dataObject.actions.deleteHighlight, dataObject.hasHighlight {
+                    Divider()
+                        .padding(.leading)
+
+                    SyncedRow(title: l("ayah.menu.delete-highlight"), action: deleteHighlight) {
+                        Image(systemName: "trash")
+                            .foregroundColor(Color.red)
+                    }
+                }
+
+                if let deleteNote = dataObject.actions.deleteNote, dataObject.hasNoteText {
+                    Divider()
+                        .padding(.leading)
+
+                    SyncedRow(title: l("ayah.menu.delete-note"), action: deleteNote) {
+                        Image(systemName: "trash")
+                            .foregroundColor(Color.red)
+                    }
+                }
+
+                Divider()
+            }
+
+            if !dataObject.isTranslationView {
+                translation
+            }
+
+            SyncedMenuGroup {
+                Divider()
+
+                SyncedRow(title: l("ayah.menu.copy"), action: dataObject.actions.copy) {
+                    Image(systemName: "doc.on.doc")
+                }
+                Divider()
+                    .padding(.leading)
+                SyncedRow(title: l("ayah.menu.share"), action: dataObject.actions.share) {
+                    Image(systemName: "square.and.arrow.up")
+                }
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+}
+
+private struct SyncedRow<Symbol: View>: View {
+    // MARK: Lifecycle
+
+    init(
+        title: String,
+        subtitle: String? = nil,
+        action: @Sendable @escaping () async -> Void,
+        @ViewBuilder symbol: () -> Symbol
+    ) {
+        self.symbol = symbol()
+        self.title = title
+        self.subtitle = subtitle
+        self.action = action
+    }
+
+    // MARK: Internal
+
+    let symbol: Symbol
+    let title: String
+    let subtitle: String?
+    let action: @Sendable () async -> Void
+    @ScaledMetric var verticalPadding = 12
+
+    var body: some View {
+        AsyncButton(action: action) {
+            HStack {
+                ZStack {
+                    SyncedIconCircles()
+                        .hidden()
+                    symbol
+                        .foregroundColor(Color.label)
+                }
+                HStack(spacing: 0) {
+                    Text(title)
+                        .foregroundColor(Color.label)
+                    if let subtitle {
+                        Group {
+                            Text(" ")
+                            Text(subtitle)
+                        }
+                        .font(.footnote)
+                        .foregroundColor(.secondaryLabel)
+                    }
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, verticalPadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(BackgroundHighlightingStyle())
+    }
+}
+
+private struct SyncedMenuGroup<Content: View>: View {
+    // MARK: Lifecycle
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    // MARK: Internal
+
+    let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            content
+        }
+        .background(Color.secondarySystemGroupedBackground)
+    }
+}
+
+private struct SyncedIconCircles: View {
+    @ScaledMetric var trailingPadding = 8
+    @ScaledMetric var purpleOffset = 8
+    @ScaledMetric var blueOffset = 4
+    @ScaledMetric var radius = 1
+
+    var body: some View {
+        ZStack {
+            SyncedIconCircle(color: .purple)
+                .offset(x: purpleOffset)
+            SyncedIconCircle(color: .blue)
+                .offset(x: blueOffset)
+            SyncedIconCircle(color: .green)
+        }
+        .compositingGroup()
+        .shadow(color: Color.tertiarySystemGroupedBackground, radius: radius)
+        .padding(.trailing, trailingPadding)
+    }
+}
+
+private struct SyncedIconCircle: View {
+    @ScaledMetric var minLength = 20
+
+    var color: HighlightColor
+
+    var body: some View {
+        ColoredCircle(color: color.color, selected: false, minLength: minLength)
+    }
+}
+
+private struct SyncedHighlightCircles: View {
+    let selectedColor: HighlightColor?
+    let tapped: @Sendable (HighlightColor) async -> Void
+
+    var body: some View {
+        HStack {
+            ForEach(HighlightColor.sortedColors, id: \.self) { color in
+                AsyncButton(
+                    action: { await tapped(color) },
+                    label: { NoteCircle(color: color.color, selected: color == selectedColor) }
+                )
+                .shadow(color: Color.tertiarySystemGroupedBackground, radius: 1)
+            }
+        }
+        .padding()
+    }
+}
+
+struct SyncedAyahMenuView_Previews: PreviewProvider {
+    static let actions = SyncedAyahMenuUI.Actions(
+        play: {},
+        repeatVerses: {},
+        highlight: { _ in },
+        addNote: {},
+        deleteHighlight: {},
+        deleteNote: {},
+        showTranslation: {},
+        copy: {},
+        share: {}
+    )
+
+    static var previews: some View {
+        Group {
+            VStack {
+                Spacer()
+                SyncedAyahMenuView(dataObject: SyncedAyahMenuUI.DataObject(
+                    highlightingColor: .green,
+                    hasHighlight: true,
+                    hasNoteText: true,
+                    playSubtitle: "To the end of Juz'",
+                    repeatSubtitle: "selected verses",
+                    actions: actions,
+                    isTranslationView: true
+                ))
+                Spacer()
+            }
+            .background(Color.systemGroupedBackground)
+
+            VStack {
+                Spacer()
+                SyncedAyahMenuView(dataObject: SyncedAyahMenuUI.DataObject(
+                    highlightingColor: .red,
+                    hasHighlight: true,
+                    hasNoteText: false,
+                    playSubtitle: "To the end of Juz'",
+                    repeatSubtitle: "selected verses",
+                    actions: actions,
+                    isTranslationView: true
+                ))
+                Spacer()
+            }
+            .background(Color.systemGroupedBackground)
+            .colorScheme(.dark)
+
+            VStack {
+                Spacer()
+                SyncedAyahMenuView(dataObject: SyncedAyahMenuUI.DataObject(
+                    highlightingColor: .green,
+                    hasHighlight: false,
+                    hasNoteText: false,
+                    playSubtitle: "To the end of Juz'",
+                    repeatSubtitle: "selected verses",
+                    actions: actions,
+                    isTranslationView: false
+                ))
+                Spacer()
+            }
+            .background(Color.systemGroupedBackground)
+        }
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/UI/NoorUI/Features/Note/AnnotationListItem.swift
+++ b/UI/NoorUI/Features/Note/AnnotationListItem.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+import UIx
+
+public struct AnnotationListItem: View {
+    @ScaledMetric private var contentSpacing = ContentDimension.interPageSpacing
+    @ScaledMetric private var footerSpacing = ContentDimension.interSpacing / 2
+
+    public init(
+        subheading: MultipartText,
+        verseText: MultipartText,
+        noteText: String?,
+        modifiedDateText: String,
+        pageNumberText: String,
+        action: AsyncAction? = nil
+    ) {
+        self.subheading = subheading
+        self.verseText = verseText
+        self.noteText = noteText
+        self.modifiedDateText = modifiedDateText
+        self.pageNumberText = pageNumberText
+        self.action = action
+    }
+
+    public var body: some View {
+        if let action {
+            AsyncButton(action: action) {
+                content
+            }
+        } else {
+            content
+        }
+    }
+
+    let subheading: MultipartText
+    let verseText: MultipartText
+    let noteText: String?
+    let modifiedDateText: String
+    let pageNumberText: String
+    let action: AsyncAction?
+
+    private var trimmedNoteText: String? {
+        let trimmed = noteText?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+
+    private var content: some View {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: contentSpacing) {
+                subheading.view(ofSize: .caption)
+                    .foregroundColor(Color.secondaryLabel)
+
+                verseText.view(ofSize: .body)
+
+                VStack(alignment: .leading, spacing: footerSpacing) {
+                    if let trimmedNoteText {
+                        Text(trimmedNoteText)
+                    }
+
+                    Text(modifiedDateText)
+                        .foregroundColor(Color.secondaryLabel)
+                        .font(.footnote)
+                }
+            }
+
+            Spacer(minLength: ContentDimension.interPageSpacing)
+
+            Text(pageNumberText)
+                .foregroundColor(.secondaryLabel)
+                .fontWeight(.light)
+        }
+        .foregroundColor(.primary)
+        .contentShape(Rectangle())
+    }
+}

--- a/UI/NoorUI/Features/Note/HighlightColor++.swift
+++ b/UI/NoorUI/Features/Note/HighlightColor++.swift
@@ -1,0 +1,32 @@
+//
+//  HighlightColor++.swift
+//
+//
+//  Created by Ahmed Nabil on 4/25/26.
+//
+
+import QuranAnnotations
+import SwiftUI
+import UIKit
+
+extension HighlightColor {
+    // MARK: Public
+
+    public var uiColor: UIColor {
+        switch self {
+        case .red: return #colorLiteral(red: 0.9976003766, green: 0.6918323636, blue: 0.790571034, alpha: 1)
+        case .green: return #colorLiteral(red: 0.7582061887, green: 0.9266348481, blue: 0.441752553, alpha: 1)
+        case .blue: return #colorLiteral(red: 0.6776656508, green: 0.8418365121, blue: 0.994728744, alpha: 1)
+        case .yellow: return #colorLiteral(red: 0.9911049008, green: 0.9235726595, blue: 0.3886876702, alpha: 1)
+        case .purple: return #colorLiteral(red: 0.8482968211, green: 0.695538938, blue: 0.9965527654, alpha: 1)
+        }
+    }
+
+    static var sortedColors: [Self] {
+        [.yellow, .green, .blue, .red, .purple]
+    }
+
+    public var color: SwiftUI.Color {
+        SwiftUI.Color(uiColor)
+    }
+}

--- a/UI/NoorUI/Features/Note/HighlightPaletteIcon.swift
+++ b/UI/NoorUI/Features/Note/HighlightPaletteIcon.swift
@@ -1,0 +1,40 @@
+import QuranAnnotations
+import SwiftUI
+import UIx
+
+public struct HighlightPaletteIcon: View {
+    @ScaledMetric private var trailingPadding = ContentDimension.interSpacing
+    @ScaledMetric private var purpleOffset = ContentDimension.interSpacing
+    @ScaledMetric private var blueOffset = ContentDimension.interSpacing / 2
+    @ScaledMetric private var shadowRadius = ContentDimension.interSpacing / 8
+    @ScaledMetric private var minLength = ContentDimension.interPageSpacing + ContentDimension.interSpacing
+
+    public init(addsTrailingPadding: Bool = false) {
+        self.addsTrailingPadding = addsTrailingPadding
+    }
+
+    public var body: some View {
+        ZStack {
+            HighlightPaletteCircle(color: .purple, minLength: minLength)
+                .offset(x: purpleOffset)
+            HighlightPaletteCircle(color: .blue, minLength: minLength)
+                .offset(x: blueOffset)
+            HighlightPaletteCircle(color: .green, minLength: minLength)
+        }
+        .frame(width: minLength + purpleOffset, alignment: .leading)
+        .compositingGroup()
+        .shadow(color: Color.tertiarySystemGroupedBackground, radius: shadowRadius)
+        .padding(.trailing, addsTrailingPadding ? trailingPadding : 0)
+    }
+
+    private let addsTrailingPadding: Bool
+}
+
+private struct HighlightPaletteCircle: View {
+    let color: HighlightColor
+    let minLength: CGFloat
+
+    var body: some View {
+        ColoredCircle(color: color.color, selected: false, minLength: minLength)
+    }
+}

--- a/UI/NoorUI/Theme/QuranHighlights+Theme.swift
+++ b/UI/NoorUI/Theme/QuranHighlights+Theme.swift
@@ -42,6 +42,10 @@ extension QuranHighlights {
             versesByHighlights[verse] = note.color.uiColor.withAlphaComponent(Self.opacity)
         }
 
+        for (verse, color) in highlightColorsByVerse {
+            versesByHighlights[verse] = color.uiColor.withAlphaComponent(Self.opacity)
+        }
+
         func add(verses: [AyahNumber], color: UIColor) {
             for verse in verses {
                 versesByHighlights[verse] = color


### PR DESCRIPTION
## Summary
Add sync-enabled highlights behavior and UI on top of the bookmark collection wrapper.

## Scope
- add Bookmarks `Highlights` row
- add fixed color list and per-color detail screen
- add sync-enabled highlight actions from the ayah menu
- render synced highlights on Quran content
- add separate synced ayah-menu flow instead of editing legacy note/highlight behavior

## Out of scope
- no notes sync
- no note editor changes
- no legacy non-sync behavior changes

## Notes
Sync-enabled highlights are based on fixed Mobile Sync collection names:
`red`, `green`, `blue`, `yellow`, `purple`.

Legacy non-sync behavior stays on the old path.
