### PR TITLE
Add navigation drawer to reading screen #794

### DIFF
--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -224,3 +224,22 @@
 "new.library_navigation" = "التنقل:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* قم بترتيب السور والأجزاء على الصفحة الرئيسية، وعرض أرقام السور حتى تتمكن من الانتقال إلى ما تحتاجه بشكل أسرع - بفضل @yismailuofa.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "التنقل";
+"navigation_drawer.search_placeholder" = "بحث";
+"navigation_drawer.tab.surah" = "السور";
+"navigation_drawer.tab.juz" = "الأجزاء";
+"navigation_drawer.tab.notes" = "الملاحظات";
+"navigation_drawer.tab.bookmarks" = "الإشارات المرجعية";
+"navigation_drawer.surah.makki" = "مكية";
+"navigation_drawer.surah.madani" = "مدنية";
+"navigation_drawer.note.untitled" = "ملاحظة بدون عنوان";
+"navigation_drawer.bookmark.page" = "صفحة %d";
+"navigation_drawer.empty.no_results" = "لا توجد نتائج";
+"navigation_drawer.empty.no_notes" = "لا توجد ملاحظات بعد";
+"navigation_drawer.empty.no_matching_notes" = "لا توجد ملاحظات مطابقة";
+"navigation_drawer.empty.no_bookmarks" = "لا توجد إشارات مرجعية بعد";
+"navigation_drawer.empty.no_matching_bookmarks" = "لا توجد إشارات مرجعية مطابقة";
+"navigation_drawer.close" = "إغلاق";

--- a/Core/Localization/Resources/de.lproj/Localizable.strings
+++ b/Core/Localization/Resources/de.lproj/Localizable.strings
@@ -317,3 +317,22 @@
 "new.library_navigation" = "Bibliothek & Navigation:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* Sortieren Sie Suren und Juz auf der Startseite und zeigen Sie Surennummern an, damit Sie schneller zu dem gelangen, was Sie brauchen - danke an @yismailuofa.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "Navigation";
+"navigation_drawer.search_placeholder" = "Suchen";
+"navigation_drawer.tab.surah" = "Sure";
+"navigation_drawer.tab.juz" = "Dschuz";
+"navigation_drawer.tab.notes" = "Notizen";
+"navigation_drawer.tab.bookmarks" = "Lesezeichen";
+"navigation_drawer.surah.makki" = "Makkanisch";
+"navigation_drawer.surah.madani" = "Medinensisch";
+"navigation_drawer.note.untitled" = "Notiz ohne Titel";
+"navigation_drawer.bookmark.page" = "Seite %d";
+"navigation_drawer.empty.no_results" = "Keine Ergebnisse";
+"navigation_drawer.empty.no_notes" = "Noch keine Notizen";
+"navigation_drawer.empty.no_matching_notes" = "Keine passenden Notizen";
+"navigation_drawer.empty.no_bookmarks" = "Noch keine Lesezeichen";
+"navigation_drawer.empty.no_matching_bookmarks" = "Keine passenden Lesezeichen";
+"navigation_drawer.close" = "Schließen";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -230,3 +230,22 @@
 // Library & Navigation
 "new.library_navigation" = "Library & Navigation:";
 "new.library_navigation.details" = "* Sort surahs and juz on Home, and display surah numbers so you can jump to what you need faster - thanks to @yismailuofa.";
+
+// MARK: - Navigation Drawer
+
+"navigation_drawer.title" = "Navigation";
+"navigation_drawer.search_placeholder" = "Search";
+"navigation_drawer.tab.surah" = "Surah";
+"navigation_drawer.tab.juz" = "Juz";
+"navigation_drawer.tab.notes" = "Notes";
+"navigation_drawer.tab.bookmarks" = "Bookmarks";
+"navigation_drawer.surah.makki" = "Makki";
+"navigation_drawer.surah.madani" = "Madani";
+"navigation_drawer.note.untitled" = "Untitled note";
+"navigation_drawer.bookmark.page" = "Page %d";
+"navigation_drawer.empty.no_results" = "No results";
+"navigation_drawer.empty.no_notes" = "No notes yet";
+"navigation_drawer.empty.no_matching_notes" = "No matching notes";
+"navigation_drawer.empty.no_bookmarks" = "No bookmarks yet";
+"navigation_drawer.empty.no_matching_bookmarks" = "No matching bookmarks";
+"navigation_drawer.close" = "Close";

--- a/Core/Localization/Resources/es.lproj/Localizable.strings
+++ b/Core/Localization/Resources/es.lproj/Localizable.strings
@@ -317,3 +317,22 @@
 "new.library_navigation" = "Biblioteca y navegación:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* Ordena suras y juz en Inicio y muestra los números de sura para que puedas acceder a lo que necesitas más rápido - gracias a @yismailuofa.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "Navegación";
+"navigation_drawer.search_placeholder" = "Buscar";
+"navigation_drawer.tab.surah" = "Sura";
+"navigation_drawer.tab.juz" = "Yuz";
+"navigation_drawer.tab.notes" = "Notas";
+"navigation_drawer.tab.bookmarks" = "Marcadores";
+"navigation_drawer.surah.makki" = "Mecana";
+"navigation_drawer.surah.madani" = "Medinense";
+"navigation_drawer.note.untitled" = "Nota sin título";
+"navigation_drawer.bookmark.page" = "Página %d";
+"navigation_drawer.empty.no_results" = "Sin resultados";
+"navigation_drawer.empty.no_notes" = "Aún no hay notas";
+"navigation_drawer.empty.no_matching_notes" = "No hay notas coincidentes";
+"navigation_drawer.empty.no_bookmarks" = "Aún no hay marcadores";
+"navigation_drawer.empty.no_matching_bookmarks" = "No hay marcadores coincidentes";
+"navigation_drawer.close" = "Cerrar";

--- a/Core/Localization/Resources/fa.lproj/Localizable.strings
+++ b/Core/Localization/Resources/fa.lproj/Localizable.strings
@@ -319,3 +319,22 @@
 "new.library_navigation" = "کتابخانه و پیمایش:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* سوره‌ها و جزءها را در صفحه اصلی مرتب کنید و شماره سوره‌ها را نمایش دهید تا سریع‌تر به آنچه نیاز دارید برسید - با تشکر از @yismailuofa.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "ناوبری";
+"navigation_drawer.search_placeholder" = "جستجو";
+"navigation_drawer.tab.surah" = "سوره";
+"navigation_drawer.tab.juz" = "جزء";
+"navigation_drawer.tab.notes" = "یادداشت‌ها";
+"navigation_drawer.tab.bookmarks" = "نشانه‌ها";
+"navigation_drawer.surah.makki" = "مکی";
+"navigation_drawer.surah.madani" = "مدنی";
+"navigation_drawer.note.untitled" = "یادداشت بدون عنوان";
+"navigation_drawer.bookmark.page" = "صفحه %d";
+"navigation_drawer.empty.no_results" = "بدون نتیجه";
+"navigation_drawer.empty.no_notes" = "هنوز یادداشتی نیست";
+"navigation_drawer.empty.no_matching_notes" = "یادداشت مطابق پیدا نشد";
+"navigation_drawer.empty.no_bookmarks" = "هنوز نشانه‌ای نیست";
+"navigation_drawer.empty.no_matching_bookmarks" = "نشانه مطابق پیدا نشد";
+"navigation_drawer.close" = "بستن";

--- a/Core/Localization/Resources/fr.lproj/Localizable.strings
+++ b/Core/Localization/Resources/fr.lproj/Localizable.strings
@@ -317,3 +317,22 @@
 "new.library_navigation" = "Bibliothèque et navigation:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* Triez les sourates et les juz sur Accueil et affichez les numéros de sourate pour accéder plus rapidement à ce dont vous avez besoin - merci à @yismailuofa.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "Navigation";
+"navigation_drawer.search_placeholder" = "Rechercher";
+"navigation_drawer.tab.surah" = "Sourate";
+"navigation_drawer.tab.juz" = "Juz";
+"navigation_drawer.tab.notes" = "Notes";
+"navigation_drawer.tab.bookmarks" = "Signets";
+"navigation_drawer.surah.makki" = "Mecquoise";
+"navigation_drawer.surah.madani" = "Médinoise";
+"navigation_drawer.note.untitled" = "Note sans titre";
+"navigation_drawer.bookmark.page" = "Page %d";
+"navigation_drawer.empty.no_results" = "Aucun résultat";
+"navigation_drawer.empty.no_notes" = "Aucune note";
+"navigation_drawer.empty.no_matching_notes" = "Aucune note correspondante";
+"navigation_drawer.empty.no_bookmarks" = "Aucun signet";
+"navigation_drawer.empty.no_matching_bookmarks" = "Aucun signet correspondant";
+"navigation_drawer.close" = "Fermer";

--- a/Core/Localization/Resources/kk.lproj/Localizable.strings
+++ b/Core/Localization/Resources/kk.lproj/Localizable.strings
@@ -299,3 +299,22 @@
 "new.library_navigation" = "Кітапхана және навигация:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* Үй бетінде сүрелер мен жүздерді сұрыптап, сүре нөмірлерін көрсетіңіз, сонда қажет нәрсеге тезірек жете аласыз - @yismailuofa-ға рахмет.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "Шарлау";
+"navigation_drawer.search_placeholder" = "Іздеу";
+"navigation_drawer.tab.surah" = "Сүре";
+"navigation_drawer.tab.juz" = "Жүз";
+"navigation_drawer.tab.notes" = "Жазбалар";
+"navigation_drawer.tab.bookmarks" = "Бетбелгілер";
+"navigation_drawer.surah.makki" = "Меккелік";
+"navigation_drawer.surah.madani" = "Мединалық";
+"navigation_drawer.note.untitled" = "Атаусыз жазба";
+"navigation_drawer.bookmark.page" = "%d-бет";
+"navigation_drawer.empty.no_results" = "Нәтиже жоқ";
+"navigation_drawer.empty.no_notes" = "Жазбалар жоқ";
+"navigation_drawer.empty.no_matching_notes" = "Сәйкес жазба жоқ";
+"navigation_drawer.empty.no_bookmarks" = "Бетбелгілер жоқ";
+"navigation_drawer.empty.no_matching_bookmarks" = "Сәйкес бетбелгі жоқ";
+"navigation_drawer.close" = "Жабу";

--- a/Core/Localization/Resources/ms.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ms.lproj/Localizable.strings
@@ -300,3 +300,22 @@
 "new.library_navigation" = "Perpustakaan & Navigasi:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* Susun surah dan juz di Halaman Utama serta paparkan nombor surah supaya anda boleh pergi ke yang diperlukan dengan lebih pantas - terima kasih kepada @yismailuofa.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "Navigasi";
+"navigation_drawer.search_placeholder" = "Cari";
+"navigation_drawer.tab.surah" = "Surah";
+"navigation_drawer.tab.juz" = "Juzuk";
+"navigation_drawer.tab.notes" = "Nota";
+"navigation_drawer.tab.bookmarks" = "Tanda buku";
+"navigation_drawer.surah.makki" = "Makkiyyah";
+"navigation_drawer.surah.madani" = "Madaniyyah";
+"navigation_drawer.note.untitled" = "Nota tanpa tajuk";
+"navigation_drawer.bookmark.page" = "Halaman %d";
+"navigation_drawer.empty.no_results" = "Tiada hasil";
+"navigation_drawer.empty.no_notes" = "Tiada nota lagi";
+"navigation_drawer.empty.no_matching_notes" = "Tiada nota yang sepadan";
+"navigation_drawer.empty.no_bookmarks" = "Tiada tanda buku lagi";
+"navigation_drawer.empty.no_matching_bookmarks" = "Tiada tanda buku yang sepadan";
+"navigation_drawer.close" = "Tutup";

--- a/Core/Localization/Resources/nl.lproj/Localizable.strings
+++ b/Core/Localization/Resources/nl.lproj/Localizable.strings
@@ -227,3 +227,22 @@
 "new.library_navigation" = "Bibliotheek & Navigatie:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* Sorteer soera's en juz op het Startscherm en toon soeranummers zodat je sneller gaat naar wat je nodig hebt - dankzij @yismailuofa.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "Navigatie";
+"navigation_drawer.search_placeholder" = "Zoeken";
+"navigation_drawer.tab.surah" = "Soera";
+"navigation_drawer.tab.juz" = "Djoez";
+"navigation_drawer.tab.notes" = "Notities";
+"navigation_drawer.tab.bookmarks" = "Bladwijzers";
+"navigation_drawer.surah.makki" = "Mekkaans";
+"navigation_drawer.surah.madani" = "Medinees";
+"navigation_drawer.note.untitled" = "Naamloze notitie";
+"navigation_drawer.bookmark.page" = "Pagina %d";
+"navigation_drawer.empty.no_results" = "Geen resultaten";
+"navigation_drawer.empty.no_notes" = "Nog geen notities";
+"navigation_drawer.empty.no_matching_notes" = "Geen overeenkomende notities";
+"navigation_drawer.empty.no_bookmarks" = "Nog geen bladwijzers";
+"navigation_drawer.empty.no_matching_bookmarks" = "Geen overeenkomende bladwijzers";
+"navigation_drawer.close" = "Sluiten";

--- a/Core/Localization/Resources/pt.lproj/Localizable.strings
+++ b/Core/Localization/Resources/pt.lproj/Localizable.strings
@@ -318,3 +318,22 @@
 "new.library_navigation" = "Biblioteca e navegação:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* Classifique suratas e juz na tela inicial e exiba os números das suras para chegar mais rápido ao que precisa - graças ao @yismailuofa.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "Navegação";
+"navigation_drawer.search_placeholder" = "Pesquisar";
+"navigation_drawer.tab.surah" = "Surata";
+"navigation_drawer.tab.juz" = "Juz";
+"navigation_drawer.tab.notes" = "Notas";
+"navigation_drawer.tab.bookmarks" = "Marcadores";
+"navigation_drawer.surah.makki" = "Meca";
+"navigation_drawer.surah.madani" = "Medina";
+"navigation_drawer.note.untitled" = "Nota sem título";
+"navigation_drawer.bookmark.page" = "Página %d";
+"navigation_drawer.empty.no_results" = "Sem resultados";
+"navigation_drawer.empty.no_notes" = "Sem notas ainda";
+"navigation_drawer.empty.no_matching_notes" = "Sem notas correspondentes";
+"navigation_drawer.empty.no_bookmarks" = "Sem marcadores ainda";
+"navigation_drawer.empty.no_matching_bookmarks" = "Sem marcadores correspondentes";
+"navigation_drawer.close" = "Fechar";

--- a/Core/Localization/Resources/ru.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ru.lproj/Localizable.strings
@@ -317,3 +317,22 @@
 "new.library_navigation" = "Библиотека и навигация:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* Сортируйте суры и джузы на главном экране и показывайте номера сур, чтобы быстрее перейти к нужному - спасибо @yismailuofa.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "Навигация";
+"navigation_drawer.search_placeholder" = "Поиск";
+"navigation_drawer.tab.surah" = "Сура";
+"navigation_drawer.tab.juz" = "Джуз";
+"navigation_drawer.tab.notes" = "Заметки";
+"navigation_drawer.tab.bookmarks" = "Закладки";
+"navigation_drawer.surah.makki" = "Мекканская";
+"navigation_drawer.surah.madani" = "Мединская";
+"navigation_drawer.note.untitled" = "Заметка без названия";
+"navigation_drawer.bookmark.page" = "Страница %d";
+"navigation_drawer.empty.no_results" = "Нет результатов";
+"navigation_drawer.empty.no_notes" = "Заметок ещё нет";
+"navigation_drawer.empty.no_matching_notes" = "Нет совпадающих заметок";
+"navigation_drawer.empty.no_bookmarks" = "Закладок ещё нет";
+"navigation_drawer.empty.no_matching_bookmarks" = "Нет совпадающих закладок";
+"navigation_drawer.close" = "Закрыть";

--- a/Core/Localization/Resources/tr.lproj/Localizable.strings
+++ b/Core/Localization/Resources/tr.lproj/Localizable.strings
@@ -258,3 +258,22 @@
 "new.library_navigation" = "Kütüphane ve Gezinme:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* Ana Sayfa'da sureleri ve cüzleri sıralayın ve sure numaralarını gösterin, böylece ihtiyacınız olana daha hızlı ulaşabilirsiniz - @yismailuofa sayesinde.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "Gezinme";
+"navigation_drawer.search_placeholder" = "Ara";
+"navigation_drawer.tab.surah" = "Sure";
+"navigation_drawer.tab.juz" = "Cüz";
+"navigation_drawer.tab.notes" = "Notlar";
+"navigation_drawer.tab.bookmarks" = "Yer İmleri";
+"navigation_drawer.surah.makki" = "Mekkî";
+"navigation_drawer.surah.madani" = "Medenî";
+"navigation_drawer.note.untitled" = "Başlıksız not";
+"navigation_drawer.bookmark.page" = "Sayfa %d";
+"navigation_drawer.empty.no_results" = "Sonuç yok";
+"navigation_drawer.empty.no_notes" = "Henüz not yok";
+"navigation_drawer.empty.no_matching_notes" = "Eşleşen not yok";
+"navigation_drawer.empty.no_bookmarks" = "Henüz yer imi yok";
+"navigation_drawer.empty.no_matching_bookmarks" = "Eşleşen yer imi yok";
+"navigation_drawer.close" = "Kapat";

--- a/Core/Localization/Resources/ug.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ug.lproj/Localizable.strings
@@ -320,3 +320,22 @@
 "new.library_navigation" = "كىتەپخانا ۋە يولباشچىلىق:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* باش بەتتە سۈرە ۋە جۇزلارنى تەرتىپلەپ، سۈرە نومۇرلىرىنى كۆرسىتىڭ، شۇنداق قىلىپ لازىملىق بەتكە تېز يېتىڭ - @yismailuofa غا رەھمەت.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "يول باشلىغۇچ";
+"navigation_drawer.search_placeholder" = "ئىزدەش";
+"navigation_drawer.tab.surah" = "سۈرە";
+"navigation_drawer.tab.juz" = "جۈز";
+"navigation_drawer.tab.notes" = "خاتىرە";
+"navigation_drawer.tab.bookmarks" = "خەتكۈچ";
+"navigation_drawer.surah.makki" = "مەككى";
+"navigation_drawer.surah.madani" = "مەدىنى";
+"navigation_drawer.note.untitled" = "ئىسىمسىز خاتىرە";
+"navigation_drawer.bookmark.page" = "%d-بەت";
+"navigation_drawer.empty.no_results" = "نەتىجە يوق";
+"navigation_drawer.empty.no_notes" = "تېخى خاتىرە يوق";
+"navigation_drawer.empty.no_matching_notes" = "ماس خاتىرە يوق";
+"navigation_drawer.empty.no_bookmarks" = "تېخى خەتكۈچ يوق";
+"navigation_drawer.empty.no_matching_bookmarks" = "ماس خەتكۈچ يوق";
+"navigation_drawer.close" = "تاقاش";

--- a/Core/Localization/Resources/uz.lproj/Localizable.strings
+++ b/Core/Localization/Resources/uz.lproj/Localizable.strings
@@ -319,3 +319,22 @@
 "new.library_navigation" = "Kutubxona va navigatsiya:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* Bosh sahifada suralar va juzlarni tartiblang hamda sura raqamlarini ko'rsating, shunda kerakli joyga tezroq o'tasiz - @yismailuofa ga rahmat.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "Navigatsiya";
+"navigation_drawer.search_placeholder" = "Qidirish";
+"navigation_drawer.tab.surah" = "Sura";
+"navigation_drawer.tab.juz" = "Juz";
+"navigation_drawer.tab.notes" = "Eslatmalar";
+"navigation_drawer.tab.bookmarks" = "Xatcho'plar";
+"navigation_drawer.surah.makki" = "Makka";
+"navigation_drawer.surah.madani" = "Madina";
+"navigation_drawer.note.untitled" = "Nomsiz eslatma";
+"navigation_drawer.bookmark.page" = "%d-bet";
+"navigation_drawer.empty.no_results" = "Natija yo'q";
+"navigation_drawer.empty.no_notes" = "Hali eslatma yo'q";
+"navigation_drawer.empty.no_matching_notes" = "Mos eslatma topilmadi";
+"navigation_drawer.empty.no_bookmarks" = "Hali xatcho'p yo'q";
+"navigation_drawer.empty.no_matching_bookmarks" = "Mos xatcho'p topilmadi";
+"navigation_drawer.close" = "Yopish";

--- a/Core/Localization/Resources/vi.lproj/Localizable.strings
+++ b/Core/Localization/Resources/vi.lproj/Localizable.strings
@@ -224,3 +224,22 @@
 "new.library_navigation" = "Thư viện & Điều hướng:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* Sắp xếp surah và juz trên Trang chủ và hiển thị số surah để bạn đến nội dung cần nhanh hơn - nhờ @yismailuofa.";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "Điều hướng";
+"navigation_drawer.search_placeholder" = "Tìm kiếm";
+"navigation_drawer.tab.surah" = "Sura";
+"navigation_drawer.tab.juz" = "Juz";
+"navigation_drawer.tab.notes" = "Ghi chú";
+"navigation_drawer.tab.bookmarks" = "Đánh dấu";
+"navigation_drawer.surah.makki" = "Mecca";
+"navigation_drawer.surah.madani" = "Medina";
+"navigation_drawer.note.untitled" = "Ghi chú không tiêu đề";
+"navigation_drawer.bookmark.page" = "Trang %d";
+"navigation_drawer.empty.no_results" = "Không có kết quả";
+"navigation_drawer.empty.no_notes" = "Chưa có ghi chú";
+"navigation_drawer.empty.no_matching_notes" = "Không có ghi chú phù hợp";
+"navigation_drawer.empty.no_bookmarks" = "Chưa có đánh dấu";
+"navigation_drawer.empty.no_matching_bookmarks" = "Không có đánh dấu phù hợp";
+"navigation_drawer.close" = "Đóng";

--- a/Core/Localization/Resources/zh.lproj/Localizable.strings
+++ b/Core/Localization/Resources/zh.lproj/Localizable.strings
@@ -318,3 +318,22 @@
 "new.library_navigation" = "书库与导航:";
 // Metadata: Translated by ChatGPT; human review required.
 "new.library_navigation.details" = "* 在主页排序苏拉和朱兹并显示苏拉编号，帮助你更快跳转到所需内容 - 感谢 @yismailuofa。";
+
+// MARK: - Navigation Drawer
+// Metadata: Translated by AI; human review required.
+"navigation_drawer.title" = "导航";
+"navigation_drawer.search_placeholder" = "搜索";
+"navigation_drawer.tab.surah" = "章";
+"navigation_drawer.tab.juz" = "卷";
+"navigation_drawer.tab.notes" = "笔记";
+"navigation_drawer.tab.bookmarks" = "书签";
+"navigation_drawer.surah.makki" = "麦加章";
+"navigation_drawer.surah.madani" = "麦地那章";
+"navigation_drawer.note.untitled" = "无标题笔记";
+"navigation_drawer.bookmark.page" = "第 %d 页";
+"navigation_drawer.empty.no_results" = "没有结果";
+"navigation_drawer.empty.no_notes" = "暂无笔记";
+"navigation_drawer.empty.no_matching_notes" = "没有匹配的笔记";
+"navigation_drawer.empty.no_bookmarks" = "暂无书签";
+"navigation_drawer.empty.no_matching_bookmarks" = "没有匹配的书签";
+"navigation_drawer.close" = "关闭";

--- a/Features/NavigationDrawerFeature/NavigationDrawerBuilder.swift
+++ b/Features/NavigationDrawerFeature/NavigationDrawerBuilder.swift
@@ -1,0 +1,61 @@
+//
+//  NavigationDrawerBuilder.swift
+//  Quran
+//
+//  Created by Abdirizak Hassan on 4/25/26.
+//  Copyright © 2026 Quran.com. All rights reserved.
+//
+
+import QuranAnnotations
+import QuranKit
+import UIKit
+
+/// Public entry point for callers that want to present the navigation drawer.
+/// Mirrors the Builder pattern used by other features (NoteEditorBuilder, etc.).
+@MainActor
+public struct NavigationDrawerBuilder {
+    public init() {}
+
+    /// Builds the drawer view controller, ready to be presented modally.
+    ///
+    /// - Parameters:
+    ///   - quran: The Quran model used to populate Surah and Juz lists.
+    ///   - currentPage: The page currently visible in the reader, used to
+    ///     highlight the matching Surah/Juz row.
+    ///   - notes: A snapshot of the user's notes to render in the Notes tab.
+    ///   - pageBookmarks: A snapshot of the user's page bookmarks for the
+    ///     Bookmarks tab.
+    ///   - onSelectPage: Called when the user taps a destination. The caller
+    ///     should dismiss the drawer and scroll the reader to the page.
+    public func build(
+        quran: Quran,
+        currentPage: Page,
+        notes: [Note],
+        pageBookmarks: [PageBookmark],
+        onSelectPage: @escaping (Page) -> Void
+    ) -> UIViewController {
+        let controllerHolder = ViewControllerHolder()
+        let viewModel = NavigationDrawerViewModel(
+            quran: quran,
+            currentPage: currentPage,
+            notes: notes,
+            pageBookmarks: pageBookmarks,
+            onSelectPage: { page in
+                controllerHolder.controller?.dismiss(animated: true) {
+                    onSelectPage(page)
+                }
+            },
+            onClose: { controllerHolder.controller?.dismiss(animated: true) }
+        )
+        let controller = NavigationDrawerViewController(viewModel: viewModel)
+        controllerHolder.controller = controller
+        return controller
+    }
+}
+
+/// Indirection so the view-model's callbacks can dismiss the controller without
+/// retain cycles.
+@MainActor
+private final class ViewControllerHolder {
+    weak var controller: UIViewController?
+}

--- a/Features/NavigationDrawerFeature/NavigationDrawerSidePresentationController.swift
+++ b/Features/NavigationDrawerFeature/NavigationDrawerSidePresentationController.swift
@@ -1,0 +1,94 @@
+//
+//  NavigationDrawerSidePresentationController.swift
+//  Quran
+//
+//  Created by Abdirizak Hassan on 4/25/26.
+//  Copyright © 2026 Quran.com. All rights reserved.
+//
+
+import UIKit
+
+/// Presents the drawer as a side sheet anchored to the trailing edge of the
+/// containing window. In LTR locales the drawer slides in from the right; in
+/// RTL it slides in from the left. A dim view sits behind it and dismisses
+/// the drawer on tap.
+final class NavigationDrawerSidePresentationController: UIPresentationController {
+    // MARK: - Constants
+
+    /// Fraction of the container width occupied by the drawer.
+    private static let widthFraction: CGFloat = 0.84
+    /// Hard cap on drawer width for tablets and large devices.
+    private static let maxWidth: CGFloat = 380
+
+    // MARK: - Subviews
+
+    private lazy var dimmingView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        view.alpha = 0
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleDimTap))
+        view.addGestureRecognizer(tap)
+        view.accessibilityIdentifier = "NavigationDrawerDimmingView"
+        return view
+    }()
+
+    // MARK: - Frames
+
+    override var frameOfPresentedViewInContainerView: CGRect {
+        guard let containerView else { return .zero }
+        let bounds = containerView.bounds
+        let width = min(bounds.width * Self.widthFraction, Self.maxWidth)
+        let isRTL = containerView.effectiveUserInterfaceLayoutDirection == .rightToLeft
+        let originX = isRTL ? 0 : bounds.width - width
+        return CGRect(x: originX, y: 0, width: width, height: bounds.height)
+    }
+
+    // MARK: - Presentation lifecycle
+
+    override func presentationTransitionWillBegin() {
+        super.presentationTransitionWillBegin()
+        guard let containerView else { return }
+
+        dimmingView.frame = containerView.bounds
+        dimmingView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        containerView.insertSubview(dimmingView, at: 0)
+
+        if let coordinator = presentingViewController.transitionCoordinator {
+            coordinator.animate(alongsideTransition: { [weak self] _ in
+                self?.dimmingView.alpha = 1
+            })
+        } else {
+            dimmingView.alpha = 1
+        }
+    }
+
+    override func dismissalTransitionWillBegin() {
+        super.dismissalTransitionWillBegin()
+        if let coordinator = presentingViewController.transitionCoordinator {
+            coordinator.animate(alongsideTransition: { [weak self] _ in
+                self?.dimmingView.alpha = 0
+            })
+        } else {
+            dimmingView.alpha = 0
+        }
+    }
+
+    override func dismissalTransitionDidEnd(_ completed: Bool) {
+        super.dismissalTransitionDidEnd(completed)
+        if completed {
+            dimmingView.removeFromSuperview()
+        }
+    }
+
+    override func containerViewWillLayoutSubviews() {
+        super.containerViewWillLayoutSubviews()
+        presentedView?.frame = frameOfPresentedViewInContainerView
+    }
+
+    // MARK: - Actions
+
+    @objc
+    private func handleDimTap() {
+        presentedViewController.dismiss(animated: true)
+    }
+}

--- a/Features/NavigationDrawerFeature/NavigationDrawerSideTransition.swift
+++ b/Features/NavigationDrawerFeature/NavigationDrawerSideTransition.swift
@@ -1,0 +1,101 @@
+//
+//  NavigationDrawerSideTransition.swift
+//  Quran
+//
+//  Created by Abdirizak Hassan on 4/25/26.
+//  Copyright © 2026 Quran.com. All rights reserved.
+//
+
+import UIKit
+
+/// Transitioning delegate that wires up the side-drawer presentation controller
+/// and its slide-in / slide-out animators.
+final class NavigationDrawerSideTransition: NSObject, UIViewControllerTransitioningDelegate {
+    func presentationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController?,
+        source: UIViewController
+    ) -> UIPresentationController? {
+        NavigationDrawerSidePresentationController(presentedViewController: presented, presenting: presenting)
+    }
+
+    func animationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController,
+        source: UIViewController
+    ) -> UIViewControllerAnimatedTransitioning? {
+        NavigationDrawerSideAnimator(isPresenting: true)
+    }
+
+    func animationController(
+        forDismissed dismissed: UIViewController
+    ) -> UIViewControllerAnimatedTransitioning? {
+        NavigationDrawerSideAnimator(isPresenting: false)
+    }
+}
+
+/// Slides the drawer in from / out to the trailing edge.
+final class NavigationDrawerSideAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+    private let isPresenting: Bool
+
+    init(isPresenting: Bool) {
+        self.isPresenting = isPresenting
+    }
+
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        0.28
+    }
+
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        let containerView = transitionContext.containerView
+        let isRTL = containerView.effectiveUserInterfaceLayoutDirection == .rightToLeft
+        let duration = transitionDuration(using: transitionContext)
+
+        if isPresenting {
+            guard let toView = transitionContext.view(forKey: .to),
+                  let toVC = transitionContext.viewController(forKey: .to)
+            else {
+                transitionContext.completeTransition(false)
+                return
+            }
+            let finalFrame = transitionContext.finalFrame(for: toVC)
+            toView.frame = finalFrame
+            // Slide in from outside the trailing edge
+            let offscreenX: CGFloat = isRTL ? -finalFrame.width : containerView.bounds.width
+            toView.transform = CGAffineTransform(translationX: offscreenX - finalFrame.origin.x, y: 0)
+            containerView.addSubview(toView)
+
+            UIView.animate(
+                withDuration: duration,
+                delay: 0,
+                options: [.curveEaseOut],
+                animations: {
+                    toView.transform = .identity
+                },
+                completion: { finished in
+                    transitionContext.completeTransition(finished && !transitionContext.transitionWasCancelled)
+                }
+            )
+        } else {
+            guard let fromView = transitionContext.view(forKey: .from) else {
+                transitionContext.completeTransition(false)
+                return
+            }
+            let frame = fromView.frame
+            let offscreenX: CGFloat = isRTL ? -frame.width : containerView.bounds.width
+
+            UIView.animate(
+                withDuration: duration,
+                delay: 0,
+                options: [.curveEaseIn],
+                animations: {
+                    fromView.transform = CGAffineTransform(translationX: offscreenX - frame.origin.x, y: 0)
+                },
+                completion: { finished in
+                    fromView.transform = .identity
+                    transitionContext.completeTransition(finished && !transitionContext.transitionWasCancelled)
+                }
+            )
+        }
+    }
+}

--- a/Features/NavigationDrawerFeature/NavigationDrawerTab.swift
+++ b/Features/NavigationDrawerFeature/NavigationDrawerTab.swift
@@ -1,0 +1,28 @@
+//
+//  NavigationDrawerTab.swift
+//  Quran
+//
+//  Created by Abdirizak Hassan on 4/25/26.
+//  Copyright © 2026 Quran.com. All rights reserved.
+//
+
+import Foundation
+import Localization
+
+enum NavigationDrawerTab: Int, CaseIterable, Identifiable {
+    case surah
+    case juz
+    case notes
+    case bookmarks
+
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .surah: return l("navigation_drawer.tab.surah")
+        case .juz: return l("navigation_drawer.tab.juz")
+        case .notes: return l("navigation_drawer.tab.notes")
+        case .bookmarks: return l("navigation_drawer.tab.bookmarks")
+        }
+    }
+}

--- a/Features/NavigationDrawerFeature/NavigationDrawerView.swift
+++ b/Features/NavigationDrawerFeature/NavigationDrawerView.swift
@@ -15,6 +15,7 @@ import SwiftUI
 
 struct NavigationDrawerView: View {
     @ObservedObject var viewModel: NavigationDrawerViewModel
+    @FocusState private var searchFocused: Bool
 
     var body: some View {
         VStack(spacing: 0) {
@@ -42,18 +43,26 @@ struct NavigationDrawerView: View {
                 .textFieldStyle(.plain)
                 .autocorrectionDisabled(true)
                 .textInputAutocapitalization(.never)
+                .submitLabel(.search)
+                .focused($searchFocused)
             if !viewModel.searchText.isEmpty {
-                Button(action: { viewModel.searchText = "" }) {
+                Button(action: {
+                    viewModel.searchText = ""
+                    searchFocused = false
+                }) {
                     Image(systemName: "xmark.circle.fill")
                         .font(.system(size: 14))
                         .foregroundColor(.secondary)
                 }
+                .buttonStyle(.plain)
             }
         }
         .padding(.vertical, 8)
         .padding(.horizontal, 10)
         .background(Color(.secondarySystemBackground))
         .clipShape(RoundedRectangle(cornerRadius: 8))
+        .contentShape(Rectangle())
+        .onTapGesture { searchFocused = true }
     }
 
     // MARK: - Header

--- a/Features/NavigationDrawerFeature/NavigationDrawerView.swift
+++ b/Features/NavigationDrawerFeature/NavigationDrawerView.swift
@@ -147,6 +147,14 @@ private struct SurahListView: View {
 
 // MARK: - Juz list (quarters grouped by juz, matching the home page style)
 
+/// Quarter doesn't conform to Identifiable in QuranKit, so we wrap it for use
+/// with NoorSection / SwiftUI.ForEach. Mirrors the QuarterItem pattern in
+/// HomeFeature.
+private struct DrawerQuarterItem: Identifiable {
+    let quarter: Quarter
+    var id: Quarter { quarter }
+}
+
 private struct JuzListView: View {
     @ObservedObject var viewModel: NavigationDrawerViewModel
 
@@ -166,9 +174,11 @@ private struct JuzListView: View {
         let grouped = Dictionary(grouping: quarters, by: { $0.juz })
         let juzs = grouped.keys.sorted { $0.juzNumber < $1.juzNumber }
         ForEach(juzs) { juz in
-            let items = (grouped[juz] ?? []).sorted { $0.quarterNumber < $1.quarterNumber }
-            NoorSection(title: juz.localizedName, items) { quarter in
-                quarterRow(quarter: quarter)
+            let items = (grouped[juz] ?? [])
+                .sorted { $0.quarterNumber < $1.quarterNumber }
+                .map(DrawerQuarterItem.init)
+            NoorSection(title: juz.localizedName, items) { item in
+                quarterRow(quarter: item.quarter)
             }
         }
     }

--- a/Features/NavigationDrawerFeature/NavigationDrawerView.swift
+++ b/Features/NavigationDrawerFeature/NavigationDrawerView.swift
@@ -1,0 +1,344 @@
+//
+//  NavigationDrawerView.swift
+//  Quran
+//
+//  Created by Abdirizak Hassan on 4/25/26.
+//  Copyright © 2026 Quran.com. All rights reserved.
+//
+
+import Localization
+import QuranAnnotations
+import QuranKit
+import QuranTextKit
+import SwiftUI
+
+struct NavigationDrawerView: View {
+    @ObservedObject var viewModel: NavigationDrawerViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            tabPicker
+                .padding(.horizontal)
+                .padding(.bottom, 8)
+            searchField
+                .padding(.horizontal)
+                .padding(.bottom, 8)
+            Divider()
+            content
+        }
+        .background(Color(.systemBackground))
+    }
+
+    // MARK: - Search
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 14))
+                .foregroundColor(.secondary)
+            TextField(l("navigation_drawer.search_placeholder"), text: $viewModel.searchText)
+                .textFieldStyle(.plain)
+                .autocorrectionDisabled(true)
+                .textInputAutocapitalization(.never)
+            if !viewModel.searchText.isEmpty {
+                Button(action: { viewModel.searchText = "" }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 14))
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 10)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Text(l("navigation_drawer.title"))
+                .font(.headline)
+            Spacer()
+            Button(action: { viewModel.close() }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(.secondary)
+                    .frame(width: 30, height: 30)
+                    .background(Color(.secondarySystemBackground))
+                    .clipShape(Circle())
+            }
+            .accessibilityLabel(l("navigation_drawer.close"))
+        }
+        .padding()
+    }
+
+    // MARK: - Tab picker
+
+    private var tabPicker: some View {
+        Picker("", selection: $viewModel.selectedTab) {
+            ForEach(NavigationDrawerTab.allCases) { tab in
+                Text(tab.title).tag(tab)
+            }
+        }
+        .pickerStyle(.segmented)
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.selectedTab {
+        case .surah:
+            SurahListView(viewModel: viewModel)
+        case .juz:
+            JuzListView(viewModel: viewModel)
+        case .notes:
+            NotesListView(viewModel: viewModel)
+        case .bookmarks:
+            BookmarksListView(viewModel: viewModel)
+        }
+    }
+}
+
+// MARK: - Surah list
+
+private struct SurahListView: View {
+    @ObservedObject var viewModel: NavigationDrawerViewModel
+
+    var body: some View {
+        let suras = viewModel.filteredSuras
+        if suras.isEmpty {
+            EmptySearchPlaceholder()
+        } else {
+            List {
+                ForEach(suras) { sura in
+                    Button {
+                        viewModel.selectPage(sura.page)
+                    } label: {
+                        DrawerRow(
+                            leading: "\(sura.suraNumber)",
+                            title: sura.localizedName(withPrefix: false),
+                            subtitle: sura.isMakki
+                                ? l("navigation_drawer.surah.makki")
+                                : l("navigation_drawer.surah.madani"),
+                            isCurrent: sura.page == viewModel.currentPage
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+}
+
+// MARK: - Juz list
+
+private struct JuzListView: View {
+    @ObservedObject var viewModel: NavigationDrawerViewModel
+
+    var body: some View {
+        let juzs = viewModel.filteredJuzs
+        if juzs.isEmpty {
+            EmptySearchPlaceholder()
+        } else {
+            List {
+                ForEach(juzs) { juz in
+                    Button {
+                        viewModel.selectPage(juz.page)
+                    } label: {
+                        DrawerRow(
+                            leading: "\(juz.juzNumber)",
+                            title: juz.localizedName,
+                            subtitle: nil,
+                            isCurrent: juz.page == viewModel.currentPage
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+}
+
+// MARK: - Row
+
+private struct DrawerRow: View {
+    let leading: String
+    let title: String
+    let subtitle: String?
+    let isCurrent: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(leading)
+                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                .foregroundColor(.secondary)
+                .frame(width: 32, alignment: .center)
+                .padding(.vertical, 4)
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(.primary)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(.system(size: 12))
+                        .foregroundColor(.secondary)
+                }
+            }
+            Spacer()
+            if isCurrent {
+                Image(systemName: "location.fill")
+                    .font(.system(size: 12))
+                    .foregroundColor(.accentColor)
+            }
+        }
+        .contentShape(Rectangle())
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Notes list
+
+private struct NotesListView: View {
+    @ObservedObject var viewModel: NavigationDrawerViewModel
+
+    var body: some View {
+        let notes = viewModel.filteredNotes
+        if notes.isEmpty {
+            EmptyDataPlaceholder(
+                systemImage: "note.text",
+                title: viewModel.searchText.isEmpty
+                    ? l("navigation_drawer.empty.no_notes")
+                    : l("navigation_drawer.empty.no_matching_notes")
+            )
+        } else {
+            List {
+                ForEach(notes, id: \.firstVerse) { note in
+                    Button {
+                        viewModel.selectPage(note.firstVerse.page)
+                    } label: {
+                        NoteRow(note: note)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+}
+
+private struct NoteRow: View {
+    let note: Note
+
+    var body: some View {
+        HStack(spacing: 10) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(swiftUIColor(for: note.color))
+                .frame(width: 4)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(note.note?.isEmpty == false ? note.note! : l("navigation_drawer.note.untitled"))
+                    .font(.system(size: 14))
+                    .foregroundColor(.primary)
+                    .lineLimit(2)
+                Text("\(note.firstVerse.sura.localizedName(withPrefix: false)) \(note.firstVerse.sura.suraNumber):\(note.firstVerse.ayah)")
+                    .font(.system(size: 11))
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 4)
+    }
+
+    private func swiftUIColor(for color: Note.Color) -> Color {
+        switch color {
+        case .red: return .red
+        case .green: return .green
+        case .blue: return .blue
+        case .yellow: return .yellow
+        case .purple: return .purple
+        }
+    }
+}
+
+// MARK: - Bookmarks list
+
+private struct BookmarksListView: View {
+    @ObservedObject var viewModel: NavigationDrawerViewModel
+
+    var body: some View {
+        let bookmarks = viewModel.filteredBookmarks
+        if bookmarks.isEmpty {
+            EmptyDataPlaceholder(
+                systemImage: "bookmark",
+                title: viewModel.searchText.isEmpty
+                    ? l("navigation_drawer.empty.no_bookmarks")
+                    : l("navigation_drawer.empty.no_matching_bookmarks")
+            )
+        } else {
+            List {
+                ForEach(bookmarks) { bookmark in
+                    Button {
+                        viewModel.selectPage(bookmark.page)
+                    } label: {
+                        DrawerRow(
+                            leading: "\(bookmark.page.pageNumber)",
+                            title: bookmark.page.startSura.localizedName(withPrefix: false),
+                            subtitle: lFormat("navigation_drawer.bookmark.page", bookmark.page.pageNumber),
+                            isCurrent: bookmark.page == viewModel.currentPage
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+}
+
+// MARK: - Generic empty placeholder
+
+private struct EmptyDataPlaceholder: View {
+    let systemImage: String
+    let title: String
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Spacer()
+            Image(systemName: systemImage)
+                .font(.system(size: 40))
+                .foregroundColor(.secondary.opacity(0.4))
+            Text(title)
+                .font(.system(size: 14))
+                .foregroundColor(.secondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Empty search placeholder
+
+private struct EmptySearchPlaceholder: View {
+    var body: some View {
+        VStack(spacing: 8) {
+            Spacer()
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 32))
+                .foregroundColor(.secondary.opacity(0.4))
+            Text(l("navigation_drawer.empty.no_results"))
+                .font(.system(size: 14))
+                .foregroundColor(.secondary)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}

--- a/Features/NavigationDrawerFeature/NavigationDrawerView.swift
+++ b/Features/NavigationDrawerFeature/NavigationDrawerView.swift
@@ -7,6 +7,7 @@
 //
 
 import Localization
+import NoorUI
 import QuranAnnotations
 import QuranKit
 import QuranTextKit
@@ -113,95 +114,74 @@ private struct SurahListView: View {
         if suras.isEmpty {
             EmptySearchPlaceholder()
         } else {
-            List {
-                ForEach(suras) { sura in
-                    Button {
-                        viewModel.selectPage(sura.page)
-                    } label: {
-                        DrawerRow(
-                            leading: "\(sura.suraNumber)",
-                            title: sura.localizedName(withPrefix: false),
-                            subtitle: sura.isMakki
-                                ? l("navigation_drawer.surah.makki")
-                                : l("navigation_drawer.surah.madani"),
-                            isCurrent: sura.page == viewModel.currentPage
-                        )
-                    }
-                    .buttonStyle(.plain)
-                }
+            NoorList {
+                surahSections(suras: suras)
             }
-            .listStyle(.plain)
+        }
+    }
+
+    @ViewBuilder
+    private func surahSections(suras: [Sura]) -> some View {
+        let grouped = Dictionary(grouping: suras, by: { $0.page.startJuz })
+        let juzs = grouped.keys.sorted { $0.juzNumber < $1.juzNumber }
+        ForEach(juzs) { juz in
+            let items = (grouped[juz] ?? []).sorted { $0.suraNumber < $1.suraNumber }
+            NoorSection(title: juz.localizedName, items) { sura in
+                surahRow(sura: sura)
+            }
+        }
+    }
+
+    private func surahRow(sura: Sura) -> some View {
+        let ayahsString = lFormat("verses", table: .android, sura.verses.count)
+        let suraType = sura.isMakki ? lAndroid("makki") : lAndroid("madani")
+        return NoorListItem(
+            title: "\(sura.localizedName(withNumber: true)) \(sura: sura.arabicSuraName)",
+            subtitle: .init(text: "\(suraType) - \(ayahsString)", location: .bottom),
+            accessory: .text(NumberFormatter.shared.format(sura.page.pageNumber))
+        ) {
+            viewModel.selectPage(sura.page)
         }
     }
 }
 
-// MARK: - Juz list
+// MARK: - Juz list (quarters grouped by juz, matching the home page style)
 
 private struct JuzListView: View {
     @ObservedObject var viewModel: NavigationDrawerViewModel
 
     var body: some View {
-        let juzs = viewModel.filteredJuzs
-        if juzs.isEmpty {
+        let quarters = viewModel.filteredQuarters
+        if quarters.isEmpty {
             EmptySearchPlaceholder()
         } else {
-            List {
-                ForEach(juzs) { juz in
-                    Button {
-                        viewModel.selectPage(juz.page)
-                    } label: {
-                        DrawerRow(
-                            leading: "\(juz.juzNumber)",
-                            title: juz.localizedName,
-                            subtitle: nil,
-                            isCurrent: juz.page == viewModel.currentPage
-                        )
-                    }
-                    .buttonStyle(.plain)
-                }
+            NoorList {
+                quarterSections(quarters: quarters)
             }
-            .listStyle(.plain)
         }
     }
-}
 
-// MARK: - Row
-
-private struct DrawerRow: View {
-    let leading: String
-    let title: String
-    let subtitle: String?
-    let isCurrent: Bool
-
-    var body: some View {
-        HStack(spacing: 12) {
-            Text(leading)
-                .font(.system(size: 13, weight: .semibold, design: .rounded))
-                .foregroundColor(.secondary)
-                .frame(width: 32, alignment: .center)
-                .padding(.vertical, 4)
-                .background(Color(.secondarySystemBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundColor(.primary)
-                if let subtitle {
-                    Text(subtitle)
-                        .font(.system(size: 12))
-                        .foregroundColor(.secondary)
-                }
-            }
-            Spacer()
-            if isCurrent {
-                Image(systemName: "location.fill")
-                    .font(.system(size: 12))
-                    .foregroundColor(.accentColor)
+    @ViewBuilder
+    private func quarterSections(quarters: [Quarter]) -> some View {
+        let grouped = Dictionary(grouping: quarters, by: { $0.juz })
+        let juzs = grouped.keys.sorted { $0.juzNumber < $1.juzNumber }
+        ForEach(juzs) { juz in
+            let items = (grouped[juz] ?? []).sorted { $0.quarterNumber < $1.quarterNumber }
+            NoorSection(title: juz.localizedName, items) { quarter in
+                quarterRow(quarter: quarter)
             }
         }
-        .contentShape(Rectangle())
-        .padding(.vertical, 4)
+    }
+
+    private func quarterRow(quarter: Quarter) -> some View {
+        let ayah = quarter.firstVerse
+        let title: MultipartText = "\(quarter.localizedName) - \(ayah.localizedName) \(sura: ayah.sura.arabicSuraName)"
+        return NoorListItem(
+            title: title,
+            accessory: .text(NumberFormatter.shared.format(ayah.page.pageNumber))
+        ) {
+            viewModel.selectPage(ayah.page)
+        }
     }
 }
 
@@ -284,22 +264,23 @@ private struct BookmarksListView: View {
                     : l("navigation_drawer.empty.no_matching_bookmarks")
             )
         } else {
-            List {
-                ForEach(bookmarks) { bookmark in
-                    Button {
-                        viewModel.selectPage(bookmark.page)
-                    } label: {
-                        DrawerRow(
-                            leading: "\(bookmark.page.pageNumber)",
-                            title: bookmark.page.startSura.localizedName(withPrefix: false),
-                            subtitle: lFormat("navigation_drawer.bookmark.page", bookmark.page.pageNumber),
-                            isCurrent: bookmark.page == viewModel.currentPage
-                        )
+            NoorList {
+                NoorBasicSection {
+                    ForEach(bookmarks) { bookmark in
+                        let sura = bookmark.page.startSura
+                        NoorListItem(
+                            title: "\(sura.localizedName(withNumber: true)) \(sura: sura.arabicSuraName)",
+                            subtitle: .init(
+                                text: lFormat("navigation_drawer.bookmark.page", bookmark.page.pageNumber),
+                                location: .bottom
+                            ),
+                            accessory: .text(NumberFormatter.shared.format(bookmark.page.pageNumber))
+                        ) {
+                            viewModel.selectPage(bookmark.page)
+                        }
                     }
-                    .buttonStyle(.plain)
                 }
             }
-            .listStyle(.plain)
         }
     }
 }

--- a/Features/NavigationDrawerFeature/NavigationDrawerViewController.swift
+++ b/Features/NavigationDrawerFeature/NavigationDrawerViewController.swift
@@ -1,0 +1,53 @@
+//
+//  NavigationDrawerViewController.swift
+//  Quran
+//
+//  Created by Abdirizak Hassan on 4/25/26.
+//  Copyright © 2026 Quran.com. All rights reserved.
+//
+
+import SwiftUI
+import UIKit
+
+/// Hosts the in-reading navigation drawer (Surah / Juz / Notes / Bookmarks tabs).
+public final class NavigationDrawerViewController: UIViewController {
+    // MARK: - Lifecycle
+
+    init(viewModel: NavigationDrawerViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .custom
+        transitioningDelegate = sideTransition
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Internal
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+
+        let host = UIHostingController(rootView: NavigationDrawerView(viewModel: viewModel))
+        host.view.backgroundColor = .clear
+        addChild(host)
+        host.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(host.view)
+        NSLayoutConstraint.activate([
+            host.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            host.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            host.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            host.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        host.didMove(toParent: self)
+    }
+
+    // MARK: - Private
+
+    private let viewModel: NavigationDrawerViewModel
+    // Held strongly because the system retains it weakly.
+    private let sideTransition = NavigationDrawerSideTransition()
+}

--- a/Features/NavigationDrawerFeature/NavigationDrawerViewModel.swift
+++ b/Features/NavigationDrawerFeature/NavigationDrawerViewModel.swift
@@ -7,6 +7,7 @@
 //
 
 import Combine
+import Localization
 import QuranAnnotations
 import QuranKit
 import QuranTextKit
@@ -51,51 +52,79 @@ final class NavigationDrawerViewModel: ObservableObject {
 
     // MARK: - Filtering
 
-    /// Returns the surahs filtered by `searchText`. Matches against the
-    /// localized name and the surah number.
+    /// All searchable representations of a sura's name — English + Arabic,
+    /// with and without the "Surah" / "سورة" prefix, and the standalone
+    /// arabicSuraName. Lets users search regardless of UI locale or whether
+    /// they include the prefix.
+    private func suraSearchTerms(_ sura: Sura) -> [String] {
+        [
+            sura.localizedName(withPrefix: false, language: .english),
+            sura.localizedName(withPrefix: true, language: .english),
+            sura.localizedName(withPrefix: false, language: .arabic),
+            sura.localizedName(withPrefix: true, language: .arabic),
+            sura.arabicSuraName,
+        ].map { $0.lowercased() }
+    }
+
+    /// Returns the surahs filtered by `searchText`. Matches against any
+    /// English / Arabic name form (with or without prefix) and the surah
+    /// number.
     var filteredSuras: [Sura] {
         let query = searchText.trimmingCharacters(in: .whitespaces).lowercased()
         guard !query.isEmpty else { return quran.suras }
         return quran.suras.filter { sura in
-            sura.localizedName(withPrefix: false).lowercased().contains(query)
+            suraSearchTerms(sura).contains { $0.contains(query) }
                 || String(sura.suraNumber).contains(query)
         }
     }
 
-    /// Returns the quarters filtered by `searchText`. Matches against the
-    /// quarter's localized name (e.g. "Hizb 1, 1/4"), the parent juz number,
-    /// the starting sura's localized name, and the page number.
+    /// Returns the quarters filtered by `searchText`. Matches:
+    /// - the quarter's localized name (e.g. "Hizb 1, 1/4")
+    /// - the parent juz number
+    /// - the page number
+    /// - the starting sura's name (en/ar with/without prefix)
+    /// - any quarter whose page range overlaps a sura matching the query
+    ///   (so typing a mid-juz sura name like "Yaseen" still returns the
+    ///   quarters that contain it)
     var filteredQuarters: [Quarter] {
         let query = searchText.trimmingCharacters(in: .whitespaces).lowercased()
         guard !query.isEmpty else { return quran.quarters }
+
+        // Page ranges of suras whose names match the query.
+        let matchingSuraPageRanges: [(Int, Int)] = quran.suras
+            .filter { suraSearchTerms($0).contains { $0.contains(query) } }
+            .map { ($0.firstVerse.page.pageNumber, $0.lastVerse.page.pageNumber) }
+
         return quran.quarters.filter { quarter in
-            quarter.localizedName.lowercased().contains(query)
-                || quarter.firstVerse.sura.localizedName(withPrefix: false).lowercased().contains(query)
+            let page = quarter.firstVerse.page.pageNumber
+            return quarter.localizedName.lowercased().contains(query)
+                || suraSearchTerms(quarter.firstVerse.sura).contains { $0.contains(query) }
                 || String(quarter.juz.juzNumber).contains(query)
-                || String(quarter.firstVerse.page.pageNumber).contains(query)
+                || String(page).contains(query)
+                || matchingSuraPageRanges.contains { page >= $0.0 && page <= $0.1 }
         }
     }
 
-    /// Returns notes filtered by `searchText`. Matches the note text and the
-    /// localized sura name of the first verse.
+    /// Returns notes filtered by `searchText`. Matches the note text and any
+    /// name form of the first verse's sura.
     var filteredNotes: [Note] {
         let query = searchText.trimmingCharacters(in: .whitespaces).lowercased()
         let sorted = notes.sorted { $0.modifiedDate > $1.modifiedDate }
         guard !query.isEmpty else { return sorted }
         return sorted.filter { note in
             (note.note ?? "").lowercased().contains(query)
-                || note.firstVerse.sura.localizedName(withPrefix: false).lowercased().contains(query)
+                || suraSearchTerms(note.firstVerse.sura).contains { $0.contains(query) }
         }
     }
 
-    /// Returns bookmarks filtered by `searchText`. Matches the localized sura
-    /// name of the bookmarked page and the page number.
+    /// Returns bookmarks filtered by `searchText`. Matches any name form of
+    /// the bookmarked page's starting sura and the page number.
     var filteredBookmarks: [PageBookmark] {
         let query = searchText.trimmingCharacters(in: .whitespaces).lowercased()
         let sorted = pageBookmarks.sorted { $0.creationDate > $1.creationDate }
         guard !query.isEmpty else { return sorted }
         return sorted.filter { bookmark in
-            bookmark.page.startSura.localizedName(withPrefix: false).lowercased().contains(query)
+            suraSearchTerms(bookmark.page.startSura).contains { $0.contains(query) }
                 || String(bookmark.page.pageNumber).contains(query)
         }
     }

--- a/Features/NavigationDrawerFeature/NavigationDrawerViewModel.swift
+++ b/Features/NavigationDrawerFeature/NavigationDrawerViewModel.swift
@@ -1,0 +1,109 @@
+//
+//  NavigationDrawerViewModel.swift
+//  Quran
+//
+//  Created by Abdirizak Hassan on 4/25/26.
+//  Copyright © 2026 Quran.com. All rights reserved.
+//
+
+import Combine
+import QuranAnnotations
+import QuranKit
+import QuranTextKit
+import SwiftUI
+
+@MainActor
+final class NavigationDrawerViewModel: ObservableObject {
+    // MARK: - State
+
+    @Published var selectedTab: NavigationDrawerTab = .surah
+    @Published var searchText: String = ""
+
+    // MARK: - Inputs
+
+    let quran: Quran
+    let currentPage: Page
+    let notes: [Note]
+    let pageBookmarks: [PageBookmark]
+
+    // Callback fired when the user picks a destination. The presenter is
+    // responsible for dismissing the drawer and navigating the reading view.
+    let onSelectPage: (Page) -> Void
+    let onClose: () -> Void
+
+    // MARK: - Lifecycle
+
+    init(
+        quran: Quran,
+        currentPage: Page,
+        notes: [Note],
+        pageBookmarks: [PageBookmark],
+        onSelectPage: @escaping (Page) -> Void,
+        onClose: @escaping () -> Void
+    ) {
+        self.quran = quran
+        self.currentPage = currentPage
+        self.notes = notes
+        self.pageBookmarks = pageBookmarks
+        self.onSelectPage = onSelectPage
+        self.onClose = onClose
+    }
+
+    // MARK: - Filtering
+
+    /// Returns the surahs filtered by `searchText`. Matches against the
+    /// localized name and the surah number.
+    var filteredSuras: [Sura] {
+        let query = searchText.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !query.isEmpty else { return quran.suras }
+        return quran.suras.filter { sura in
+            sura.localizedName(withPrefix: false).lowercased().contains(query)
+                || String(sura.suraNumber).contains(query)
+        }
+    }
+
+    /// Returns the juzs filtered by `searchText`. Matches against the
+    /// localized name and the juz number.
+    var filteredJuzs: [Juz] {
+        let query = searchText.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !query.isEmpty else { return quran.juzs }
+        return quran.juzs.filter { juz in
+            juz.localizedName.lowercased().contains(query)
+                || String(juz.juzNumber).contains(query)
+        }
+    }
+
+    /// Returns notes filtered by `searchText`. Matches the note text and the
+    /// localized sura name of the first verse.
+    var filteredNotes: [Note] {
+        let query = searchText.trimmingCharacters(in: .whitespaces).lowercased()
+        let sorted = notes.sorted { $0.modifiedDate > $1.modifiedDate }
+        guard !query.isEmpty else { return sorted }
+        return sorted.filter { note in
+            (note.note ?? "").lowercased().contains(query)
+                || note.firstVerse.sura.localizedName(withPrefix: false).lowercased().contains(query)
+        }
+    }
+
+    /// Returns bookmarks filtered by `searchText`. Matches the localized sura
+    /// name of the bookmarked page and the page number.
+    var filteredBookmarks: [PageBookmark] {
+        let query = searchText.trimmingCharacters(in: .whitespaces).lowercased()
+        let sorted = pageBookmarks.sorted { $0.creationDate > $1.creationDate }
+        guard !query.isEmpty else { return sorted }
+        return sorted.filter { bookmark in
+            bookmark.page.startSura.localizedName(withPrefix: false).lowercased().contains(query)
+                || String(bookmark.page.pageNumber).contains(query)
+        }
+    }
+
+    // MARK: - Actions
+
+    func selectPage(_ page: Page) {
+        onSelectPage(page)
+    }
+
+    func close() {
+        onClose()
+    }
+}

--- a/Features/NavigationDrawerFeature/NavigationDrawerViewModel.swift
+++ b/Features/NavigationDrawerFeature/NavigationDrawerViewModel.swift
@@ -62,14 +62,17 @@ final class NavigationDrawerViewModel: ObservableObject {
         }
     }
 
-    /// Returns the juzs filtered by `searchText`. Matches against the
-    /// localized name and the juz number.
-    var filteredJuzs: [Juz] {
+    /// Returns the quarters filtered by `searchText`. Matches against the
+    /// quarter's localized name (e.g. "Hizb 1, 1/4"), the parent juz number,
+    /// the starting sura's localized name, and the page number.
+    var filteredQuarters: [Quarter] {
         let query = searchText.trimmingCharacters(in: .whitespaces).lowercased()
-        guard !query.isEmpty else { return quran.juzs }
-        return quran.juzs.filter { juz in
-            juz.localizedName.lowercased().contains(query)
-                || String(juz.juzNumber).contains(query)
+        guard !query.isEmpty else { return quran.quarters }
+        return quran.quarters.filter { quarter in
+            quarter.localizedName.lowercased().contains(query)
+                || quarter.firstVerse.sura.localizedName(withPrefix: false).lowercased().contains(query)
+                || String(quarter.juz.juzNumber).contains(query)
+                || String(quarter.firstVerse.page.pageNumber).contains(query)
         }
     }
 

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -104,6 +104,13 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     var allNotes: [Note] { notes }
     var allPageBookmarks: [PageBookmark] { pageBookmarks }
 
+    /// The page to highlight in the drawer. Falls back to the input's initial
+    /// page when `visiblePages` hasn't propagated yet (e.g. user opens drawer
+    /// immediately after entering from a recent).
+    var drawerCurrentPage: Page {
+        visiblePages.first ?? input.initialPage
+    }
+
     func navigateToPage(_ page: Page) {
         contentViewModel?.visiblePages = [page]
     }

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -98,6 +98,16 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
     var visiblePages: [Page] { contentViewModel?.visiblePages ?? [] }
 
+    // MARK: - Navigation drawer
+
+    var quran: Quran { deps.quran }
+    var allNotes: [Note] { notes }
+    var allPageBookmarks: [PageBookmark] { pageBookmarks }
+
+    func navigateToPage(_ page: Page) {
+        contentViewModel?.visiblePages = [page]
+    }
+
     func start() {
         deps.noteService.notes(quran: deps.quran)
             .receive(on: DispatchQueue.main)

--- a/Features/QuranViewFeature/QuranView.swift
+++ b/Features/QuranViewFeature/QuranView.swift
@@ -92,7 +92,16 @@ class QuranView: UIView, UIGestureRecognizerDelegate, UINavigationBarDelegate {
     }
 
     override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        gestureRecognizer != tapGesture || !isFirstResponder // dismiss bars only if not first responder
+        if gestureRecognizer == tapGesture {
+            // Don't intercept taps that land on the visible navigation bar —
+            // its titleView (or any bar button items) need to receive them.
+            let location = gestureRecognizer.location(in: self)
+            if !navigationBar.isHidden, navigationBar.alpha > 0, navigationBar.frame.contains(location) {
+                return false
+            }
+            return !isFirstResponder // dismiss bars only if not first responder
+        }
+        return true
     }
 
     // MARK: Private

--- a/Features/QuranViewFeature/QuranView.swift
+++ b/Features/QuranViewFeature/QuranView.swift
@@ -92,14 +92,18 @@ class QuranView: UIView, UIGestureRecognizerDelegate, UINavigationBarDelegate {
     }
 
     override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        if gestureRecognizer == tapGesture {
-            // Don't intercept taps that land on the visible navigation bar —
-            // its titleView (or any bar button items) need to receive them.
-            let location = gestureRecognizer.location(in: self)
-            if !navigationBar.isHidden, navigationBar.alpha > 0, navigationBar.frame.contains(location) {
-                return false
-            }
-            return !isFirstResponder // dismiss bars only if not first responder
+        gestureRecognizer != tapGesture || !isFirstResponder // dismiss bars only if not first responder
+    }
+
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        // Don't deliver taps on the visible navigation bar to the bar-toggle
+        // recognizer — the title view (and bar button items) need them.
+        if gestureRecognizer == tapGesture,
+           !navigationBar.isHidden,
+           navigationBar.alpha > 0,
+           navigationBar.frame.contains(touch.location(in: self))
+        {
+            return false
         }
         return true
     }

--- a/Features/QuranViewFeature/QuranView.swift
+++ b/Features/QuranViewFeature/QuranView.swift
@@ -85,7 +85,6 @@ class QuranView: UIView, UIGestureRecognizerDelegate, UINavigationBarDelegate {
 
     @objc
     func onViewTapped(_ sender: UITapGestureRecognizer) {
-        print("[NavDrawer] QuranView.onViewTapped fired (this should NOT happen for taps on the title)")
         if let audioView, audioView.bounds.contains(sender.location(in: audioView)), audioView.isUserInteractionEnabled {
             return
         }
@@ -99,11 +98,12 @@ class QuranView: UIView, UIGestureRecognizerDelegate, UINavigationBarDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         // Don't deliver taps on the visible navigation bar to the bar-toggle
         // recognizer — the title view (and bar button items) need them.
-        if gestureRecognizer == tapGesture {
-            let loc = touch.location(in: self)
-            let inBar = !navigationBar.isHidden && navigationBar.alpha > 0 && navigationBar.frame.contains(loc)
-            print("[NavDrawer] QuranView.shouldReceive touch loc=\(loc) navBar.frame=\(navigationBar.frame) hidden=\(navigationBar.isHidden) alpha=\(navigationBar.alpha) inBar=\(inBar) -> \(inBar ? "REJECT" : "accept")")
-            if inBar { return false }
+        if gestureRecognizer == tapGesture,
+           !navigationBar.isHidden,
+           navigationBar.alpha > 0,
+           navigationBar.frame.contains(touch.location(in: self))
+        {
+            return false
         }
         return true
     }

--- a/Features/QuranViewFeature/QuranView.swift
+++ b/Features/QuranViewFeature/QuranView.swift
@@ -85,6 +85,7 @@ class QuranView: UIView, UIGestureRecognizerDelegate, UINavigationBarDelegate {
 
     @objc
     func onViewTapped(_ sender: UITapGestureRecognizer) {
+        print("[NavDrawer] QuranView.onViewTapped fired (this should NOT happen for taps on the title)")
         if let audioView, audioView.bounds.contains(sender.location(in: audioView)), audioView.isUserInteractionEnabled {
             return
         }
@@ -98,12 +99,11 @@ class QuranView: UIView, UIGestureRecognizerDelegate, UINavigationBarDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         // Don't deliver taps on the visible navigation bar to the bar-toggle
         // recognizer — the title view (and bar button items) need them.
-        if gestureRecognizer == tapGesture,
-           !navigationBar.isHidden,
-           navigationBar.alpha > 0,
-           navigationBar.frame.contains(touch.location(in: self))
-        {
-            return false
+        if gestureRecognizer == tapGesture {
+            let loc = touch.location(in: self)
+            let inBar = !navigationBar.isHidden && navigationBar.alpha > 0 && navigationBar.frame.contains(loc)
+            print("[NavDrawer] QuranView.shouldReceive touch loc=\(loc) navBar.frame=\(navigationBar.frame) hidden=\(navigationBar.isHidden) alpha=\(navigationBar.alpha) inBar=\(inBar) -> \(inBar ? "REJECT" : "accept")")
+            if inBar { return false }
         }
         return true
     }

--- a/Features/QuranViewFeature/QuranViewController.swift
+++ b/Features/QuranViewFeature/QuranViewController.swift
@@ -20,6 +20,7 @@
 
 import Combine
 import Localization
+import NavigationDrawerFeature
 import NoorUI
 import QuranKit
 import QuranTextKit
@@ -82,10 +83,12 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         quranView?.delegate = self
 
         // set the custom title view
-        quranView?.navigationItem.titleView = TwoLineNavigationTitleView(
+        let titleView = TwoLineNavigationTitleView(
             firstLineFont: .boldSystemFont(ofSize: 15),
             secondLineFont: .systemFont(ofSize: 15, weight: .light)
         )
+        titleView.onTap = { [weak self] in self?.presentNavigationDrawer() }
+        quranView?.navigationItem.titleView = titleView
 
         let backImage: UIImage?
         backImage = UIImage(systemName: "chevron.backward")
@@ -386,5 +389,19 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
     @objc
     private func onMoreBarButtonTapped(_ barButton: UIBarButtonItem) {
         interactor.onMoreBarButtonTapped()
+    }
+
+    private func presentNavigationDrawer() {
+        guard let currentPage = interactor.visiblePages.first else { return }
+        let drawer = NavigationDrawerBuilder().build(
+            quran: interactor.quran,
+            currentPage: currentPage,
+            notes: interactor.allNotes,
+            pageBookmarks: interactor.allPageBookmarks,
+            onSelectPage: { [weak self] page in
+                self?.interactor.navigateToPage(page)
+            }
+        )
+        present(drawer, animated: true)
     }
 }

--- a/Features/QuranViewFeature/QuranViewController.swift
+++ b/Features/QuranViewFeature/QuranViewController.swift
@@ -87,12 +87,8 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
             firstLineFont: .boldSystemFont(ofSize: 15),
             secondLineFont: .systemFont(ofSize: 15, weight: .light)
         )
-        titleView.onTap = { [weak self] in
-            print("[NavDrawer] titleView.onTap closure fired")
-            self?.presentNavigationDrawer()
-        }
+        titleView.onTap = { [weak self] in self?.presentNavigationDrawer() }
         quranView?.navigationItem.titleView = titleView
-        print("[NavDrawer] QuranViewController viewDidLoad: titleView installed at \(titleView)")
 
         let backImage: UIImage?
         backImage = UIImage(systemName: "chevron.backward")
@@ -396,7 +392,6 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
     }
 
     private func presentNavigationDrawer() {
-        print("[NavDrawer] presentNavigationDrawer called; visiblePages=\(interactor.visiblePages.map(\.pageNumber)) drawerCurrentPage=\(interactor.drawerCurrentPage.pageNumber)")
         let drawer = NavigationDrawerBuilder().build(
             quran: interactor.quran,
             currentPage: interactor.drawerCurrentPage,
@@ -406,8 +401,6 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
                 self?.interactor.navigateToPage(page)
             }
         )
-        present(drawer, animated: true) {
-            print("[NavDrawer] drawer presented")
-        }
+        present(drawer, animated: true)
     }
 }

--- a/Features/QuranViewFeature/QuranViewController.swift
+++ b/Features/QuranViewFeature/QuranViewController.swift
@@ -392,10 +392,9 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
     }
 
     private func presentNavigationDrawer() {
-        guard let currentPage = interactor.visiblePages.first else { return }
         let drawer = NavigationDrawerBuilder().build(
             quran: interactor.quran,
-            currentPage: currentPage,
+            currentPage: interactor.drawerCurrentPage,
             notes: interactor.allNotes,
             pageBookmarks: interactor.allPageBookmarks,
             onSelectPage: { [weak self] page in

--- a/Features/QuranViewFeature/QuranViewController.swift
+++ b/Features/QuranViewFeature/QuranViewController.swift
@@ -87,8 +87,12 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
             firstLineFont: .boldSystemFont(ofSize: 15),
             secondLineFont: .systemFont(ofSize: 15, weight: .light)
         )
-        titleView.onTap = { [weak self] in self?.presentNavigationDrawer() }
+        titleView.onTap = { [weak self] in
+            print("[NavDrawer] titleView.onTap closure fired")
+            self?.presentNavigationDrawer()
+        }
         quranView?.navigationItem.titleView = titleView
+        print("[NavDrawer] QuranViewController viewDidLoad: titleView installed at \(titleView)")
 
         let backImage: UIImage?
         backImage = UIImage(systemName: "chevron.backward")
@@ -392,6 +396,7 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
     }
 
     private func presentNavigationDrawer() {
+        print("[NavDrawer] presentNavigationDrawer called; visiblePages=\(interactor.visiblePages.map(\.pageNumber)) drawerCurrentPage=\(interactor.drawerCurrentPage.pageNumber)")
         let drawer = NavigationDrawerBuilder().build(
             quran: interactor.quran,
             currentPage: interactor.drawerCurrentPage,
@@ -401,6 +406,8 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
                 self?.interactor.navigateToPage(page)
             }
         )
-        present(drawer, animated: true)
+        present(drawer, animated: true) {
+            print("[NavDrawer] drawer presented")
+        }
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -711,6 +711,7 @@ private func featuresTargets() -> [[Target]] {
 
         target(type, name: "NavigationDrawerFeature", hasTests: false, dependencies: [
             "Localization",
+            "NoorUI",
             "QuranKit",
             "QuranAnnotations",
             "QuranTextKit",

--- a/Package.swift
+++ b/Package.swift
@@ -709,11 +709,20 @@ private func featuresTargets() -> [[Target]] {
             "Preferences",
         ]),
 
+        target(type, name: "NavigationDrawerFeature", hasTests: false, dependencies: [
+            "Localization",
+            "QuranKit",
+            "QuranAnnotations",
+            "QuranTextKit",
+            "UIx",
+        ]),
+
         target(type, name: "QuranViewFeature", hasTests: false, dependencies: [
             "AudioBannerFeature",
             "QuranContentFeature",
             "AyahMenuFeature",
             "MoreMenuFeature",
+            "NavigationDrawerFeature",
             "NoteEditorFeature",
             "WordPointerFeature",
             "TranslationsFeature",

--- a/UI/UIx/UIKit/Views/TwoLineNavigationTitleView.swift
+++ b/UI/UIx/UIKit/Views/TwoLineNavigationTitleView.swift
@@ -32,6 +32,11 @@ public class TwoLineNavigationTitleView: UIView {
         didSet { updateAttributedText() }
     }
 
+    /// Called when the title is tapped. Setting this enables a tap gesture; clearing it removes it.
+    public var onTap: (() -> Void)? {
+        didSet { updateTapGesture() }
+    }
+
     override public var intrinsicContentSize: CGSize {
         label.attributedText?.size() ?? .zero
     }
@@ -52,6 +57,8 @@ public class TwoLineNavigationTitleView: UIView {
         didSet { updateAttributedText() }
     }
 
+    private var tapGesture: UITapGestureRecognizer?
+
     private func setUp() {
         label.numberOfLines = 0
         label.textAlignment = .center
@@ -59,6 +66,23 @@ public class TwoLineNavigationTitleView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         addAutoLayoutSubview(label)
         label.vc.center()
+    }
+
+    private func updateTapGesture() {
+        if onTap != nil, tapGesture == nil {
+            let gesture = UITapGestureRecognizer(target: self, action: #selector(handleTap))
+            addGestureRecognizer(gesture)
+            isUserInteractionEnabled = true
+            tapGesture = gesture
+        } else if onTap == nil, let tapGesture {
+            removeGestureRecognizer(tapGesture)
+            self.tapGesture = nil
+        }
+    }
+
+    @objc
+    private func handleTap() {
+        onTap?()
     }
 
     private func updateIsCompressed(_ size: CGSize? = nil) {

--- a/UI/UIx/UIKit/Views/TwoLineNavigationTitleView.swift
+++ b/UI/UIx/UIKit/Views/TwoLineNavigationTitleView.swift
@@ -74,6 +74,7 @@ public class TwoLineNavigationTitleView: UIView {
             addGestureRecognizer(gesture)
             isUserInteractionEnabled = true
             tapGesture = gesture
+            print("[NavDrawer] TwoLineNavigationTitleView tap gesture installed; isUserInteractionEnabled=\(isUserInteractionEnabled)")
         } else if onTap == nil, let tapGesture {
             removeGestureRecognizer(tapGesture)
             self.tapGesture = nil
@@ -82,6 +83,7 @@ public class TwoLineNavigationTitleView: UIView {
 
     @objc
     private func handleTap() {
+        print("[NavDrawer] TwoLineNavigationTitleView.handleTap fired; onTap=\(onTap != nil ? "set" : "nil")")
         onTap?()
     }
 

--- a/UI/UIx/UIKit/Views/TwoLineNavigationTitleView.swift
+++ b/UI/UIx/UIKit/Views/TwoLineNavigationTitleView.swift
@@ -46,6 +46,17 @@ public class TwoLineNavigationTitleView: UIView {
         updateIsCompressed()
     }
 
+    override public func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        // When a tap handler is set, expand the hit area so taps reliably
+        // register even if the navigation bar lays this view out tighter than
+        // its visible label.
+        if onTap != nil {
+            let expanded = bounds.insetBy(dx: -60, dy: -12)
+            if expanded.contains(point) { return true }
+        }
+        return super.point(inside: point, with: event)
+    }
+
     // MARK: Private
 
     private let label = UILabel()
@@ -58,6 +69,7 @@ public class TwoLineNavigationTitleView: UIView {
     }
 
     private var tapGesture: UITapGestureRecognizer?
+    private var didInvalidateOnFirstNonEmptyText = false
 
     private func setUp() {
         label.numberOfLines = 0
@@ -74,7 +86,6 @@ public class TwoLineNavigationTitleView: UIView {
             addGestureRecognizer(gesture)
             isUserInteractionEnabled = true
             tapGesture = gesture
-            print("[NavDrawer] TwoLineNavigationTitleView tap gesture installed; isUserInteractionEnabled=\(isUserInteractionEnabled)")
         } else if onTap == nil, let tapGesture {
             removeGestureRecognizer(tapGesture)
             self.tapGesture = nil
@@ -83,7 +94,6 @@ public class TwoLineNavigationTitleView: UIView {
 
     @objc
     private func handleTap() {
-        print("[NavDrawer] TwoLineNavigationTitleView.handleTap fired; onTap=\(onTap != nil ? "set" : "nil")")
         onTap?()
     }
 
@@ -106,6 +116,15 @@ public class TwoLineNavigationTitleView: UIView {
             .font: secondLineFont,
         ]))
         label.attributedText = string
+        // Invalidate ONCE, the first time the text becomes non-empty. Without
+        // this, the navigation bar keeps the zero-sized layout it computed
+        // when this view was instantiated with empty text, and hit-testing
+        // misses the title view. Skipping subsequent invalidations keeps
+        // page-changes cheap (no UINavigationBar relayout per swipe).
+        if !didInvalidateOnFirstNonEmptyText, !firstLine.isEmpty || !secondLine.isEmpty {
+            didInvalidateOnFirstNonEmptyText = true
+            invalidateIntrinsicContentSize()
+        }
     }
 }
 


### PR DESCRIPTION
Closes #794                                                                                              
                                                                                                           
  ## What it does                                                                                          
                                                                                                           
  Adds a side-sheet you open by **tapping the title in the reading nav bar**. From there you can jump to   
  any:                                                                                                     
                                        
  - **Surah** (114, grouped by juz)                                                                        
  - **Juz / quarter** (240 quarters, same layout as Home)                                                  
  - **Note** (your saved notes)                                                
  - **Bookmark** (your bookmarked pages)                                                                   
                                                                                                           
  …with a search field that filters the active tab.                             
                                                                                                           
  ## Why                                                          
                                                                                                           
  Today, switching surahs or checking a note means backing out of the reading view to the main tabs and    
  re-entering — interrupting the reading flow. The drawer keeps you in context: tap title → pick           
  destination → keep reading.                                                                              
                                                                  
  ## How                                                                                                   
   
  - New `NavigationDrawerFeature` SPM target. Drawer is built only when the title is tapped — nothing new  
  runs on the reading / scrolling path.                                         
  - Reuses `NoorList` / `NoorListItem` so rows look the same as the Home tab.
  - Strings added to all 16 locales (`en`/`ar` hand-written, the rest AI-translated and labelled per the
  repo's existing convention).                                                                             
                                                                                
  ## Demo                                                                                                  
                                                                                                           
  > Uploading iPhone 16E Screen Recording Apr 25 2026.mp4…

                                                                  
                                                                                                           
  ## Tested                                                                                                
                                                                                                           
  - First-tap from cold start, recents, surah list, and juz list → drawer opens reliably
  - Search filters each tab                                                                                
  - Selecting a destination navigates and dismisses the drawer                  
  - RTL + dark mode both look right                                                                        
                                                                               
  Happy to address feedback. 🙏 