### PR TITLE
Add notes sync data service

### DIFF
--- a/Data/MobileSyncSupport/Sources/NotesSyncService.swift
+++ b/Data/MobileSyncSupport/Sources/NotesSyncService.swift
@@ -66,6 +66,10 @@
             Int64(QuranData.shared.getAyahId(sura: Int32(verse.sura.suraNumber), ayah: Int32(verse.ayah)))
         }
 
+        // TODO: Remove/Revisit this workaround once Mobile Sync stops throwing
+        // "Expected note after insert." for notes that were actually persisted.
+        // Today note creation can succeed in the sync store but still surface that
+        // false-negative error, so we verify the inserted note exists before failing.
         private static func isExpectedNoteAfterInsert(_ error: Error) -> Bool {
             let description = String(describing: error)
             return description.contains("Expected note after insert.")

--- a/Data/MobileSyncSupport/Sources/NotesSyncService.swift
+++ b/Data/MobileSyncSupport/Sources/NotesSyncService.swift
@@ -1,0 +1,68 @@
+//
+//  NotesSyncService.swift
+//
+//
+//  Created by Ahmed Nabil on 2026-04-22.
+//
+
+#if QURAN_SYNC
+    import Foundation
+    import MobileSync
+    import QuranKit
+
+    public struct NotesSyncService {
+        // MARK: Lifecycle
+
+        public init(syncService: SyncService) {
+            self.syncService = syncService
+        }
+
+        // MARK: Public
+
+        public func createNote(body: String, verses: Set<AyahNumber>) async throws {
+            guard let range = Self.ayahIdRange(for: verses) else {
+                return
+            }
+            try await syncService.createNote(body: body, startAyahId: range.start, endAyahId: range.end)
+        }
+
+        public func updateNote(localId: String, body: String, verses: Set<AyahNumber>) async throws {
+            guard let range = Self.ayahIdRange(for: verses) else {
+                return
+            }
+            try await syncService.updateNote(
+                localId: localId,
+                body: body,
+                startAyahId: range.start,
+                endAyahId: range.end
+            )
+        }
+
+        public func removeNote(localId: String) async throws {
+            try await syncService.removeNote(localId: localId)
+        }
+
+        public func snapshot() async throws -> [Note_] {
+            for try await notes in syncService.notesSequence() {
+                return notes
+            }
+            return []
+        }
+
+        // MARK: Private
+
+        private let syncService: SyncService
+
+        private static func ayahIdRange(for verses: Set<AyahNumber>) -> (start: Int64, end: Int64)? {
+            guard let startVerse = verses.min(), let endVerse = verses.max() else {
+                return nil
+            }
+            return (start: ayahId(for: startVerse), end: ayahId(for: endVerse))
+        }
+
+        private static func ayahId(for verse: AyahNumber) -> Int64 {
+            Int64(QuranData.shared.getAyahId(sura: Int32(verse.sura.suraNumber), ayah: Int32(verse.ayah)))
+        }
+    }
+
+#endif

--- a/Data/MobileSyncSupport/Sources/NotesSyncService.swift
+++ b/Data/MobileSyncSupport/Sources/NotesSyncService.swift
@@ -19,17 +19,22 @@
 
         // MARK: Public
 
-        public func createNote(body: String, verses: Set<AyahNumber>) async throws {
-            guard let range = Self.ayahIdRange(for: verses) else {
-                return
+        public func createNote(body: String, startVerse: AyahNumber, endVerse: AyahNumber) async throws {
+            let range = Self.ayahIdRange(startVerse: startVerse, endVerse: endVerse)
+
+            do {
+                try await syncService.createNote(body: body, startAyahId: range.start, endAyahId: range.end)
+            } catch {
+                guard Self.isExpectedNoteAfterInsert(error),
+                      try await noteExists(body: body, range: range)
+                else {
+                    throw error
+                }
             }
-            try await syncService.createNote(body: body, startAyahId: range.start, endAyahId: range.end)
         }
 
-        public func updateNote(localId: String, body: String, verses: Set<AyahNumber>) async throws {
-            guard let range = Self.ayahIdRange(for: verses) else {
-                return
-            }
+        public func updateNote(localId: String, body: String, startVerse: AyahNumber, endVerse: AyahNumber) async throws {
+            let range = Self.ayahIdRange(startVerse: startVerse, endVerse: endVerse)
             try await syncService.updateNote(
                 localId: localId,
                 body: body,
@@ -53,15 +58,32 @@
 
         private let syncService: SyncService
 
-        private static func ayahIdRange(for verses: Set<AyahNumber>) -> (start: Int64, end: Int64)? {
-            guard let startVerse = verses.min(), let endVerse = verses.max() else {
-                return nil
-            }
-            return (start: ayahId(for: startVerse), end: ayahId(for: endVerse))
+        private static func ayahIdRange(startVerse: AyahNumber, endVerse: AyahNumber) -> (start: Int64, end: Int64) {
+            (start: ayahId(for: startVerse), end: ayahId(for: endVerse))
         }
 
         private static func ayahId(for verse: AyahNumber) -> Int64 {
             Int64(QuranData.shared.getAyahId(sura: Int32(verse.sura.suraNumber), ayah: Int32(verse.ayah)))
+        }
+
+        private static func isExpectedNoteAfterInsert(_ error: Error) -> Bool {
+            let description = String(describing: error)
+            return description.contains("Expected note after insert.")
+        }
+
+        private func noteExists(body: String, range: (start: Int64, end: Int64)) async throws -> Bool {
+            for attempt in 0 ..< 3 {
+                let notes = try await snapshot()
+                if notes.contains(where: {
+                    $0.body == body && $0.startAyahId == range.start && $0.endAyahId == range.end
+                }) {
+                    return true
+                }
+                if attempt < 2 {
+                    try? await Task.sleep(nanoseconds: 100_000_000)
+                }
+            }
+            return false
         }
     }
 

--- a/Features/AppDependencies/AppDependencies.swift
+++ b/Features/AppDependencies/AppDependencies.swift
@@ -45,6 +45,7 @@ public protocol AppDependencies {
     #if QURAN_SYNC
         var syncService: SyncService? { get }
         var bookmarkCollectionService: BookmarkCollectionService? { get }
+        var notesSyncService: NotesSyncService? { get }
     #endif
 
     var authenticationClient: (any AuthenticationClient)? { get }
@@ -65,6 +66,9 @@ extension AppDependencies {
             syncService.map { BookmarkCollectionService(syncService: $0) }
         }
 
+        public var notesSyncService: NotesSyncService? {
+            syncService.map { NotesSyncService(syncService: $0) }
+        }
     #endif
 
     public func noteService() -> NoteService {

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quran/mobile-sync-spm.git",
       "state" : {
-        "revision" : "ab9d351a8372502f93fffc440798621c4d6dfcca",
-        "version" : "0.0.6"
+        "revision" : "0c84f20d13637f05a1603899f77f211847a4d537",
+        "version" : "0.0.7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -68,7 +68,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
 
         // Sync
-        .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.0.6"),
+        .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.0.7"),
 
     ], targets: validated(targets) + [testTargetLinkingAllPackageTargets(targets)]
 )


### PR DESCRIPTION
## Summary
Add the sync notes data layer only.

## Scope
- bump `mobile-sync-spm` to `0.0.7`
- add `NotesSyncService` in `MobileSyncSupport`
- wire the service through `AppDependencies` under `QURAN_SYNC`

## Behavior
- create always creates a sync note
- update/delete are by concrete sync note id

## Out of scope
- no notes UI
- no note editor changes
- no ayah menu icon/presentation changes
- no note tinting changes

## Notes
Legacy CoreData notes flow remains untouched in this PR.
