### PR TITLE
Transparently map verses when talking to sync

### DIFF
--- a/Domain/AnnotationsService/Sources/LastPageService.swift
+++ b/Domain/AnnotationsService/Sources/LastPageService.swift
@@ -14,42 +14,78 @@ import QuranKit
 public struct LastPageService {
     // MARK: Lifecycle
 
-    public init(persistence: LastPagePersistence) {
+    public init(persistence: LastPagePersistence, storedPageQuran: Quran = .hafsMadani1405) {
         self.persistence = persistence
+        self.storedPageQuran = storedPageQuran
     }
 
     // MARK: Public
 
     public func lastPages(quran: Quran) -> AnyPublisher<[LastPage], Never> {
-        persistence.lastPages()
-            .map { lastPages in lastPages.map { LastPage(quran: quran, $0) } }
+        let mapper = QuranPageMapper(destination: quran)
+        return persistence.lastPages()
+            .map { lastPages in
+                lastPages.compactMap { lastPage in
+                    Page(quran: storedPageQuran, pageNumber: lastPage.page)
+                        .flatMap(mapper.mapPage)
+                        .map {
+                            LastPage(page: $0, createdOn: lastPage.createdOn, modifiedOn: lastPage.modifiedOn)
+                        }
+                }
+            }
             .eraseToAnyPublisher()
     }
 
     // MARK: Internal
 
     let persistence: LastPagePersistence
+    let storedPageQuran: Quran
 
     func add(page: Page) async throws -> LastPage {
-        let persistenceModel = try await persistence.add(page: page.pageNumber)
-        return LastPage(quran: page.quran, persistenceModel)
+        let storedPage = try storedPage(for: page)
+        let persistenceModel = try await persistence.add(page: storedPage.pageNumber)
+        return try lastPage(quran: page.quran, persistenceModel)
     }
 
     func update(page: Page, toPage: Page) async throws -> LastPage {
+        let currentStoredPage = try storedPage(for: page)
+        let storedToPage = try storedPage(for: toPage)
         let persistenceModel = try await persistence.update(
-            page: page.pageNumber,
-            toPage: toPage.pageNumber
+            page: currentStoredPage.pageNumber,
+            toPage: storedToPage.pageNumber
         )
-        return LastPage(quran: toPage.quran, persistenceModel)
+        return try lastPage(quran: toPage.quran, persistenceModel)
     }
-}
 
-private extension LastPage {
-    init(quran: Quran, _ other: LastPagePersistenceModel) {
-        self.init(
-            page: Page(quran: quran, pageNumber: Int(other.page))!,
-            createdOn: other.createdOn,
-            modifiedOn: other.modifiedOn
+    // MARK: Private
+
+    private func storedPage(for page: Page) throws -> Page {
+        guard let storedPage = QuranPageMapper(destination: storedPageQuran).mapPage(page) else {
+            throw PageMappingError.unableToMapPage(
+                pageNumber: page.pageNumber,
+                source: page.quran,
+                destination: storedPageQuran
+            )
+        }
+
+        return storedPage
+    }
+
+    private func lastPage(quran: Quran, _ persistenceModel: LastPagePersistenceModel) throws -> LastPage {
+        guard let storedPage = Page(quran: storedPageQuran, pageNumber: persistenceModel.page),
+              let page = QuranPageMapper(destination: quran).mapPage(storedPage)
+        else {
+            throw PageMappingError.unableToMapPage(
+                pageNumber: persistenceModel.page,
+                source: storedPageQuran,
+                destination: quran
+            )
+        }
+
+        return LastPage(
+            page: page,
+            createdOn: persistenceModel.createdOn,
+            modifiedOn: persistenceModel.modifiedOn
         )
     }
 }

--- a/Domain/AnnotationsService/Sources/PageBookmarkService.swift
+++ b/Domain/AnnotationsService/Sources/PageBookmarkService.swift
@@ -14,24 +14,36 @@ import QuranKit
 public struct PageBookmarkService {
     // MARK: Lifecycle
 
-    public init(persistence: PageBookmarkPersistence) {
+    public init(persistence: PageBookmarkPersistence, storedPageQuran: Quran = .hafsMadani1405) {
         self.persistence = persistence
+        self.storedPageQuran = storedPageQuran
     }
 
     // MARK: Public
 
     public func pageBookmarks(quran: Quran) -> AnyPublisher<[PageBookmark], Never> {
-        persistence.pageBookmarks()
-            .map { bookmarks in bookmarks.map { PageBookmark(quran: quran, $0) } }
+        let mapper = QuranPageMapper(destination: quran)
+        return persistence.pageBookmarks()
+            .map { bookmarks in
+                bookmarks.compactMap { bookmark in
+                    Page(quran: storedPageQuran, pageNumber: bookmark.page)
+                        .flatMap(mapper.mapPage)
+                        .map {
+                            PageBookmark(page: $0, creationDate: bookmark.creationDate)
+                        }
+                }
+            }
             .eraseToAnyPublisher()
     }
 
     public func insertPageBookmark(_ page: Page) async throws {
-        try await persistence.insertPageBookmark(page.pageNumber)
+        let storedPage = try storedPage(for: page)
+        try await persistence.insertPageBookmark(storedPage.pageNumber)
     }
 
     public func removePageBookmark(_ page: Page) async throws {
-        try await persistence.removePageBookmark(page.pageNumber)
+        let storedPage = try storedPage(for: page)
+        try await persistence.removePageBookmark(storedPage.pageNumber)
     }
 
     public func removeAllPageBookmarks() async throws {
@@ -41,13 +53,19 @@ public struct PageBookmarkService {
     // MARK: Internal
 
     let persistence: PageBookmarkPersistence
-}
+    let storedPageQuran: Quran
 
-private extension PageBookmark {
-    init(quran: Quran, _ other: PageBookmarkPersistenceModel) {
-        self.init(
-            page: Page(quran: quran, pageNumber: Int(other.page))!,
-            creationDate: other.creationDate
-        )
+    // MARK: Private
+
+    private func storedPage(for page: Page) throws -> Page {
+        guard let storedPage = QuranPageMapper(destination: storedPageQuran).mapPage(page) else {
+            throw PageMappingError.unableToMapPage(
+                pageNumber: page.pageNumber,
+                source: page.quran,
+                destination: storedPageQuran
+            )
+        }
+
+        return storedPage
     }
 }

--- a/Domain/AnnotationsService/Sources/PageMappingError.swift
+++ b/Domain/AnnotationsService/Sources/PageMappingError.swift
@@ -1,0 +1,12 @@
+//
+//  PageMappingError.swift
+//  Quran
+//
+//  Created by OpenAI on 2026-04-25.
+//
+
+import QuranKit
+
+enum PageMappingError: Error {
+    case unableToMapPage(pageNumber: Int, source: Quran, destination: Quran)
+}

--- a/Domain/AnnotationsService/Tests/PageMappingServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/PageMappingServiceTests.swift
@@ -1,0 +1,217 @@
+//
+//  PageMappingServiceTests.swift
+//  Quran
+//
+//  Created by OpenAI on 2026-04-25.
+//
+
+import Combine
+import XCTest
+@testable import AnnotationsService
+@testable import LastPagePersistence
+@testable import PageBookmarkPersistence
+@testable import QuranKit
+
+final class PageMappingServiceTests: XCTestCase {
+    private struct SkippedFirstPageReadingInfoRawData: QuranReadingInfoRawData {
+        // MARK: Internal
+
+        var arabicBesmAllah: String { base.arabicBesmAllah }
+        var numberOfPages: Int { base.numberOfPages + 1 }
+        var pagesToSkip: Int { 1 }
+
+        var startPageOfSura: [Int] {
+            base.startPageOfSura.map { $0 + pagesToSkip }
+        }
+
+        var startSuraOfPage: [Int] {
+            [base.startSuraOfPage[0]] + base.startSuraOfPage
+        }
+
+        var startAyahOfPage: [Int] {
+            [base.startAyahOfPage[0]] + base.startAyahOfPage
+        }
+
+        var numberOfAyahsInSura: [Int] { base.numberOfAyahsInSura }
+        var isMakkiSura: [Bool] { base.isMakkiSura }
+        var quarters: [(sura: Int, ayah: Int)] { base.quarters }
+
+        // MARK: Private
+
+        private let base = Madani1405QuranReadingInfoRawData()
+    }
+
+    // MARK: Internal
+
+    func testPageBookmarksMapsStoredCanonicalPagesToRequestedQuran() {
+        let persistence = PageBookmarkPersistenceFake(bookmarks: [
+            PageBookmarkPersistenceModel(page: 1, creationDate: date),
+        ])
+        let service = PageBookmarkService(persistence: persistence)
+        let quran = skippedPageQuran()
+
+        let bookmarks = value(from: service.pageBookmarks(quran: quran))
+
+        XCTAssertEqual(bookmarks.map(\.page.pageNumber), [2])
+        XCTAssertEqual(bookmarks.map(\.creationDate), [date])
+    }
+
+    func testInsertPageBookmarkStoresCanonicalPage() async throws {
+        let persistence = PageBookmarkPersistenceFake()
+        let service = PageBookmarkService(persistence: persistence)
+
+        try await service.insertPageBookmark(skippedPageQuran().pages[0])
+
+        XCTAssertEqual(persistence.insertedPages, [1])
+    }
+
+    func testRemovePageBookmarkRemovesCanonicalPage() async throws {
+        let persistence = PageBookmarkPersistenceFake()
+        let service = PageBookmarkService(persistence: persistence)
+
+        try await service.removePageBookmark(skippedPageQuran().pages[0])
+
+        XCTAssertEqual(persistence.removedPages, [1])
+    }
+
+    func testPageBookmarksIgnoreInvalidStoredPages() {
+        let persistence = PageBookmarkPersistenceFake(bookmarks: [
+            PageBookmarkPersistenceModel(page: 1, creationDate: date),
+            PageBookmarkPersistenceModel(page: 605, creationDate: date),
+        ])
+        let service = PageBookmarkService(persistence: persistence)
+
+        let bookmarks = value(from: service.pageBookmarks(quran: skippedPageQuran()))
+
+        XCTAssertEqual(bookmarks.map(\.page.pageNumber), [2])
+    }
+
+    func testLastPagesMapStoredCanonicalPagesToRequestedQuran() {
+        let persistence = LastPagePersistenceFake(lastPages: [
+            LastPagePersistenceModel(page: 1, createdOn: date, modifiedOn: laterDate),
+        ])
+        let service = LastPageService(persistence: persistence)
+
+        let lastPages = value(from: service.lastPages(quran: skippedPageQuran()))
+
+        XCTAssertEqual(lastPages.map(\.page.pageNumber), [2])
+        XCTAssertEqual(lastPages.map(\.createdOn), [date])
+        XCTAssertEqual(lastPages.map(\.modifiedOn), [laterDate])
+    }
+
+    func testAddLastPageStoresCanonicalPageAndReturnsRequestedQuranPage() async throws {
+        let persistence = LastPagePersistenceFake()
+        let service = LastPageService(persistence: persistence)
+
+        let lastPage = try await service.add(page: skippedPageQuran().pages[0])
+
+        XCTAssertEqual(persistence.addedPages, [1])
+        XCTAssertEqual(lastPage.page.pageNumber, 2)
+    }
+
+    func testUpdateLastPageStoresCanonicalPagesAndReturnsRequestedQuranPage() async throws {
+        let persistence = LastPagePersistenceFake()
+        let service = LastPageService(persistence: persistence)
+        let quran = skippedPageQuran()
+
+        let lastPage = try await service.update(page: quran.pages[0], toPage: quran.pages[1])
+
+        XCTAssertEqual(persistence.updates, [LastPagePersistenceFake.Update(page: 1, toPage: 2)])
+        XCTAssertEqual(lastPage.page.pageNumber, 3)
+    }
+
+    // MARK: Private
+
+    private let date = Date(timeIntervalSince1970: 1000)
+    private let laterDate = Date(timeIntervalSince1970: 2000)
+
+    private func skippedPageQuran() -> Quran {
+        Quran(raw: SkippedFirstPageReadingInfoRawData())
+    }
+
+    private func value<P: Publisher>(from publisher: P) -> P.Output where P.Failure == Never {
+        var value: P.Output?
+        let cancellable = publisher.sink { value = $0 }
+        withExtendedLifetime(cancellable) {}
+        return value!
+    }
+}
+
+private final class PageBookmarkPersistenceFake: PageBookmarkPersistence {
+    // MARK: Lifecycle
+
+    init(bookmarks: [PageBookmarkPersistenceModel] = []) {
+        self.bookmarks = bookmarks
+    }
+
+    // MARK: Internal
+
+    var bookmarks: [PageBookmarkPersistenceModel]
+    private(set) var insertedPages: [Int] = []
+    private(set) var removedPages: [Int] = []
+
+    func pageBookmarks() -> AnyPublisher<[PageBookmarkPersistenceModel], Never> {
+        Just(bookmarks).eraseToAnyPublisher()
+    }
+
+    func insertPageBookmark(_ page: Int) async throws {
+        insertedPages.append(page)
+    }
+
+    func removePageBookmark(_ page: Int) async throws {
+        removedPages.append(page)
+    }
+
+    func removeAllPageBookmarks() async throws {
+        bookmarks.removeAll()
+    }
+}
+
+private final class LastPagePersistenceFake: LastPagePersistence, @unchecked Sendable {
+    struct Update: Equatable {
+        let page: Int
+        let toPage: Int
+    }
+
+    // MARK: Lifecycle
+
+    init(lastPages: [LastPagePersistenceModel] = []) {
+        lastPagesList = lastPages
+    }
+
+    // MARK: Internal
+
+    private(set) var lastPagesList: [LastPagePersistenceModel]
+    private(set) var addedPages: [Int] = []
+    private(set) var updates: [Update] = []
+
+    func lastPages() -> AnyPublisher<[LastPagePersistenceModel], Never> {
+        Just(lastPagesList).eraseToAnyPublisher()
+    }
+
+    func retrieveAll() async throws -> [LastPagePersistenceModel] {
+        lastPagesList
+    }
+
+    func add(page: Int) async throws -> LastPagePersistenceModel {
+        addedPages.append(page)
+        let model = LastPagePersistenceModel(
+            page: page,
+            createdOn: Date(timeIntervalSince1970: 1000),
+            modifiedOn: Date(timeIntervalSince1970: 2000)
+        )
+        lastPagesList.append(model)
+        return model
+    }
+
+    func update(page: Int, toPage: Int) async throws -> LastPagePersistenceModel {
+        updates.append(Update(page: page, toPage: toPage))
+        let model = LastPagePersistenceModel(
+            page: toPage,
+            createdOn: Date(timeIntervalSince1970: 1000),
+            modifiedOn: Date(timeIntervalSince1970: 2000)
+        )
+        lastPagesList.append(model)
+        return model
+    }
+}

--- a/Model/QuranKit/Tests/QuranPageMetadataTests.swift
+++ b/Model/QuranKit/Tests/QuranPageMetadataTests.swift
@@ -123,6 +123,14 @@ final class QuranPageMetadataTests: XCTestCase {
         XCTAssertEqual(mappedPage, mappedAyah?.page)
     }
 
+    func testPageMapperMapsSkippedPageBackToCanonicalPage() {
+        let sourceQuran = Quran(raw: SkippedFirstPageReadingInfoRawData())
+        let mapper = QuranPageMapper(destination: .hafsMadani1405)
+
+        XCTAssertEqual(mapper.mapPage(sourceQuran.pages[0])?.pageNumber, 1)
+        XCTAssertEqual(mapper.mapPage(sourceQuran.pages[1])?.pageNumber, 2)
+    }
+
     func testPageMapperMapsAyahBackedStateToDestinationAyah() {
         let sourceQuran = Quran.hafsMadani1405
         let destinationQuran = Quran(raw: SkippedFirstPageReadingInfoRawData())

--- a/Package.swift
+++ b/Package.swift
@@ -514,6 +514,9 @@ private func domainTargets() -> [[Target]] {
             "Localization",
             "Analytics",
         ], testDependencies: [
+            "LastPagePersistence",
+            "PageBookmarkPersistence",
+            "QuranKit",
         ]),
 
         target(type, name: "SettingsService", hasTests: false, dependencies: [


### PR DESCRIPTION
Quran.com's sync only deals with Madani mushaf numbering. For naskh and
others, transparently map between the ui and the database, so that
syncing and the source of truth are madani numbering, but the actual
pages can use different numbering.
