### PR TITLE
Parameterize line pages

### DIFF
--- a/Domain/ImageService/Sources/LinePageAssetService.swift
+++ b/Domain/ImageService/Sources/LinePageAssetService.swift
@@ -69,18 +69,27 @@ public struct LinePageAssets {
 public struct LinePageAssetService {
     // MARK: Lifecycle
 
+    public init(readingDirectory: URL?, metrics: LinePageMetrics, quran: Quran, fileSystem: FileSystem = DefaultFileSystem()) {
+        self.init(
+            readingDirectory: readingDirectory,
+            metrics: metrics,
+            requiredPageNumbers: quran.pages.map(\.pageNumber),
+            fileSystem: fileSystem
+        )
+    }
+
     public init(readingDirectory: URL?, widthParameter: Int, fileSystem: FileSystem = DefaultFileSystem()) {
         self.init(
             readingDirectory: readingDirectory,
-            widthParameter: widthParameter,
+            metrics: .madaniLinePages(widthParameter: widthParameter),
             requiredPageNumbers: Quran.hafsMadani1440.pages.map(\.pageNumber),
             fileSystem: fileSystem
         )
     }
 
-    init(readingDirectory: URL?, widthParameter: Int, requiredPageNumbers: [Int], fileSystem: FileSystem) {
+    init(readingDirectory: URL?, metrics: LinePageMetrics, requiredPageNumbers: [Int], fileSystem: FileSystem) {
         self.readingDirectory = readingDirectory
-        self.widthParameter = widthParameter
+        self.metrics = metrics
         self.requiredPageNumbers = requiredPageNumbers
         self.fileSystem = fileSystem
     }
@@ -115,11 +124,9 @@ public struct LinePageAssetService {
     // MARK: Private
 
     private let readingDirectory: URL?
-    private let widthParameter: Int
+    private let metrics: LinePageMetrics
     private let requiredPageNumbers: [Int]
     private let fileSystem: FileSystem
-
-    private let lineCount = 15
 
     private func loadAssetsForPage(_ page: Page) -> LinePageAssetsResult {
         guard let readingDirectory else {
@@ -135,7 +142,7 @@ public struct LinePageAssetService {
         }
 
         var lines: [LinePageAssets.LineImage] = []
-        for lineNumber in 1 ... lineCount {
+        for lineNumber in 1 ... metrics.lineCount {
             let imageURL = lineImageURL(pageNumber: page.pageNumber, lineNumber: lineNumber, in: readingDirectory)
             guard let image = UIImage(contentsOfFile: imageURL.path) else {
                 return .unavailable
@@ -155,15 +162,15 @@ public struct LinePageAssetService {
 
     private func ayahInfoDatabaseURL(in readingDirectory: URL) -> URL {
         readingDirectory
-            .appendingPathComponent("images_\(widthParameter)")
+            .appendingPathComponent("images_\(metrics.widthParameter)")
             .appendingPathComponent("databases")
-            .appendingPathComponent("ayahinfo_\(widthParameter).db")
+            .appendingPathComponent("ayahinfo_\(metrics.widthParameter).db")
     }
 
     private func imagesURL(in readingDirectory: URL) -> URL {
         readingDirectory
-            .appendingPathComponent("images_\(widthParameter)")
-            .appendingPathComponent("width_\(widthParameter)")
+            .appendingPathComponent("images_\(metrics.widthParameter)")
+            .appendingPathComponent("width_\(metrics.widthParameter)")
     }
 
     private func lineImageURL(pageNumber: Int, lineNumber: Int, in readingDirectory: URL) -> URL {

--- a/Domain/ImageService/Sources/LinePageGeometry.swift
+++ b/Domain/ImageService/Sources/LinePageGeometry.swift
@@ -59,19 +59,22 @@ public struct LinePageGeometryData: Sendable {
     }
 
     public init(
-        lineCount: Int = 15,
+        metrics: LinePageMetrics = .madaniLinePages(widthParameter: 1080),
+        lineCount: Int? = nil,
         highlightSpans: [LinePageHighlightSpan],
         ayahMarkers: [LinePageAyahMarker],
         suraHeaders: [LinePageSuraHeader],
         sidelines: [Sideline]
     ) {
-        self.lineCount = lineCount
+        self.metrics = metrics
+        self.lineCount = lineCount ?? metrics.lineCount
         self.highlightSpans = highlightSpans
         self.ayahMarkers = ayahMarkers
         self.suraHeaders = suraHeaders
         self.sidelines = sidelines
     }
 
+    public let metrics: LinePageMetrics
     public let lineCount: Int
     public let highlightSpans: [LinePageHighlightSpan]
     public let ayahMarkers: [LinePageAyahMarker]
@@ -326,39 +329,40 @@ public struct LinePageGeometryEngine {
             nil
         }
 
-        let lineFrames = lineFrames(in: pageFrame, lineCount: input.data.lineCount)
+        let lineFrames = lineFrames(in: pageFrame, data: input.data)
         let versesByLine = Dictionary(grouping: input.data.highlightSpans, by: \.line)
 
         let highlightRects = highlightRects(
             for: input.highlights.highlightedVerses,
             spans: input.data.highlightSpans,
             in: pageFrame,
-            lineCount: input.data.lineCount
+            data: input.data
         )
         let ayahMarkerPlacements = ayahMarkerPlacements(
             markers: input.data.ayahMarkers,
             in: pageFrame,
-            lineCount: input.data.lineCount
+            data: input.data
         )
         let suraHeaderPlacements = suraHeaderPlacements(
             headers: input.data.suraHeaders,
             in: pageFrame,
-            lineCount: input.data.lineCount,
+            data: input.data,
             aspectRatio: input.suraHeaderAspectRatio
         )
         let sidelinePlacements = sidelinePlacements(
             for: input.data.sidelines,
             in: sidelineFrame,
-            parity: input.pageParity
+            parity: input.pageParity,
+            data: input.data
         )
         let selectionAnchorsByAyah = selectionAnchors(
             for: input.data.highlightSpans,
             in: pageFrame,
-            lineCount: input.data.lineCount
+            data: input.data
         )
         let selectionLineRanges = selectionLineRanges(
             in: pageFrame,
-            lineCount: input.data.lineCount
+            data: input.data
         )
 
         return LinePageLayout(
@@ -384,6 +388,7 @@ public struct LinePageGeometryEngine {
         let availableWidth = input.availableSize.width
         let availableHeight = input.availableSize.height
         let effectiveHeaderFooterHeightRatio = input.displaySettings.showHeaderFooter ? headerFooterHeightRatio : 0
+        let minimumPageWidthToHeightRatio = 1 / minimumPageHeightToWidthRatio(data: input.data)
 
         let sidelineWidth = input.displaySettings.showSidelines
             ? floor(availableWidth * sidelineWidthRatio)
@@ -394,7 +399,7 @@ public struct LinePageGeometryEngine {
         case .portrait:
             let initialHeaderFooterHeight = floor(effectiveHeaderFooterHeightRatio * availableHeight)
             let initialPageHeight = availableHeight - (2 * initialHeaderFooterHeight)
-            let computedWidth = floor(initialPageHeight * pageMinWidthToHeightRatio)
+            let computedWidth = floor(initialPageHeight * minimumPageWidthToHeightRatio)
             let pageWidth = min(layoutWidth, computedWidth)
             let maxPageHeight = round(pageWidth / pageMaxWidthToHeightRatio)
 
@@ -418,7 +423,7 @@ public struct LinePageGeometryEngine {
             )
         case .landscape:
             let pageWidth = min(scrollableMaximumPageWidth, round(layoutWidth * scrollablePageWidthRatio))
-            let pageHeight = ceil(pageWidth * scrollablePageHeightToWidthRatio)
+            let pageHeight = ceil(pageWidth * scrollablePageHeightToWidthRatio(data: input.data))
             let headerFooterHeight = floor(pageWidth * effectiveHeaderFooterHeightRatio)
             let headerMargin = floor(pageWidth * headerFooterMarginRatio)
 
@@ -452,35 +457,33 @@ public struct LinePageGeometryEngine {
         }
     }
 
-    private func lineFrames(in pageFrame: CGRect, lineCount: Int) -> [LinePageLineFrame] {
-        let ranges = selectionLineRanges(in: pageFrame, lineCount: lineCount)
-        let imageLineHeight = pageFrame.width * lineHeightRatio
-        let lastLineIndex = CGFloat(max(lineCount - 1, 1))
-
-        return (0 ..< lineCount).map { lineIndex in
-            let imageY = floor((pageFrame.height - imageLineHeight) / lastLineIndex * CGFloat(lineIndex))
-            return LinePageLineFrame(
+    private func lineFrames(in pageFrame: CGRect, data: LinePageGeometryData) -> [LinePageLineFrame] {
+        let ranges = selectionLineRanges(in: pageFrame, data: data)
+        return (0 ..< data.lineCount).map { lineIndex in
+            LinePageLineFrame(
                 lineNumber: lineIndex + 1,
-                imageFrame: CGRect(
-                    x: pageFrame.minX,
-                    y: pageFrame.minY + imageY,
-                    width: pageFrame.width,
-                    height: imageLineHeight
-                ),
+                imageFrame: lineImageFrame(in: pageFrame, lineIndex: lineIndex, data: data),
                 hitFrame: ranges[lineIndex].hitFrame
             )
         }
     }
 
-    private func selectionLineRanges(in pageFrame: CGRect, lineCount: Int) -> [SelectionLineRange] {
+    private func selectionLineRanges(in pageFrame: CGRect, data: LinePageGeometryData) -> [SelectionLineRange] {
+        if data.metrics.allowLineOverlap {
+            return overlappingSelectionLineRanges(in: pageFrame, data: data)
+        }
+        return nonOverlappingSelectionLineRanges(in: pageFrame, data: data)
+    }
+
+    private func overlappingSelectionLineRanges(in pageFrame: CGRect, data: LinePageGeometryData) -> [SelectionLineRange] {
         let width = Int(pageFrame.width)
         let height = Int(pageFrame.height)
-        let lineHeight = Int(CGFloat(width) * lineHeightRatio)
-        let lastLineIndex = max(lineCount - 1, 1)
+        let lineHeight = Int(lineImageHeight(in: pageFrame, metrics: data.metrics))
+        let lastLineIndex = max(data.lineCount - 1, 1)
         let lineHeightWithoutOverlap = (height - lineHeight) / lastLineIndex
         let offset = (lineHeight - lineHeightWithoutOverlap) / 2
 
-        return (0 ..< lineCount).map { lineIndex in
+        return (0 ..< data.lineCount).map { lineIndex in
             let fullLineStart = Int(floor(Double(height - lineHeight) / Double(lastLineIndex) * Double(lineIndex)))
             let hitY = fullLineStart + offset
             return SelectionLineRange(
@@ -496,18 +499,116 @@ public struct LinePageGeometryEngine {
         }
     }
 
+    private func nonOverlappingSelectionLineRanges(in pageFrame: CGRect, data: LinePageGeometryData) -> [SelectionLineRange] {
+        let slotHeight = lineSlotHeight(in: pageFrame, lineCount: data.lineCount)
+
+        return (0 ..< data.lineCount).map { lineIndex in
+            let lineStart = slotHeight * CGFloat(lineIndex)
+            return SelectionLineRange(
+                lineNumber: lineIndex,
+                fullLineRange: lineStart ... (lineStart + slotHeight),
+                hitFrame: CGRect(
+                    x: pageFrame.minX,
+                    y: pageFrame.minY + lineStart,
+                    width: pageFrame.width,
+                    height: slotHeight
+                )
+            )
+        }
+    }
+
+    private func lineImageFrame(in pageFrame: CGRect, lineIndex: Int, data: LinePageGeometryData) -> CGRect {
+        let imageLineHeight = lineImageHeight(in: pageFrame, metrics: data.metrics)
+        let imageY: CGFloat
+
+        if data.metrics.allowLineOverlap {
+            let lastLineIndex = CGFloat(max(data.lineCount - 1, 1))
+            imageY = floor((pageFrame.height - imageLineHeight) / lastLineIndex * CGFloat(lineIndex))
+        } else {
+            let slotHeight = lineSlotHeight(in: pageFrame, lineCount: data.lineCount)
+            imageY = (slotHeight * CGFloat(lineIndex)) + ((slotHeight - imageLineHeight) / 2)
+        }
+
+        return CGRect(
+            x: pageFrame.minX,
+            y: pageFrame.minY + imageY,
+            width: pageFrame.width,
+            height: imageLineHeight
+        )
+    }
+
+    private func lineContentFrame(in pageFrame: CGRect, lineIndex: Int, data: LinePageGeometryData) -> CGRect {
+        guard data.metrics.allowLineOverlap else {
+            return lineImageFrame(in: pageFrame, lineIndex: lineIndex, data: data)
+        }
+
+        let imageLineHeight = lineImageHeight(in: pageFrame, metrics: data.metrics)
+        let lastLineIndex = CGFloat(max(data.lineCount - 1, 1))
+        let imageY = ((pageFrame.height - imageLineHeight) / lastLineIndex) * CGFloat(lineIndex)
+        return CGRect(
+            x: pageFrame.minX,
+            y: pageFrame.minY + imageY,
+            width: pageFrame.width,
+            height: imageLineHeight
+        )
+    }
+
+    private func lineImageHeight(in pageFrame: CGRect, metrics: LinePageMetrics) -> CGFloat {
+        pageFrame.width * CGFloat(metrics.lineHeightRatio)
+    }
+
+    private func lineSlotHeight(in pageFrame: CGRect, lineCount: Int) -> CGFloat {
+        pageFrame.height / CGFloat(max(lineCount, 1))
+    }
+
     private func highlightRects(
         for highlightedVerses: Set<AyahNumber>,
         spans: [LinePageHighlightSpan],
         in pageFrame: CGRect,
-        lineCount: Int
+        data: LinePageGeometryData
     ) -> [LinePageHighlightRect] {
         guard !highlightedVerses.isEmpty else {
             return []
         }
 
-        let drawLineHeight = pageFrame.width * lineHeightRatio
-        let lastLineIndex = CGFloat(max(lineCount - 1, 1))
+        if data.metrics.allowLineOverlap {
+            return overlappingHighlightRects(
+                for: highlightedVerses,
+                spans: spans,
+                in: pageFrame,
+                data: data
+            )
+        }
+
+        let lineRanges = Dictionary(uniqueKeysWithValues: selectionLineRanges(in: pageFrame, data: data).map {
+            ($0.lineNumber, $0.hitFrame)
+        })
+
+        return spans.compactMap { span in
+            guard highlightedVerses.contains(span.ayah) else {
+                return nil
+            }
+            guard let hitFrame = lineRanges[span.line] else {
+                return nil
+            }
+
+            let x = hitFrame.minX + (span.left * pageFrame.width)
+            let width = ceil((span.right - span.left) * pageFrame.width)
+            return LinePageHighlightRect(
+                ayah: span.ayah,
+                rect: CGRect(x: x, y: hitFrame.minY, width: width, height: hitFrame.height)
+            )
+        }
+    }
+
+    private func overlappingHighlightRects(
+        for highlightedVerses: Set<AyahNumber>,
+        spans: [LinePageHighlightSpan],
+        in pageFrame: CGRect,
+        data: LinePageGeometryData
+    ) -> [LinePageHighlightRect] {
+        let drawLineHeight = lineImageHeight(in: pageFrame, metrics: data.metrics)
+        let lastLineIndex = CGFloat(max(data.lineCount - 1, 1))
         let lineHeightWithoutOverlap = (pageFrame.height - drawLineHeight) / lastLineIndex
         let yStart = (drawLineHeight - lineHeightWithoutOverlap) / 2
 
@@ -530,17 +631,14 @@ public struct LinePageGeometryEngine {
     private func ayahMarkerPlacements(
         markers: [LinePageAyahMarker],
         in pageFrame: CGRect,
-        lineCount: Int
+        data: LinePageGeometryData
     ) -> [LinePageAyahMarkerPlacement] {
-        let lastLineIndex = CGFloat(max(lineCount - 1, 1))
-        let lineHeight = pageFrame.width * lineHeightRatio
         let markerDimension = 0.05 * pageFrame.width
 
         return markers.map { marker in
-            let lineIndex = CGFloat(marker.line)
+            let contentFrame = lineContentFrame(in: pageFrame, lineIndex: marker.line, data: data)
             let x = pageFrame.minX + ((marker.centerX * pageFrame.width) - (markerDimension / 2))
-            let yStart = ((pageFrame.height - lineHeight) / lastLineIndex) * lineIndex
-            let y = pageFrame.minY + yStart + (marker.centerY * lineHeight) - (markerDimension / 2)
+            let y = contentFrame.minY + (marker.centerY * contentFrame.height) - (markerDimension / 2)
 
             return LinePageAyahMarkerPlacement(
                 marker: marker,
@@ -552,19 +650,16 @@ public struct LinePageGeometryEngine {
     private func suraHeaderPlacements(
         headers: [LinePageSuraHeader],
         in pageFrame: CGRect,
-        lineCount: Int,
+        data: LinePageGeometryData,
         aspectRatio: CGFloat
     ) -> [LinePageSuraHeaderPlacement] {
-        let lastLineIndex = CGFloat(max(lineCount - 1, 1))
-        let lineHeight = pageFrame.width * lineHeightRatio
         let width = pageFrame.width * suraHeaderWidthRatio
         let height = width * aspectRatio
 
         return headers.map { header in
-            let lineIndex = CGFloat(header.line)
+            let contentFrame = lineContentFrame(in: pageFrame, lineIndex: header.line, data: data)
             let x = pageFrame.minX + ((header.centerX * pageFrame.width) - (width / 2))
-            let yStart = ((pageFrame.height - lineHeight) / lastLineIndex) * lineIndex
-            let y = pageFrame.minY + yStart + (header.centerY * lineHeight) - (height / 2)
+            let y = contentFrame.minY + (header.centerY * contentFrame.height) - (height / 2)
 
             return LinePageSuraHeaderPlacement(
                 header: header,
@@ -576,7 +671,8 @@ public struct LinePageGeometryEngine {
     private func sidelinePlacements(
         for sidelines: [LinePageGeometryData.Sideline],
         in sidelineFrame: CGRect?,
-        parity: LinePageParity
+        parity: LinePageParity,
+        data: LinePageGeometryData
     ) -> [LinePageSidelinePlacement] {
         guard let sidelineFrame else {
             return []
@@ -588,7 +684,7 @@ public struct LinePageGeometryEngine {
             }
             return lhs.targetLine < rhs.targetLine
         }
-        let lineHeight = sidelineFrame.height / 15
+        let lineHeight = sidelineFrame.height / CGFloat(max(data.lineCount, 1))
 
         let locations = sortedSidelines.map { sideline -> ClosedRange<CGFloat> in
             let targetLineTop = lineHeight * CGFloat(sideline.targetLine - 1)
@@ -610,7 +706,8 @@ public struct LinePageGeometryEngine {
                 sortedSidelines: sortedSidelines,
                 locations: locations,
                 containerWidth: sidelineFrame.width,
-                lineHeight: lineHeight
+                lineHeight: lineHeight,
+                metrics: data.metrics
             )
 
             let y: CGFloat
@@ -647,13 +744,14 @@ public struct LinePageGeometryEngine {
         sortedSidelines: [LinePageGeometryData.Sideline],
         locations: [ClosedRange<CGFloat>],
         containerWidth: CGFloat,
-        lineHeight: CGFloat
+        lineHeight: CGFloat,
+        metrics: LinePageMetrics
     ) -> CGSize {
         let intrinsic = sideline.intrinsicSize
         let overlapsNext = locations.count > index + 1 && locations[index + 1].lowerBound < locations[index].upperBound
 
         if overlapsNext {
-            let originalLinesSpanned = Int(ceil(intrinsic.height / (1.35 * intrinsicLineHeight)))
+            let originalLinesSpanned = Int(ceil(intrinsic.height / (1.35 * CGFloat(metrics.intrinsicLineHeight))))
             let nextUsedLine: Int = if sideline.direction == .up {
                 (sortedSidelines.filter { $0.targetLine < sideline.targetLine }
                     .map(\.targetLine)
@@ -682,7 +780,7 @@ public struct LinePageGeometryEngine {
             )
         }
 
-        let originalLinesSpanned = Int(ceil(intrinsic.height / (1.35 * intrinsicLineHeight)))
+        let originalLinesSpanned = Int(ceil(intrinsic.height / (1.35 * CGFloat(metrics.intrinsicLineHeight))))
         let originalTargetHeight = CGFloat(originalLinesSpanned) * lineHeight
         let targetHeight = abs(intrinsic.height + originalTargetHeight) / 2
         return CGSize(
@@ -694,9 +792,9 @@ public struct LinePageGeometryEngine {
     private func selectionAnchors(
         for spans: [LinePageHighlightSpan],
         in pageFrame: CGRect,
-        lineCount: Int
+        data: LinePageGeometryData
     ) -> [AyahNumber: LinePageSelectionAnchors] {
-        let lineRanges = Dictionary(uniqueKeysWithValues: selectionLineRanges(in: pageFrame, lineCount: lineCount).map {
+        let lineRanges = Dictionary(uniqueKeysWithValues: selectionLineRanges(in: pageFrame, data: data).map {
             ($0.lineNumber, $0.hitFrame)
         })
 
@@ -729,6 +827,24 @@ public struct LinePageGeometryEngine {
             height: hitFrame.height
         )
     }
+
+    private func minimumPageHeightToWidthRatio(data: LinePageGeometryData) -> CGFloat {
+        guard !data.metrics.allowLineOverlap else {
+            return overlappingPageMinimumHeightToWidthRatio
+        }
+
+        return max(
+            overlappingPageMinimumHeightToWidthRatio,
+            CGFloat(data.lineCount) * CGFloat(data.metrics.lineHeightRatio)
+        )
+    }
+
+    private func scrollablePageHeightToWidthRatio(data: LinePageGeometryData) -> CGFloat {
+        max(
+            scrollableOverlappingPageHeightToWidthRatio,
+            minimumPageHeightToWidthRatio(data: data)
+        )
+    }
 }
 
 private struct SelectionLineRange: Sendable {
@@ -738,13 +854,11 @@ private struct SelectionLineRange: Sendable {
 }
 
 private let headerFooterHeightRatio: CGFloat = 0.04
-private let pageMinWidthToHeightRatio: CGFloat = 1 / 1.60
+private let overlappingPageMinimumHeightToWidthRatio: CGFloat = 1.60
 private let pageMaxWidthToHeightRatio: CGFloat = 1 / 1.84
 private let headerFooterMarginRatio: CGFloat = 0.027
 private let scrollablePageWidthRatio: CGFloat = 0.97
 private let scrollableMaximumPageWidth: CGFloat = 1080
-private let scrollablePageHeightToWidthRatio: CGFloat = 1.76
+private let scrollableOverlappingPageHeightToWidthRatio: CGFloat = 1.76
 private let sidelineWidthRatio: CGFloat = 0.1
-private let lineHeightRatio: CGFloat = 174 / 1080
 private let suraHeaderWidthRatio: CGFloat = 1038 / 1080
-private let intrinsicLineHeight: CGFloat = 174

--- a/Domain/ImageService/Sources/LinePageWordFrameAdapter.swift
+++ b/Domain/ImageService/Sources/LinePageWordFrameAdapter.swift
@@ -21,6 +21,7 @@ public struct LinePageWordFrameAdapter {
     public func wordFrames(
         from highlightSpans: [LinePageHighlightSpan],
         quran: Quran,
+        metrics: LinePageMetrics = .madaniLinePages(widthParameter: 1080),
         lineCount: Int
     ) -> WordFrameCollection {
         guard !highlightSpans.isEmpty else {
@@ -33,7 +34,13 @@ public struct LinePageWordFrameAdapter {
         let frames = orderedSpans.map { span in
             let segmentNumber = nextSegmentByAyah[span.ayah, default: 0] + 1
             nextSegmentByAyah[span.ayah] = segmentNumber
-            return syntheticWordFrame(for: span, quran: quran, lineCount: lineCount, segmentNumber: segmentNumber)
+            return syntheticWordFrame(
+                for: span,
+                quran: quran,
+                metrics: metrics,
+                lineCount: lineCount,
+                segmentNumber: segmentNumber
+            )
         }
 
         return processor.processWordFrames(frames)
@@ -41,9 +48,7 @@ public struct LinePageWordFrameAdapter {
 
     // MARK: Private
 
-    private static let pageWidth: CGFloat = 1080
-    private static let pageHeightToWidthRatio: CGFloat = 1.76
-    private static let lineHeightRatio: CGFloat = 174 / 1080
+    private static let overlappingPageHeightToWidthRatio: CGFloat = 1.76
 
     private let processor = WordFrameProcessor()
 
@@ -61,12 +66,14 @@ public struct LinePageWordFrameAdapter {
     private func syntheticWordFrame(
         for span: LinePageHighlightSpan,
         quran: Quran,
+        metrics: LinePageMetrics,
         lineCount: Int,
         segmentNumber: Int
     ) -> WordFrame {
-        let lineFrame = canonicalLineFrame(for: span.line, lineCount: lineCount)
-        let minX = Int(floor(span.left * Self.pageWidth))
-        let maxX = Int(ceil(span.right * Self.pageWidth))
+        let pageWidth = canonicalPageWidth(metrics: metrics)
+        let lineFrame = canonicalLineFrame(for: span.line, metrics: metrics, lineCount: lineCount)
+        let minX = Int(floor(span.left * pageWidth))
+        let maxX = Int(ceil(span.right * pageWidth))
         let minY = Int(floor(lineFrame.minY))
         let maxY = Int(ceil(lineFrame.maxY))
 
@@ -80,11 +87,35 @@ public struct LinePageWordFrameAdapter {
         )
     }
 
-    private func canonicalLineFrame(for lineIndex: Int, lineCount: Int) -> CGRect {
-        let imageLineHeight = Self.pageWidth * Self.lineHeightRatio
-        let pageHeight = Self.pageWidth * Self.pageHeightToWidthRatio
-        let lastLineIndex = CGFloat(max(lineCount - 1, 1))
-        let imageY = floor((pageHeight - imageLineHeight) / lastLineIndex * CGFloat(lineIndex))
-        return CGRect(x: 0, y: imageY, width: Self.pageWidth, height: imageLineHeight)
+    private func canonicalLineFrame(for lineIndex: Int, metrics: LinePageMetrics, lineCount: Int) -> CGRect {
+        let pageWidth = canonicalPageWidth(metrics: metrics)
+        let pageHeight = canonicalPageHeight(metrics: metrics, lineCount: lineCount)
+        let imageLineHeight = CGFloat(metrics.intrinsicLineHeight)
+        let imageY: CGFloat
+
+        if metrics.allowLineOverlap {
+            let lastLineIndex = CGFloat(max(lineCount - 1, 1))
+            imageY = floor((pageHeight - imageLineHeight) / lastLineIndex * CGFloat(lineIndex))
+        } else {
+            let slotHeight = pageHeight / CGFloat(max(lineCount, 1))
+            imageY = (slotHeight * CGFloat(lineIndex)) + ((slotHeight - imageLineHeight) / 2)
+        }
+
+        return CGRect(x: 0, y: imageY, width: pageWidth, height: imageLineHeight)
+    }
+
+    private func canonicalPageWidth(metrics: LinePageMetrics) -> CGFloat {
+        CGFloat(metrics.intrinsicLineHeight / metrics.lineHeightRatio)
+    }
+
+    private func canonicalPageHeight(metrics: LinePageMetrics, lineCount: Int) -> CGFloat {
+        let pageWidth = canonicalPageWidth(metrics: metrics)
+        let minimumHeightToWidthRatio: CGFloat = metrics.allowLineOverlap
+            ? Self.overlappingPageHeightToWidthRatio
+            : max(
+                Self.overlappingPageHeightToWidthRatio,
+                CGFloat(lineCount) * CGFloat(metrics.lineHeightRatio)
+            )
+        return pageWidth * minimumHeightToWidthRatio
     }
 }

--- a/Domain/ImageService/Tests/LinePageAssetServiceTests.swift
+++ b/Domain/ImageService/Tests/LinePageAssetServiceTests.swift
@@ -36,6 +36,25 @@ final class LinePageAssetServiceTests: XCTestCase {
         XCTAssertFalse(service.hasRequiredStructure())
     }
 
+    func testRequiredStructureChecksFirstConfiguredVisiblePage() throws {
+        try createAyahInfoDatabase()
+        try createPage(pageNumber: 1, missingLines: Set(2 ... 15))
+        try createPage(pageNumber: 2, missingLines: Set(2 ... 15))
+
+        let service = makeService(requiredPageNumbers: [2, 3])
+
+        XCTAssertTrue(service.hasRequiredStructure())
+    }
+
+    func testRequiredStructureReturnsUnavailableWhenFirstConfiguredVisiblePageIsMissing() throws {
+        try createAyahInfoDatabase()
+        try createPage(pageNumber: 1, missingLines: Set(2 ... 15))
+
+        let service = makeService(requiredPageNumbers: [2, 3])
+
+        XCTAssertFalse(service.hasRequiredStructure())
+    }
+
     func testAssetsForPageReturnsAvailableWhenSidelinesAreMissing() async throws {
         try createAyahInfoDatabase()
         try createPage(pageNumber: 1)
@@ -53,15 +72,42 @@ final class LinePageAssetServiceTests: XCTestCase {
         }
     }
 
+    func testAssetsForPageUsesMetricsLineCount() async throws {
+        try createAyahInfoDatabase()
+        try createPage(pageNumber: 1, lineCount: 2)
+
+        let service = makeService(
+            metrics: LinePageMetrics(
+                widthParameter: 1440,
+                lineCount: 2,
+                lineHeightRatio: 174 / 1080,
+                intrinsicLineHeight: 174,
+                allowLineOverlap: true
+            ),
+            requiredPageNumbers: [1]
+        )
+        let page = try XCTUnwrap(Page(quran: .hafsMadani1440, pageNumber: 1))
+
+        switch await service.assetsForPage(page) {
+        case .available(let assets):
+            XCTAssertEqual(assets.lines.map(\.lineNumber), [1, 2])
+        case .unavailable:
+            XCTFail("Expected available assets")
+        }
+    }
+
     // MARK: Private
 
     private lazy var rootURL = FileManager.default.temporaryDirectory
         .appendingPathComponent(UUID().uuidString, isDirectory: true)
 
-    private func makeService(requiredPageNumbers: [Int]) -> LinePageAssetService {
+    private func makeService(
+        metrics: LinePageMetrics = .madaniLinePages(widthParameter: 1440),
+        requiredPageNumbers: [Int]
+    ) -> LinePageAssetService {
         LinePageAssetService(
             readingDirectory: rootURL,
-            widthParameter: 1440,
+            metrics: metrics,
             requiredPageNumbers: requiredPageNumbers,
             fileSystem: DefaultFileSystem()
         )
@@ -78,14 +124,19 @@ final class LinePageAssetServiceTests: XCTestCase {
         )
     }
 
-    private func createPage(pageNumber: Int, missingLines: Set<Int> = [], includeSidelines: Bool = false) throws {
+    private func createPage(
+        pageNumber: Int,
+        lineCount: Int = 15,
+        missingLines: Set<Int> = [],
+        includeSidelines: Bool = false
+    ) throws {
         let pageDirectory = rootURL
             .appendingPathComponent("images_1440")
             .appendingPathComponent("width_1440")
             .appendingPathComponent(String(pageNumber), isDirectory: true)
         try FileManager.default.createDirectory(at: pageDirectory, withIntermediateDirectories: true, attributes: nil)
 
-        for lineNumber in 1 ... 15 where !missingLines.contains(lineNumber) {
+        for lineNumber in 1 ... lineCount where !missingLines.contains(lineNumber) {
             try makePNG().write(to: pageDirectory.appendingPathComponent("\(lineNumber).png"))
         }
 

--- a/Domain/ImageService/Tests/LinePageGeometryTests.swift
+++ b/Domain/ImageService/Tests/LinePageGeometryTests.swift
@@ -200,6 +200,38 @@ final class LinePageGeometryTests: XCTestCase {
         XCTAssertNil(layout.sidelineFrame)
     }
 
+    func testNonOverlappingMetricsPlaceLinesInEvenSlots() throws {
+        let metrics = LinePageMetrics.naskhLinePages
+        let layout = makeEngine().layout(
+            LinePageGeometryInput(
+                availableSize: CGSize(width: 400, height: 800),
+                orientation: .portrait,
+                pageParity: .odd,
+                displaySettings: LinePageDisplaySettings(showHeaderFooter: true, showSidelines: false),
+                data: makeData(metrics: metrics),
+                suraHeaderAspectRatio: 0.25
+            )
+        )
+
+        let slotHeight = layout.pageFrame.height / CGFloat(metrics.lineCount)
+        let imageLineHeight = layout.pageFrame.width * CGFloat(metrics.lineHeightRatio)
+        let expectedFirstImageY = layout.pageFrame.minY + ((slotHeight - imageLineHeight) / 2)
+
+        assertEqual(
+            layout.lineFrames[0].hitFrame,
+            CGRect(x: layout.pageFrame.minX, y: layout.pageFrame.minY, width: layout.pageFrame.width, height: slotHeight)
+        )
+        XCTAssertEqual(layout.lineFrames[0].imageFrame.minY, expectedFirstImageY, accuracy: 0.001)
+        XCTAssertEqual(layout.lineFrames[0].imageFrame.height, imageLineHeight, accuracy: 0.001)
+
+        for lineIndex in 0 ..< layout.lineFrames.count - 1 {
+            XCTAssertLessThanOrEqual(
+                layout.lineFrames[lineIndex].imageFrame.maxY,
+                layout.lineFrames[lineIndex + 1].imageFrame.minY
+            )
+        }
+    }
+
     // MARK: Private
 
     private let quran = Quran.hafsMadani1405
@@ -211,9 +243,11 @@ final class LinePageGeometryTests: XCTestCase {
     }
 
     private func makeData(
+        metrics: LinePageMetrics = .madaniLinePages(widthParameter: 1080),
         sidelines: [LinePageGeometryData.Sideline] = []
     ) -> LinePageGeometryData {
         LinePageGeometryData(
+            metrics: metrics,
             highlightSpans: [
                 .init(ayah: try! ayah(1, 1), line: 5, left: 0.2445, right: 0.7555),
                 .init(ayah: try! ayah(1, 2), line: 6, left: 0.156, right: 0.844),

--- a/Features/QuranImageFeature/ContentImageBuilder.swift
+++ b/Features/QuranImageFeature/ContentImageBuilder.swift
@@ -64,12 +64,13 @@ public struct ContentImageBuilder {
     }
 
     static func buildLinePageAssetService(reading: Reading, container: AppDependencies) -> LinePageAssetService {
-        guard let widthParameter = reading.linePageAssetWidth else {
+        guard let metrics = reading.linePageMetrics else {
             preconditionFailure("Attempted to build line-page assets for non-line-page reading \(reading)")
         }
         return LinePageAssetService(
             readingDirectory: Self.readingDirectory(reading, container: container),
-            widthParameter: widthParameter
+            metrics: metrics,
+            quran: reading.quran
         )
     }
 

--- a/Features/QuranImageFeature/ContentLineViewModel.swift
+++ b/Features/QuranImageFeature/ContentLineViewModel.swift
@@ -29,7 +29,16 @@ final class ContentLineViewModel: ObservableObject {
         self.reading = reading
         self.page = page
         self.linePageAssetService = linePageAssetService
+        linePageMetrics = reading.linePageMetrics ?? .madaniLinePages(widthParameter: 1080)
         highlights = highlightsService.highlights
+
+        geometryData = LinePageGeometryData(
+            metrics: linePageMetrics,
+            highlightSpans: [],
+            ayahMarkers: [],
+            suraHeaders: [],
+            sidelines: []
+        )
 
         highlightsService.$highlights
             .sink { [weak self] in self?.highlights = $0 }
@@ -47,12 +56,7 @@ final class ContentLineViewModel: ObservableObject {
     let page: Page
 
     @Published var assets: LinePageAssets?
-    @Published private(set) var geometryData = LinePageGeometryData(
-        highlightSpans: [],
-        ayahMarkers: [],
-        suraHeaders: [],
-        sidelines: []
-    )
+    @Published private(set) var geometryData: LinePageGeometryData
     @Published var highlights: QuranHighlights
     @Published var scrollToVerse: AyahNumber?
 
@@ -72,6 +76,7 @@ final class ContentLineViewModel: ObservableObject {
         wordFrameAdapter.wordFrames(
             from: geometryData.highlightSpans,
             quran: page.quran,
+            metrics: linePageMetrics,
             lineCount: geometryData.lineCount
         )
     }
@@ -87,6 +92,7 @@ final class ContentLineViewModel: ObservableObject {
             let persistence = GRDBLinePagePersistence(fileURL: assets.ayahInfoDatabaseURL)
             self.assets = assets
             geometryData = LinePageGeometryData(
+                metrics: linePageMetrics,
                 lineCount: assets.lines.count,
                 highlightSpans: [],
                 ayahMarkers: [],
@@ -103,6 +109,7 @@ final class ContentLineViewModel: ObservableObject {
                 let loadedSuraHeaders = try await suraHeaders
 
                 geometryData = LinePageGeometryData(
+                    metrics: linePageMetrics,
                     lineCount: assets.lines.count,
                     highlightSpans: loadedHighlightSpans,
                     ayahMarkers: loadedAyahMarkers,
@@ -136,6 +143,7 @@ final class ContentLineViewModel: ObservableObject {
                     showSidelines: !geometryData.sidelines.isEmpty
                 ),
                 data: LinePageGeometryData(
+                    metrics: linePageMetrics,
                     lineCount: assets.lines.count,
                     highlightSpans: geometryData.highlightSpans,
                     ayahMarkers: geometryData.ayahMarkers,
@@ -179,6 +187,7 @@ final class ContentLineViewModel: ObservableObject {
 
     private let reading: Reading
     private let linePageAssetService: LinePageAssetService
+    private let linePageMetrics: LinePageMetrics
     private let wordFrameAdapter = LinePageWordFrameAdapter()
     private let geometryEngine = LinePageGeometryEngine()
     private var cancellables: Set<AnyCancellable> = []

--- a/Model/QuranKit/Sources/LinePageMetrics.swift
+++ b/Model/QuranKit/Sources/LinePageMetrics.swift
@@ -1,0 +1,50 @@
+//
+//  LinePageMetrics.swift
+//
+//
+//  Created by OpenAI on 2026-04-26.
+//
+
+public struct LinePageMetrics: Equatable, Sendable {
+    // MARK: Lifecycle
+
+    public init(
+        widthParameter: Int,
+        lineCount: Int,
+        lineHeightRatio: Double,
+        intrinsicLineHeight: Double,
+        allowLineOverlap: Bool
+    ) {
+        self.widthParameter = widthParameter
+        self.lineCount = lineCount
+        self.lineHeightRatio = lineHeightRatio
+        self.intrinsicLineHeight = intrinsicLineHeight
+        self.allowLineOverlap = allowLineOverlap
+    }
+
+    // MARK: Public
+
+    public let widthParameter: Int
+    public let lineCount: Int
+    public let lineHeightRatio: Double
+    public let intrinsicLineHeight: Double
+    public let allowLineOverlap: Bool
+
+    public static func madaniLinePages(widthParameter: Int) -> LinePageMetrics {
+        LinePageMetrics(
+            widthParameter: widthParameter,
+            lineCount: 15,
+            lineHeightRatio: 174 / 1080,
+            intrinsicLineHeight: 174,
+            allowLineOverlap: true
+        )
+    }
+
+    public static let naskhLinePages = LinePageMetrics(
+        widthParameter: 1342,
+        lineCount: 15,
+        lineHeightRatio: 148 / 1342,
+        intrinsicLineHeight: 148,
+        allowLineOverlap: false
+    )
+}

--- a/Model/QuranKit/Sources/Reading.swift
+++ b/Model/QuranKit/Sources/Reading.swift
@@ -39,18 +39,22 @@ public enum Reading: Int {
     }
 
     public var usesLinePages: Bool {
-        linePageAssetWidth != nil
+        linePageMetrics != nil
     }
 
-    public var linePageAssetWidth: Int? {
+    public var linePageMetrics: LinePageMetrics? {
         switch self {
         case .hafs_1439:
-            return 1080
+            return .madaniLinePages(widthParameter: 1080)
         case .hafs_1441:
-            return 1440
+            return .madaniLinePages(widthParameter: 1440)
         default:
             return nil
         }
+    }
+
+    public var linePageAssetWidth: Int? {
+        linePageMetrics?.widthParameter
     }
 
     public var imageAssetWidth: Int {


### PR DESCRIPTION
Madani line pages (1439, 1441) render with slightly different
parameters, line ratios, etc to naskh. Moreover, madani lines are made
to slightly overlap each other safely, whereas this is not the case with
naskh lines, which need to split the spacing equally. This patch makes
these parameters.
