### PR TITLE
Add sync notes UI behavior

### DIFF
--- a/Features/AppStructureFeature/Tabs/NotesTab.swift
+++ b/Features/AppStructureFeature/Tabs/NotesTab.swift
@@ -16,10 +16,29 @@ struct NotesTabBuilder: TabBuildable {
     let container: AppDependencies
 
     func build() -> UIViewController {
-        let interactor = NotesTabInteractor(
-            quranBuilder: QuranBuilder(container: container),
-            notesBuilder: NotesBuilder(container: container)
-        )
+        let notesBuilder = NotesBuilder(container: container)
+
+        #if QURAN_SYNC
+            let interactor: NotesTabInteractor = if container.notesSyncService != nil, container.syncService != nil {
+                NotesTabInteractor(
+                    quranBuilder: QuranBuilder(container: container),
+                    notesBuilder: notesBuilder,
+                    syncedNotesBuilder: SyncedNotesBuilder(container: container)
+                )
+            } else {
+                NotesTabInteractor(
+                    quranBuilder: QuranBuilder(container: container),
+                    notesBuilder: notesBuilder,
+                    syncedNotesBuilder: nil
+                )
+            }
+        #else
+            let interactor = NotesTabInteractor(
+                quranBuilder: QuranBuilder(container: container),
+                notesBuilder: notesBuilder
+            )
+        #endif
+
         let viewController = NotesTabViewController(interactor: interactor)
         viewController.navigationBar.prefersLargeTitles = true
         return viewController
@@ -29,21 +48,51 @@ struct NotesTabBuilder: TabBuildable {
 private final class NotesTabInteractor: TabInteractor {
     // MARK: Lifecycle
 
-    init(quranBuilder: QuranBuilder, notesBuilder: NotesBuilder) {
+    init(
+        quranBuilder: QuranBuilder,
+        notesBuilder: NotesBuilder
+    ) {
         self.notesBuilder = notesBuilder
+        #if QURAN_SYNC
+            syncedNotesBuilder = nil
+        #endif
         super.init(quranBuilder: quranBuilder)
     }
+
+    #if QURAN_SYNC
+        init(
+            quranBuilder: QuranBuilder,
+            notesBuilder: NotesBuilder,
+            syncedNotesBuilder: SyncedNotesBuilder?
+        ) {
+            self.syncedNotesBuilder = syncedNotesBuilder
+            self.notesBuilder = notesBuilder
+            super.init(quranBuilder: quranBuilder)
+        }
+    #endif
 
     // MARK: Internal
 
     override func start() {
-        let rootViewController = notesBuilder.build(withListener: self)
+        #if QURAN_SYNC
+            let rootViewController: UIViewController = if let syncedNotesBuilder {
+                syncedNotesBuilder.build(withListener: self)
+            } else {
+                notesBuilder.build(withListener: self)
+            }
+        #else
+            let rootViewController = notesBuilder.build(withListener: self)
+        #endif
+
         presenter?.setViewControllers([rootViewController], animated: false)
     }
 
     // MARK: Private
 
     private let notesBuilder: NotesBuilder
+    #if QURAN_SYNC
+        private let syncedNotesBuilder: SyncedNotesBuilder?
+    #endif
 }
 
 private class NotesTabViewController: TabViewController {

--- a/Features/AyahMenuFeature/SyncedAyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/SyncedAyahMenuBuilder.swift
@@ -15,7 +15,7 @@
             sourceView: UIView,
             pointInView: CGPoint,
             verses: [AyahNumber],
-            notes: [QuranAnnotations.Note],
+            notes: [SyncedNoteReference],
             syncHighlightColor: HighlightColor?,
             hasSyncHighlight: Bool
         ) {
@@ -32,7 +32,7 @@
         let sourceView: UIView
         let pointInView: CGPoint
         let verses: [AyahNumber]
-        let notes: [QuranAnnotations.Note]
+        let notes: [SyncedNoteReference]
         let syncHighlightColor: HighlightColor?
         let hasSyncHighlight: Bool
     }

--- a/Features/AyahMenuFeature/SyncedAyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/SyncedAyahMenuViewModel.swift
@@ -15,6 +15,8 @@
     @MainActor
     public protocol SyncedAyahMenuListener: AyahMenuListener {
         func deleteSyncHighlights(_ verses: [AyahNumber]) async
+        func deleteSyncedNotes(_ notes: [SyncedNoteReference], verses: [AyahNumber]) async
+        func editSyncedNote(_ note: SyncedNoteReference)
     }
 
     @MainActor
@@ -23,7 +25,7 @@
             let sourceView: UIView
             let pointInView: CGPoint
             let verses: [AyahNumber]
-            let notes: [QuranAnnotations.Note]
+            let notes: [SyncedNoteReference]
             let syncHighlightColor: HighlightColor?
             let hasSyncHighlight: Bool
             let syncService: SyncService?
@@ -74,7 +76,7 @@
         }
 
         var hasNoteText: Bool {
-            deps.notes.contains { !(($0.note ?? "").isEmpty) }
+            deps.notes.contains { !$0.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
         }
 
         var canDeleteHighlight: Bool {
@@ -111,15 +113,15 @@
         func deleteNote() async {
             logger.info("AyahMenu: delete note. Verses: \(deps.verses)")
             listener?.dismissAyahMenu()
-            await listener?.deleteNotes(deps.notes, verses: deps.verses)
+            await listener?.deleteSyncedNotes(deps.notes, verses: deps.verses)
         }
 
         func editNote() async {
             logger.info("AyahMenu: edit notes. Verses: \(deps.verses)")
-            if let note = deps.notes.first(where: { !(($0.note ?? "").isEmpty) }) {
-                listener?.editNote(note)
+            if let note = deps.notes.first(where: { !$0.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) {
+                listener?.editSyncedNote(note)
             } else {
-                listener?.editNote(newLocalNoteDraft())
+                listener?.editSyncedNote(newSyncedNoteDraft())
             }
         }
 
@@ -172,23 +174,13 @@
         private let audioPreferences = AudioPreferences.shared
         private let deps: Deps
 
-        private func newLocalNoteDraft() -> QuranAnnotations.Note {
-            QuranAnnotations.Note(
-                verses: Set(deps.verses),
-                modifiedDate: Date(),
-                note: nil,
-                color: noteColor(from: highlightingColor)
+        private func newSyncedNoteDraft() -> SyncedNoteReference {
+            SyncedNoteReference(
+                localId: nil,
+                body: "",
+                verses: deps.verses,
+                modifiedDate: Date()
             )
-        }
-
-        private func noteColor(from color: HighlightColor) -> QuranAnnotations.Note.Color {
-            switch color {
-            case .red: .red
-            case .green: .green
-            case .blue: .blue
-            case .yellow: .yellow
-            case .purple: .purple
-            }
         }
 
         private func retrieveSelectedAyahText() async throws -> [String] {

--- a/Features/FeaturesSupport/DisplayVerseTextRetriever.swift
+++ b/Features/FeaturesSupport/DisplayVerseTextRetriever.swift
@@ -1,0 +1,24 @@
+#if QURAN_SYNC
+    import Foundation
+    import Localization
+    import QuranKit
+    import QuranTextKit
+
+    public struct DisplayVerseTextRetriever {
+        public init(databasesURL: URL, quranFileURL: URL) {
+            textService = QuranTextDataService(databasesURL: databasesURL, quranFileURL: quranFileURL)
+        }
+
+        public func textForVerses(_ verses: [AyahNumber]) async throws -> String {
+            let verseTexts = try await textService.textForVerses(verses, translations: [])
+            let sortedVerses = verses.sorted()
+            return sortedVerses
+                .compactMap { verse in
+                    verseTexts[verse].map { $0.arabicText + " \(NumberFormatter.arabicNumberFormatter.format(verse.ayah))" }
+                }
+                .joined(separator: " ")
+        }
+
+        private let textService: QuranTextDataService
+    }
+#endif

--- a/Features/FeaturesSupport/SyncedNoteReference.swift
+++ b/Features/FeaturesSupport/SyncedNoteReference.swift
@@ -1,0 +1,74 @@
+#if QURAN_SYNC
+    import Foundation
+    import MobileSync
+    import QuranAnnotations
+    import QuranKit
+
+    public struct SyncedNoteReference: Identifiable, Equatable, Sendable {
+        public init(localId: String?, body: String, verses: [AyahNumber], modifiedDate: Date) {
+            self.localId = localId
+            self.body = body
+            self.verses = verses
+            self.modifiedDate = modifiedDate
+        }
+
+        public var id: String {
+            localId ?? verses.map { "\($0.sura.suraNumber):\($0.ayah)" }.joined(separator: "-")
+        }
+
+        public let localId: String?
+        public let body: String
+        public let verses: [AyahNumber]
+        public let modifiedDate: Date
+
+        public var firstVerse: AyahNumber? {
+            verses.first
+        }
+
+        public var versesSet: Set<AyahNumber> {
+            Set(verses)
+        }
+
+        public func highlightColor(in colorsByVerse: [AyahNumber: HighlightColor]) -> HighlightColor? {
+            let colors = Set(verses.compactMap { colorsByVerse[$0] })
+            guard colors.count == 1 else {
+                return nil
+            }
+            return colors.first
+        }
+
+        public static func makeAll(from notes: [Note_], quran: Quran) -> [SyncedNoteReference] {
+            let lookup = ayahLookup(for: quran)
+            return notes.compactMap { note in
+                makeReference(from: note, lookup: lookup)
+            }
+        }
+
+        private static func makeReference(from note: Note_, lookup: [Int64: AyahNumber]) -> SyncedNoteReference? {
+            let verses = Array(note.startAyahId ... note.endAyahId).compactMap { lookup[$0] }
+            guard !verses.isEmpty else {
+                return nil
+            }
+
+            return SyncedNoteReference(
+                localId: note.localId,
+                body: note.body,
+                verses: verses,
+                modifiedDate: note.lastUpdated
+            )
+        }
+
+        private static func ayahLookup(for quran: Quran) -> [Int64: AyahNumber] {
+            var lookup: [Int64: AyahNumber] = [:]
+            for sura in quran.suras {
+                for verse in sura.verses {
+                    let suraNumber = sura.suraNumber
+                    let ayah = AyahNumber(quran: quran, sura: suraNumber, ayah: verse.ayah)!
+                    let ayahId = Int64(QuranData.shared.getAyahId(sura: Int32(suraNumber), ayah: Int32(verse.ayah)))
+                    lookup[ayahId] = ayah
+                }
+            }
+            return lookup
+        }
+    }
+#endif

--- a/Features/NoteEditorFeature/SyncedNoteEditorBuilder.swift
+++ b/Features/NoteEditorFeature/SyncedNoteEditorBuilder.swift
@@ -1,0 +1,31 @@
+#if QURAN_SYNC
+    import AppDependencies
+    import FeaturesSupport
+    import QuranTextKit
+    import UIKit
+
+    @MainActor
+    public struct SyncedNoteEditorBuilder {
+        public init(container: AppDependencies) {
+            self.container = container
+        }
+
+        public func build(withListener listener: NoteEditorListener, note: SyncedNoteReference) -> UIViewController {
+            let textRetriever = ShareableVerseTextRetriever(
+                databasesURL: container.databasesURL,
+                quranFileURL: container.quranUthmaniV2Database
+            )
+            let guardService = container.notesSyncService
+            let viewModel = SyncedNoteEditorInteractor(
+                notesSyncService: guardService,
+                textRetriever: textRetriever,
+                note: note
+            )
+            let viewController = SyncedNoteEditorViewController(viewModel: viewModel)
+            viewModel.listener = listener
+            return viewController
+        }
+
+        let container: AppDependencies
+    }
+#endif

--- a/Features/NoteEditorFeature/SyncedNoteEditorBuilder.swift
+++ b/Features/NoteEditorFeature/SyncedNoteEditorBuilder.swift
@@ -1,7 +1,6 @@
 #if QURAN_SYNC
     import AppDependencies
     import FeaturesSupport
-    import QuranTextKit
     import UIKit
 
     @MainActor
@@ -11,14 +10,13 @@
         }
 
         public func build(withListener listener: NoteEditorListener, note: SyncedNoteReference) -> UIViewController {
-            let textRetriever = ShareableVerseTextRetriever(
+            let displayTextRetriever = DisplayVerseTextRetriever(
                 databasesURL: container.databasesURL,
                 quranFileURL: container.quranUthmaniV2Database
             )
-            let guardService = container.notesSyncService
             let viewModel = SyncedNoteEditorInteractor(
-                notesSyncService: guardService,
-                textRetriever: textRetriever,
+                notesSyncService: container.notesSyncService,
+                textRetriever: displayTextRetriever,
                 note: note
             )
             let viewController = SyncedNoteEditorViewController(viewModel: viewModel)

--- a/Features/NoteEditorFeature/SyncedNoteEditorInteractor.swift
+++ b/Features/NoteEditorFeature/SyncedNoteEditorInteractor.swift
@@ -1,11 +1,8 @@
 #if QURAN_SYNC
-    import Crashing
     import FeaturesSupport
     import Foundation
     import MobileSyncSupport
     import NoorUI
-    import QuranAnnotations
-    import QuranTextKit
     import VLogging
 
     @MainActor
@@ -14,7 +11,7 @@
 
         init(
             notesSyncService: NotesSyncService?,
-            textRetriever: ShareableVerseTextRetriever,
+            textRetriever: DisplayVerseTextRetriever,
             note: SyncedNoteReference
         ) {
             self.notesSyncService = notesSyncService
@@ -35,59 +32,51 @@
         }
 
         func fetchNote() async throws -> EditableNote {
-            do {
-                let versesText = try await textRetriever.textForVerses(note.verses)
-                let editableNote = EditableNote(
-                    ayahText: versesText.joined(separator: "\n"),
-                    modifiedSince: note.modifiedDate.timeAgo(),
-                    selectedColor: .red,
-                    note: note.body
-                )
-                self.editableNote = editableNote
-                logger.info("SyncedNoteEditor: note loaded")
-                return editableNote
-            } catch {
-                crasher.recordError(error, reason: "Failed to retrieve sync note text")
-                throw error
-            }
+            let versesText = try await textRetriever.textForVerses(note.verses)
+            let editableNote = EditableNote(
+                ayahText: versesText,
+                modifiedSince: note.modifiedDate.timeAgo(),
+                selectedColor: .red,
+                note: note.body
+            )
+            self.editableNote = editableNote
+            logger.info("SyncedNoteEditor: note loaded")
+            return editableNote
         }
 
-        func commitEditsAndExist() async {
+        func commitEditsAndExit() async throws {
             logger.info("SyncedNoteEditor: done tapped")
             let body = (editableNote?.note ?? note.body).trimmingCharacters(in: .whitespacesAndNewlines)
-            do {
-                if body.isEmpty {
-                    if let localId = note.localId {
-                        try await notesSyncService?.removeNote(localId: localId)
-                    }
-                } else if let localId = note.localId {
-                    try await notesSyncService?.updateNote(localId: localId, body: body, verses: note.versesSet)
-                } else {
-                    try await notesSyncService?.createNote(body: body, verses: note.versesSet)
-                }
-                logger.info("SyncedNoteEditor: note saved")
-                listener?.dismissNoteEditor()
-            } catch {
-                crasher.recordError(error, reason: "Failed to save sync note")
-            }
-        }
-
-        func forceDelete() async {
-            logger.info("SyncedNoteEditor: force delete note")
-            do {
+            if body.isEmpty {
                 if let localId = note.localId {
                     try await notesSyncService?.removeNote(localId: localId)
                 }
-                listener?.dismissNoteEditor()
-            } catch {
-                crasher.recordError(error, reason: "Failed to delete sync note")
+            } else if let localId = note.localId {
+                if let startVerse = note.verses.first, let endVerse = note.verses.last {
+                    try await notesSyncService?.updateNote(localId: localId, body: body, startVerse: startVerse, endVerse: endVerse)
+                }
+            } else {
+                if let startVerse = note.verses.first, let endVerse = note.verses.last {
+                    try await notesSyncService?.createNote(body: body, startVerse: startVerse, endVerse: endVerse)
+                }
             }
+
+            logger.info("SyncedNoteEditor: note saved")
+            listener?.dismissNoteEditor()
+        }
+
+        func forceDelete() async throws {
+            logger.info("SyncedNoteEditor: force delete note")
+            if let localId = note.localId {
+                try await notesSyncService?.removeNote(localId: localId)
+            }
+            listener?.dismissNoteEditor()
         }
 
         // MARK: Private
 
         private let notesSyncService: NotesSyncService?
-        private let textRetriever: ShareableVerseTextRetriever
+        private let textRetriever: DisplayVerseTextRetriever
         private let note: SyncedNoteReference
 
         private var editableNote: EditableNote?

--- a/Features/NoteEditorFeature/SyncedNoteEditorInteractor.swift
+++ b/Features/NoteEditorFeature/SyncedNoteEditorInteractor.swift
@@ -1,0 +1,95 @@
+#if QURAN_SYNC
+    import Crashing
+    import FeaturesSupport
+    import Foundation
+    import MobileSyncSupport
+    import NoorUI
+    import QuranAnnotations
+    import QuranTextKit
+    import VLogging
+
+    @MainActor
+    final class SyncedNoteEditorInteractor {
+        // MARK: Lifecycle
+
+        init(
+            notesSyncService: NotesSyncService?,
+            textRetriever: ShareableVerseTextRetriever,
+            note: SyncedNoteReference
+        ) {
+            self.notesSyncService = notesSyncService
+            self.textRetriever = textRetriever
+            self.note = note
+        }
+
+        // MARK: Internal
+
+        weak var listener: NoteEditorListener?
+
+        var isEditedNote: Bool {
+            !(editableNote?.note ?? note.body).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        var hasPersistedNote: Bool {
+            note.localId != nil
+        }
+
+        func fetchNote() async throws -> EditableNote {
+            do {
+                let versesText = try await textRetriever.textForVerses(note.verses)
+                let editableNote = EditableNote(
+                    ayahText: versesText.joined(separator: "\n"),
+                    modifiedSince: note.modifiedDate.timeAgo(),
+                    selectedColor: .red,
+                    note: note.body
+                )
+                self.editableNote = editableNote
+                logger.info("SyncedNoteEditor: note loaded")
+                return editableNote
+            } catch {
+                crasher.recordError(error, reason: "Failed to retrieve sync note text")
+                throw error
+            }
+        }
+
+        func commitEditsAndExist() async {
+            logger.info("SyncedNoteEditor: done tapped")
+            let body = (editableNote?.note ?? note.body).trimmingCharacters(in: .whitespacesAndNewlines)
+            do {
+                if body.isEmpty {
+                    if let localId = note.localId {
+                        try await notesSyncService?.removeNote(localId: localId)
+                    }
+                } else if let localId = note.localId {
+                    try await notesSyncService?.updateNote(localId: localId, body: body, verses: note.versesSet)
+                } else {
+                    try await notesSyncService?.createNote(body: body, verses: note.versesSet)
+                }
+                logger.info("SyncedNoteEditor: note saved")
+                listener?.dismissNoteEditor()
+            } catch {
+                crasher.recordError(error, reason: "Failed to save sync note")
+            }
+        }
+
+        func forceDelete() async {
+            logger.info("SyncedNoteEditor: force delete note")
+            do {
+                if let localId = note.localId {
+                    try await notesSyncService?.removeNote(localId: localId)
+                }
+                listener?.dismissNoteEditor()
+            } catch {
+                crasher.recordError(error, reason: "Failed to delete sync note")
+            }
+        }
+
+        // MARK: Private
+
+        private let notesSyncService: NotesSyncService?
+        private let textRetriever: ShareableVerseTextRetriever
+        private let note: SyncedNoteReference
+
+        private var editableNote: EditableNote?
+    }
+#endif

--- a/Features/NoteEditorFeature/SyncedNoteEditorViewController.swift
+++ b/Features/NoteEditorFeature/SyncedNoteEditorViewController.swift
@@ -1,4 +1,5 @@
 #if QURAN_SYNC
+    import Combine
     import NoorUI
     import SwiftUI
     import UIKit
@@ -33,19 +34,30 @@
                     let note = try await viewModel.fetchNote()
                     setNote(note)
                 } catch {
+                    showErrorAlert(error: error)
                 }
             }
         }
 
         func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+            guard !isCompleting else {
+                return
+            }
             done()
         }
 
         // MARK: Private
 
         private let viewModel: SyncedNoteEditorInteractor
+        private var currentNote: EditableNote?
+        private var doneButton: UIBarButtonItem?
+        private var noteCancellable: AnyCancellable?
+        private var isCompleting = false
 
         private func setNote(_ note: EditableNote) {
+            currentNote = note
+            observe(note)
+
             let noteEditor = NoteEditorView(
                 note: note,
                 done: { [weak self] in self?.done() },
@@ -55,12 +67,14 @@
             let viewController = UIHostingController(rootView: noteEditor)
             let navigationController = buildNavigationController(rootViewController: viewController, note: note)
             addFullScreenChild(navigationController)
+            updateDoneButtonState()
         }
 
         private func buildNavigationController(rootViewController: UIViewController, note: EditableNote) -> UINavigationController {
             let modifiedText = UIBarButtonItem(title: note.modifiedSince, style: .plain, target: nil, action: nil)
             modifiedText.isEnabled = false
             let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneTapped))
+            self.doneButton = doneButton
 
             rootViewController.navigationItem.largeTitleDisplayMode = .never
             rootViewController.navigationItem.leftBarButtonItem = modifiedText
@@ -69,14 +83,37 @@
             return UINavigationController(rootViewController: rootViewController)
         }
 
+        private func observe(_ note: EditableNote) {
+            noteCancellable = note.objectWillChange.sink { [weak self] in
+                DispatchQueue.main.async {
+                    self?.updateDoneButtonState()
+                }
+            }
+        }
+
+        private func updateDoneButtonState() {
+            let trimmedText = currentNote?.note.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            doneButton?.isEnabled = !trimmedText.isEmpty
+        }
+
         @objc
         private func doneTapped() {
             done()
         }
 
         private func done() {
+            guard !isCompleting else {
+                return
+            }
+            isCompleting = true
+
             Task {
-                await viewModel.commitEditsAndExist()
+                do {
+                    try await viewModel.commitEditsAndExit()
+                } catch {
+                    isCompleting = false
+                    showErrorAlert(error: error)
+                }
             }
         }
 
@@ -85,11 +122,21 @@
             if viewModel.hasPersistedNote, viewModel.isEditedNote {
                 logger.info("SyncedNoteEditor: confirm note deletion")
                 confirmNoteDelete(
-                    delete: { await self.viewModel.forceDelete() },
+                    delete: {
+                        do {
+                            try await self.viewModel.forceDelete()
+                        } catch {
+                            self.showErrorAlert(error: error)
+                        }
+                    },
                     cancel: { }
                 )
             } else if viewModel.hasPersistedNote {
-                await viewModel.forceDelete()
+                do {
+                    try await viewModel.forceDelete()
+                } catch {
+                    showErrorAlert(error: error)
+                }
             } else {
                 dismiss(animated: true)
             }

--- a/Features/NoteEditorFeature/SyncedNoteEditorViewController.swift
+++ b/Features/NoteEditorFeature/SyncedNoteEditorViewController.swift
@@ -1,0 +1,98 @@
+#if QURAN_SYNC
+    import NoorUI
+    import SwiftUI
+    import UIKit
+    import VLogging
+
+    final class SyncedNoteEditorViewController: BaseViewController, UIAdaptivePresentationControllerDelegate {
+        // MARK: Lifecycle
+
+        init(viewModel: SyncedNoteEditorInteractor) {
+            self.viewModel = viewModel
+            super.init(nibName: nil, bundle: nil)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        // MARK: Internal
+
+        override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+            traitCollection.userInterfaceIdiom == .pad ? .all : .portrait
+        }
+
+        override func viewDidLoad() {
+            super.viewDidLoad()
+
+            presentationController?.delegate = self
+
+            Task {
+                do {
+                    let note = try await viewModel.fetchNote()
+                    setNote(note)
+                } catch {
+                }
+            }
+        }
+
+        func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+            done()
+        }
+
+        // MARK: Private
+
+        private let viewModel: SyncedNoteEditorInteractor
+
+        private func setNote(_ note: EditableNote) {
+            let noteEditor = NoteEditorView(
+                note: note,
+                done: { [weak self] in self?.done() },
+                delete: { [weak self] in await self?.delete() },
+                style: .sync
+            )
+            let viewController = UIHostingController(rootView: noteEditor)
+            let navigationController = buildNavigationController(rootViewController: viewController, note: note)
+            addFullScreenChild(navigationController)
+        }
+
+        private func buildNavigationController(rootViewController: UIViewController, note: EditableNote) -> UINavigationController {
+            let modifiedText = UIBarButtonItem(title: note.modifiedSince, style: .plain, target: nil, action: nil)
+            modifiedText.isEnabled = false
+            let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneTapped))
+
+            rootViewController.navigationItem.largeTitleDisplayMode = .never
+            rootViewController.navigationItem.leftBarButtonItem = modifiedText
+            rootViewController.navigationItem.rightBarButtonItem = doneButton
+
+            return UINavigationController(rootViewController: rootViewController)
+        }
+
+        @objc
+        private func doneTapped() {
+            done()
+        }
+
+        private func done() {
+            Task {
+                await viewModel.commitEditsAndExist()
+            }
+        }
+
+        private func delete() async {
+            logger.info("SyncedNoteEditor: delete note")
+            if viewModel.hasPersistedNote, viewModel.isEditedNote {
+                logger.info("SyncedNoteEditor: confirm note deletion")
+                confirmNoteDelete(
+                    delete: { await self.viewModel.forceDelete() },
+                    cancel: { }
+                )
+            } else if viewModel.hasPersistedNote {
+                await viewModel.forceDelete()
+            } else {
+                dismiss(animated: true)
+            }
+        }
+    }
+#endif

--- a/Features/NotesFeature/SyncedNoteItem.swift
+++ b/Features/NotesFeature/SyncedNoteItem.swift
@@ -1,0 +1,12 @@
+#if QURAN_SYNC
+    import FeaturesSupport
+    import QuranAnnotations
+
+    struct SyncedNoteItem: Equatable, Identifiable {
+        let note: SyncedNoteReference
+        let verseText: String
+        let highlightColor: HighlightColor?
+
+        var id: String { note.id }
+    }
+#endif

--- a/Features/NotesFeature/SyncedNotesBuilder.swift
+++ b/Features/NotesFeature/SyncedNotesBuilder.swift
@@ -1,0 +1,33 @@
+#if QURAN_SYNC
+    import AppDependencies
+    import FeaturesSupport
+    import QuranKit
+    import QuranTextKit
+    import UIKit
+
+    @MainActor
+    public struct SyncedNotesBuilder {
+        public init(container: AppDependencies) {
+            self.container = container
+        }
+
+        public func build(withListener listener: QuranNavigator) -> UIViewController {
+            let textRetriever = ShareableVerseTextRetriever(
+                databasesURL: container.databasesURL,
+                quranFileURL: container.quranUthmaniV2Database
+            )
+
+            let viewModel = SyncedNotesViewModel(
+                notesSyncService: container.notesSyncService,
+                syncService: container.syncService,
+                textRetriever: textRetriever,
+                navigateTo: { [weak listener] verse in
+                    listener?.navigateTo(page: verse.page, lastPage: nil, highlightingSearchAyah: nil)
+                }
+            )
+            return SyncedNotesViewController(viewModel: viewModel)
+        }
+
+        let container: AppDependencies
+    }
+#endif

--- a/Features/NotesFeature/SyncedNotesBuilder.swift
+++ b/Features/NotesFeature/SyncedNotesBuilder.swift
@@ -12,7 +12,11 @@
         }
 
         public func build(withListener listener: QuranNavigator) -> UIViewController {
-            let textRetriever = ShareableVerseTextRetriever(
+            let displayTextRetriever = DisplayVerseTextRetriever(
+                databasesURL: container.databasesURL,
+                quranFileURL: container.quranUthmaniV2Database
+            )
+            let shareableTextRetriever = ShareableVerseTextRetriever(
                 databasesURL: container.databasesURL,
                 quranFileURL: container.quranUthmaniV2Database
             )
@@ -20,7 +24,8 @@
             let viewModel = SyncedNotesViewModel(
                 notesSyncService: container.notesSyncService,
                 syncService: container.syncService,
-                textRetriever: textRetriever,
+                displayTextRetriever: displayTextRetriever,
+                shareableTextRetriever: shareableTextRetriever,
                 navigateTo: { [weak listener] verse in
                     listener?.navigateTo(page: verse.page, lastPage: nil, highlightingSearchAyah: nil)
                 }

--- a/Features/NotesFeature/SyncedNotesView.swift
+++ b/Features/NotesFeature/SyncedNotesView.swift
@@ -1,0 +1,82 @@
+#if QURAN_SYNC
+    import Localization
+    import NoorUI
+    import QuranAnnotations
+    import SwiftUI
+    import UIx
+
+    struct SyncedNotesView: View {
+        @StateObject var viewModel: SyncedNotesViewModel
+
+        var body: some View {
+            SyncedNotesViewUI(
+                editMode: $viewModel.editMode,
+                error: $viewModel.error,
+                notes: viewModel.notes,
+                start: { await viewModel.start() },
+                selectAction: { viewModel.navigateTo($0) },
+                deleteAction: { await viewModel.deleteItem($0) }
+            )
+        }
+    }
+
+    private struct SyncedNotesViewUI: View {
+        @Binding var editMode: EditMode
+        @Binding var error: Error?
+
+        let notes: [SyncedNoteItem]
+        let start: AsyncAction
+        let selectAction: ItemAction<SyncedNoteItem>
+        let deleteAction: AsyncItemAction<SyncedNoteItem>
+
+        var body: some View {
+            Group {
+                if notes.isEmpty {
+                    noData
+                } else {
+                    NoorList {
+                        NoorSection(notes) { note in
+                            listItem(note)
+                        }
+                        .onDelete(action: deleteAction)
+                    }
+                }
+            }
+            .task { await start() }
+            .errorAlert(error: $error)
+            .environment(\.editMode, $editMode)
+        }
+
+        private var noData: some View {
+            DataUnavailableView(
+                title: l("notes.no-data.title"),
+                text: l("notes.no-data.text"),
+                image: .note
+            )
+        }
+
+        private func listItem(_ item: SyncedNoteItem) -> some View {
+            guard let ayah = item.note.firstVerse else {
+                return AnyView(EmptyView())
+            }
+
+            let localizedVerse = ayah.localizedName
+            let arabicSuraName = ayah.sura.arabicSuraName
+            let ayahCount = item.note.verses.count
+            let numberOfAyahs = ayahCount > 1 ? lFormat("notes.verses-count", ayahCount - 1) : ""
+            let verseColor = (item.highlightColor?.color ?? .clear).opacity(QuranHighlights.opacity)
+
+            return AnyView(
+                AnnotationListItem(
+                    subheading: "\(localizedVerse) \(sura: arabicSuraName) \(numberOfAyahs)",
+                    verseText: "\(verse: item.verseText, color: verseColor, lineLimit: 2)",
+                    noteText: item.note.body,
+                    modifiedDateText: item.note.modifiedDate.timeAgo(),
+                    pageNumberText: NumberFormatter.shared.format(ayah.page.pageNumber)
+                ) {
+                    selectAction(item)
+                }
+            )
+        }
+    }
+#endif

--- a/Features/NotesFeature/SyncedNotesViewController.swift
+++ b/Features/NotesFeature/SyncedNotesViewController.swift
@@ -1,0 +1,71 @@
+#if QURAN_SYNC
+    import Localization
+    import SwiftUI
+    import UIx
+
+    final class SyncedNotesViewController: UIHostingController<SyncedNotesView> {
+        init(viewModel: SyncedNotesViewModel) {
+            self.viewModel = viewModel
+            super.init(rootView: SyncedNotesView(viewModel: viewModel))
+
+            initialize()
+        }
+
+        @available(*, unavailable)
+        @MainActor
+        dynamic required init?(coder aDecoder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        private var editController: EditController?
+        private let viewModel: SyncedNotesViewModel
+
+        private var currentEditMode: EditMode? {
+            if viewModel.notes.isEmpty {
+                return nil
+            }
+            return viewModel.editMode
+        }
+
+        private func initialize() {
+            title = l("tab.notes")
+            addCloudSyncInfo()
+
+            editController = EditController(
+                navigationItem: navigationItem,
+                reload: viewModel.objectWillChange.eraseToAnyPublisher(),
+                editMode: Binding(
+                    get: { [weak self] in self?.currentEditMode },
+                    set: { [weak self] value in self?.viewModel.editMode = value ?? .inactive }
+                ),
+                customItems: [
+                    UIBarButtonItem(
+                        image: UIImage(systemName: "square.and.arrow.up"),
+                        style: .plain,
+                        target: self,
+                        action: #selector(shareAllNotes)
+                    ),
+                ]
+            )
+        }
+
+        @objc
+        private func shareAllNotes() {
+            Task {
+                do {
+                    let notesText = try await viewModel.prepareNotesForSharing()
+                    let activityViewController = UIActivityViewController(activityItems: [notesText], applicationActivities: nil)
+                    let view = navigationController?.view
+                    let viewBound = view.map { CGRect(x: $0.bounds.midX, y: $0.bounds.midY, width: 0, height: 0) }
+                    activityViewController.modalPresentationStyle = .formSheet
+                    activityViewController.popoverPresentationController?.permittedArrowDirections = []
+                    activityViewController.popoverPresentationController?.sourceView = view
+                    activityViewController.popoverPresentationController?.sourceRect = viewBound ?? .zero
+                    present(activityViewController, animated: true)
+                } catch {
+                    showErrorAlert(error: error)
+                }
+            }
+        }
+    }
+#endif

--- a/Features/NotesFeature/SyncedNotesViewModel.swift
+++ b/Features/NotesFeature/SyncedNotesViewModel.swift
@@ -1,7 +1,6 @@
 #if QURAN_SYNC
     import AsyncAlgorithms
     import Combine
-    import Crashing
     import FeaturesSupport
     import Foundation
     import MobileSync
@@ -21,12 +20,14 @@
         init(
             notesSyncService: NotesSyncService?,
             syncService: SyncService?,
-            textRetriever: ShareableVerseTextRetriever,
+            displayTextRetriever: DisplayVerseTextRetriever,
+            shareableTextRetriever: ShareableVerseTextRetriever,
             navigateTo: @escaping (AyahNumber) -> Void
         ) {
             self.notesSyncService = notesSyncService
             self.syncService = syncService
-            self.textRetriever = textRetriever
+            self.displayTextRetriever = displayTextRetriever
+            self.shareableTextRetriever = shareableTextRetriever
             self.navigateTo = navigateTo
         }
 
@@ -79,31 +80,30 @@
         }
 
         func prepareNotesForSharing() async throws -> String {
-            try await crasher.recordError("Failed to share sync notes") {
-                var notesText = [String]()
-                let notes: [SyncedNoteItem] = await self.notes
-                for (index, note) in notes.enumerated() {
-                    let title = note.note.body.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !title.isEmpty {
-                        notesText.append(contentsOf: [title, ""])
-                    }
-
-                    let verses = try await textRetriever.textForVerses(note.note.verses)
-                    notesText.append(contentsOf: verses)
-
-                    if index != notes.count - 1 {
-                        notesText.append(contentsOf: ["", "", ""])
-                    }
+            var notesText = [String]()
+            let notes: [SyncedNoteItem] = await notes
+            for (index, note) in notes.enumerated() {
+                let title = note.note.body.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !title.isEmpty {
+                    notesText.append(contentsOf: [title, ""])
                 }
-                return notesText.joined(separator: "\n")
+
+                let verses = try await shareableTextRetriever.textForVerses(note.note.verses)
+                notesText.append(contentsOf: verses)
+
+                if index != notes.count - 1 {
+                    notesText.append(contentsOf: ["", "", ""])
+                }
             }
+            return notesText.joined(separator: "\n")
         }
 
         // MARK: Private
 
         private let notesSyncService: NotesSyncService?
         private let syncService: SyncService?
-        private let textRetriever: ShareableVerseTextRetriever
+        private let displayTextRetriever: DisplayVerseTextRetriever
+        private let shareableTextRetriever: ShareableVerseTextRetriever
         private let navigateTo: (AyahNumber) -> Void
         private let readingPreferences = ReadingPreferences.shared
 
@@ -115,14 +115,13 @@
                 for note in notes {
                     group.addTask {
                         do {
-                            let verseText = try await self.textRetriever.textForVerses(note.verses)
+                            let verseText = try await self.displayTextRetriever.textForVerses(note.verses)
                             return SyncedNoteItem(
                                 note: note,
-                                verseText: verseText.joined(separator: "\n"),
+                                verseText: verseText,
                                 highlightColor: note.highlightColor(in: highlightColorsByVerse)
                             )
                         } catch {
-                            crasher.recordError(error, reason: "SyncedNotes.textForVerses")
                             let verseText = note.firstVerse?.localizedName ?? ""
                             return SyncedNoteItem(
                                 note: note,

--- a/Features/NotesFeature/SyncedNotesViewModel.swift
+++ b/Features/NotesFeature/SyncedNotesViewModel.swift
@@ -1,0 +1,140 @@
+#if QURAN_SYNC
+    import AsyncAlgorithms
+    import Combine
+    import Crashing
+    import FeaturesSupport
+    import Foundation
+    import MobileSync
+    import MobileSyncSupport
+    import QuranAnnotations
+    import QuranKit
+    import QuranTextKit
+    import ReadingService
+    import SwiftUI
+    import Utilities
+    import VLogging
+
+    @MainActor
+    final class SyncedNotesViewModel: ObservableObject {
+        // MARK: Lifecycle
+
+        init(
+            notesSyncService: NotesSyncService?,
+            syncService: SyncService?,
+            textRetriever: ShareableVerseTextRetriever,
+            navigateTo: @escaping (AyahNumber) -> Void
+        ) {
+            self.notesSyncService = notesSyncService
+            self.syncService = syncService
+            self.textRetriever = textRetriever
+            self.navigateTo = navigateTo
+        }
+
+        // MARK: Internal
+
+        @Published var editMode: EditMode = .inactive
+        @Published var error: Error? = nil
+        @Published var notes: [SyncedNoteItem] = []
+
+        func start() async {
+            guard let syncService else {
+                return
+            }
+
+            let quran = readingPreferences.reading.quran
+
+            do {
+                for try await (syncNotes, collections) in combineLatest(
+                    syncService.notesSequence(),
+                    HighlightCollection.updates(from: syncService)
+                ) {
+                    let notes = SyncedNoteReference.makeAll(from: syncNotes, quran: quran)
+                    let colorsByVerse = HighlightCollection.highlightColorsByVerse(in: collections, quran: quran)
+                    self.notes = await noteItems(with: notes, highlightColorsByVerse: colorsByVerse)
+                        .sorted { $0.note.modifiedDate > $1.note.modifiedDate }
+                }
+            } catch is CancellationError {
+            } catch {
+                self.error = error
+            }
+        }
+
+        func navigateTo(_ item: SyncedNoteItem) {
+            guard let firstVerse = item.note.firstVerse else {
+                return
+            }
+            logger.info("SyncedNotes: select note at \(firstVerse)")
+            navigateTo(firstVerse)
+        }
+
+        func deleteItem(_ item: SyncedNoteItem) async {
+            logger.info("SyncedNotes: delete note at \(String(describing: item.note.firstVerse))")
+            do {
+                if let localId = item.note.localId {
+                    try await notesSyncService?.removeNote(localId: localId)
+                }
+            } catch {
+                self.error = error
+            }
+        }
+
+        func prepareNotesForSharing() async throws -> String {
+            try await crasher.recordError("Failed to share sync notes") {
+                var notesText = [String]()
+                let notes: [SyncedNoteItem] = await self.notes
+                for (index, note) in notes.enumerated() {
+                    let title = note.note.body.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !title.isEmpty {
+                        notesText.append(contentsOf: [title, ""])
+                    }
+
+                    let verses = try await textRetriever.textForVerses(note.note.verses)
+                    notesText.append(contentsOf: verses)
+
+                    if index != notes.count - 1 {
+                        notesText.append(contentsOf: ["", "", ""])
+                    }
+                }
+                return notesText.joined(separator: "\n")
+            }
+        }
+
+        // MARK: Private
+
+        private let notesSyncService: NotesSyncService?
+        private let syncService: SyncService?
+        private let textRetriever: ShareableVerseTextRetriever
+        private let navigateTo: (AyahNumber) -> Void
+        private let readingPreferences = ReadingPreferences.shared
+
+        private nonisolated func noteItems(
+            with notes: [SyncedNoteReference],
+            highlightColorsByVerse: [AyahNumber: HighlightColor]
+        ) async -> [SyncedNoteItem] {
+            await withTaskGroup(of: SyncedNoteItem.self) { group in
+                for note in notes {
+                    group.addTask {
+                        do {
+                            let verseText = try await self.textRetriever.textForVerses(note.verses)
+                            return SyncedNoteItem(
+                                note: note,
+                                verseText: verseText.joined(separator: "\n"),
+                                highlightColor: note.highlightColor(in: highlightColorsByVerse)
+                            )
+                        } catch {
+                            crasher.recordError(error, reason: "SyncedNotes.textForVerses")
+                            let verseText = note.firstVerse?.localizedName ?? ""
+                            return SyncedNoteItem(
+                                note: note,
+                                verseText: verseText,
+                                highlightColor: note.highlightColor(in: highlightColorsByVerse)
+                            )
+                        }
+                    }
+                }
+
+                return await group.collect()
+            }
+        }
+    }
+#endif

--- a/Features/QuranViewFeature/QuranBuilder.swift
+++ b/Features/QuranViewFeature/QuranBuilder.swift
@@ -47,6 +47,7 @@ public struct QuranBuilder {
                 audioBannerBuilder: AudioBannerBuilder(container: container),
                 wordPointerBuilder: WordPointerBuilder(container: container),
                 noteEditorBuilder: NoteEditorBuilder(container: container),
+                syncedNoteEditorBuilder: container.notesSyncService.map { _ in SyncedNoteEditorBuilder(container: container) },
                 contentBuilder: ContentBuilder(container: container, highlightsService: highlightsService),
                 translationsSelectionBuilder: TranslationsListBuilder(container: container),
                 translationVerseBuilder: TranslationVerseBuilder(container: container),

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -75,6 +75,9 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let audioBannerBuilder: AudioBannerBuilder
         let wordPointerBuilder: WordPointerBuilder
         let noteEditorBuilder: NoteEditorBuilder
+        #if QURAN_SYNC
+            let syncedNoteEditorBuilder: SyncedNoteEditorBuilder?
+        #endif
         let contentBuilder: ContentBuilder
         let translationsSelectionBuilder: TranslationsListBuilder
         let translationVerseBuilder: TranslationVerseBuilder
@@ -91,6 +94,12 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         self.deps = deps
         self.input = input
         logger.info("Quran: opening quran \(input)")
+    }
+
+    deinit {
+        #if QURAN_SYNC
+            syncNotesTask?.cancel()
+        #endif
     }
 
     // MARK: Internal
@@ -134,6 +143,22 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         contentStatePreferences.$quranMode
             .sink { [weak self] _ in self?.onQuranModeUpdated() }
             .store(in: &cancellables)
+
+        #if QURAN_SYNC
+            if let syncService = deps.syncService {
+                syncNotesTask = Task { [weak self] in
+                    do {
+                        for try await notes in syncService.notesSequence() {
+                            guard let self else { return }
+                            syncNotes = SyncedNoteReference.makeAll(from: notes, quran: deps.quran)
+                        }
+                    } catch is CancellationError {
+                    } catch {
+                        crasher.recordError(error, reason: "Failed to observe synced notes")
+                    }
+                }
+            }
+        #endif
 
         deps.resources.publisher
             .receive(on: DispatchQueue.main)
@@ -236,6 +261,42 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
                 crasher.recordError(error, reason: "Failed to remove synced highlights")
             }
         }
+
+        func deleteSyncedNotes(_ notes: [SyncedNoteReference], verses _: [AyahNumber]) async {
+            contentViewModel?.removeAyahMenuHighlight()
+
+            func performDelete() async {
+                for note in notes {
+                    guard let localId = note.localId else {
+                        continue
+                    }
+                    do {
+                        try await deps.syncService?.removeNote(localId: localId)
+                    } catch {
+                        crasher.recordError(error, reason: "Failed to remove synced note")
+                    }
+                }
+            }
+
+            if notes.contains(where: { !$0.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) {
+                presenter?.confirmNoteDelete(
+                    delete: { await performDelete() },
+                    cancel: { self.contentViewModel?.removeAyahMenuHighlight() }
+                )
+            } else {
+                await performDelete()
+            }
+        }
+
+        func editSyncedNote(_ note: SyncedNoteReference) {
+            dismissAyahMenu()
+            presenter?.rotateToPortraitIfPhone()
+            guard let syncedNoteEditorBuilder = deps.syncedNoteEditorBuilder else {
+                return
+            }
+            let viewController = syncedNoteEditorBuilder.build(withListener: self, note: note)
+            presenter?.present(viewController, animated: true)
+        }
     #endif
 
     func shareText(_ lines: [String], in sourceView: UIView, at point: CGPoint) {
@@ -286,11 +347,12 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let notes = notes.isEmpty ? notesInteractingVerses(verses) : notes
         #if QURAN_SYNC
             if let syncedAyahMenuBuilder = deps.syncedAyahMenuBuilder, deps.syncService != nil {
+                let syncNotes = syncedNotesInteractingVerses(verses)
                 let input = SyncedAyahMenuInput(
                     sourceView: sourceView,
                     pointInView: point,
                     verses: verses,
-                    notes: notes,
+                    notes: syncNotes,
                     syncHighlightColor: syncHighlightColor,
                     hasSyncHighlight: hasSyncHighlight
                 )
@@ -380,6 +442,11 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     private let selectedTranslationsPreferences = SelectedTranslationsPreferences.shared
 
     private var notes: [QuranAnnotations.Note] = []
+
+    #if QURAN_SYNC
+        private var syncNotes: [SyncedNoteReference] = []
+        private var syncNotesTask: Task<Void, Never>?
+    #endif
 
     private var deps: Deps
     private let input: QuranInput
@@ -486,6 +553,14 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             showPageBookmarkIfNeeded(for: visiblePages)
         }
     }
+
+    #if QURAN_SYNC
+        private func syncedNotesInteractingVerses(_ verses: [AyahNumber]) -> [SyncedNoteReference] {
+            syncNotes.filter { note in
+                !Set(note.verses).isDisjoint(with: verses)
+            }
+        }
+    #endif
 
     private func bookmarked(_ pages: [Page]) -> Bool {
         let visibleBookmarks = pageBookmarks.filter { pages.contains($0.page) }

--- a/Package.swift
+++ b/Package.swift
@@ -557,6 +557,7 @@ private func featuresTargets() -> [[Target]] {
             "MobileSyncSupport",
             .product(name: "MobileSync", package: "mobile-sync-spm"),
             "NoorUI",
+            "QuranTextKit",
         ]),
 
         target(type, name: "ReciterListFeature", hasTests: false, dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -626,7 +626,10 @@ private func featuresTargets() -> [[Target]] {
         target(type, name: "NoteEditorFeature", hasTests: false, dependencies: [
             "AppDependencies",
             "AnnotationsService",
+            "FeaturesSupport",
+            "MobileSyncSupport",
             "NoorUI",
+            "QuranTextKit",
         ]),
 
         target(type, name: "BookmarksFeature", dependencies: [
@@ -698,7 +701,10 @@ private func featuresTargets() -> [[Target]] {
             "AppDependencies",
             "FeaturesSupport",
             "ReadingService",
+            "MobileSyncSupport",
             "NoorUI",
+            .product(name: "MobileSync", package: "mobile-sync-spm"),
+            .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
         ]),
 
         target(type, name: "TranslationVerseFeature", hasTests: false, dependencies: [

--- a/UI/NoorUI/Features/AyahMenu/SyncedAyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/SyncedAyahMenuView.swift
@@ -57,15 +57,15 @@ private struct SyncedAyahMenuViewList: View {
 
     var editNote: some View {
         SyncedRow(title: l("ayah.menu.edit-note"), action: dataObject.actions.addNote) {
-            Image(systemName: "text.bubble.fill")
-                .foregroundColor(dataObject.highlightingColor.color)
+            NoorSystemImage.note.image
+                .foregroundColor(.primary)
         }
     }
 
     var addNote: some View {
         SyncedRow(title: l("ayah.menu.add-note"), action: dataObject.actions.addNote) {
-            Image(systemName: "plus.bubble.fill")
-                .foregroundColor(dataObject.highlightingColor.color)
+            NoorSystemImage.note.image
+                .foregroundColor(.primary)
         }
     }
 

--- a/UI/NoorUI/Features/Note/NoteEditorView.swift
+++ b/UI/NoorUI/Features/Note/NoteEditorView.swift
@@ -13,42 +13,48 @@ import UIx
 public struct NoteEditorView: View {
     // MARK: Lifecycle
 
-    public init(note: EditableNote, done: @escaping () -> Void, delete: @Sendable @escaping () async -> Void) {
+    public init(
+        note: EditableNote,
+        done: @escaping () -> Void,
+        delete: @Sendable @escaping () async -> Void,
+        style: Style = .legacy
+    ) {
         _note = ObservedObject(initialValue: note)
         self.done = done
         self.delete = delete
+        self.style = style
     }
 
     // MARK: Public
 
+    public enum Style {
+        case legacy
+        case sync
+    }
+
     public var body: some View {
         VStack {
-            ZStack(alignment: .leading) {
-                HStack {
-                    Spacer()
-                    ForEach(Note.Color.sortedColors, id: \.self) { color in
-                        Button(
-                            action: { note.selectedColor = color },
-                            label: { NoteCircle(color: color.color, selected: color == note.selectedColor) }
-                        )
+            switch style {
+            case .legacy:
+                ZStack(alignment: .leading) {
+                    HStack {
+                        Spacer()
+                        ForEach(Note.Color.sortedColors, id: \.self) { color in
+                            Button(
+                                action: { note.selectedColor = color },
+                                label: { NoteCircle(color: color.color, selected: color == note.selectedColor) }
+                            )
+                        }
+                        Spacer()
                     }
+
+                    deleteButton
+                }
+            case .sync:
+                HStack {
+                    deleteButton
                     Spacer()
                 }
-
-                Button(action: {
-                    Task {
-                        await delete()
-                    }
-                }, label: {
-                    Image(systemName: "trash")
-                        .foregroundColor(Color.red)
-                        .padding()
-                        .background(
-                            Circle()
-                                .fill(Color.systemBackground)
-                                .shadow(color: Color.primary.opacity(0.5), radius: 1)
-                        )
-                })
             }
             HStack {
                 Spacer()
@@ -56,11 +62,15 @@ public struct NoteEditorView: View {
                     .lineLimit(3)
                     .font(.quran(ofSize: .small))
                     .padding(.leading)
-                    .overlay(HStack {
-                        Rectangle().fill(note.selectedColor.color)
-                            .frame(width: 4)
-                        Spacer()
-                    })
+                    .overlay(alignment: .leading) {
+                        switch style {
+                        case .legacy:
+                            Rectangle().fill(note.selectedColor.color)
+                                .frame(width: 4)
+                        case .sync:
+                            EmptyView()
+                        }
+                    }
                     .environment(\.layoutDirection, .rightToLeft)
             }
 
@@ -86,6 +96,26 @@ public struct NoteEditorView: View {
 
     let done: () -> Void
     let delete: @Sendable () async -> Void
+    let style: Style
+
+    // MARK: Private
+
+    private var deleteButton: some View {
+        Button(action: {
+            Task {
+                await delete()
+            }
+        }, label: {
+            Image(systemName: "trash")
+                .foregroundColor(Color.red)
+                .padding()
+                .background(
+                    Circle()
+                        .fill(Color.systemBackground)
+                        .shadow(color: Color.primary.opacity(0.5), radius: 1)
+                )
+        })
+    }
 }
 
 struct NoteEditorView_Previews: PreviewProvider {


### PR DESCRIPTION
## Summary
Add the sync-enabled notes UI flow on top of the notes sync service.

## Scope
- add sync-specific notes list flow
- add sync-specific note editor flow
- hide color controls in sync note editor
- save note text through sync notes service
- keep note and highlight actions separate in sync mode
- tint sync notes only from highlight membership

## Out of scope
- no changes to legacy non-sync notes behavior
- no migration of old note/highlight storage
- no full app data-layer migration in this PR

## Notes
This PR is gated behind `QURAN_SYNC`. The legacy notes flow remains unchanged when sync is disabled.
