### PR TITLE
Add CarPlay audio playback with verse range selection

### DIFF
--- a/Example/QuranEngineApp.xcodeproj/project.pbxproj
+++ b/Example/QuranEngineApp.xcodeproj/project.pbxproj
@@ -17,6 +17,9 @@
 		D975EDEA2A4799A2009DE942 /* reciters.plist in Resources */ = {isa = PBXBuildFile; fileRef = D975EDE92A4799A2009DE942 /* reciters.plist */; };
 		D98543D32A47C88700F477A2 /* hafs_1405 in Resources */ = {isa = PBXBuildFile; fileRef = D98543D22A47C88700F477A2 /* hafs_1405 */; };
 		D98543DD2A49095800F477A2 /* words.db in Resources */ = {isa = PBXBuildFile; fileRef = D98543DC2A49095800F477A2 /* words.db */; };
+		F12C1AE42F57E6CB00BA3E4E /* CarPlayTemplateBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12C1AE22F57E6CB00BA3E4E /* CarPlayTemplateBuilder.swift */; };
+		F12C1AE52F57E6CB00BA3E4E /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F12C1AE12F57E6CB00BA3E4E /* CarPlaySceneDelegate.swift */; };
+		F2B000012F6A000100000001 /* AudioBannerFeature in Frameworks */ = {isa = PBXBuildFile; productRef = F2B000022F6A000100000001 /* AudioBannerFeature */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -33,6 +36,8 @@
 		D98543D22A47C88700F477A2 /* hafs_1405 */ = {isa = PBXFileReference; lastKnownFileType = folder; path = hafs_1405; sourceTree = "<group>"; };
 		D98543D42A47E14200F477A2 /* QuranEngineApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "QuranEngineApp-Bridging-Header.h"; sourceTree = "<group>"; };
 		D98543DC2A49095800F477A2 /* words.db */ = {isa = PBXFileReference; lastKnownFileType = file; path = words.db; sourceTree = "<group>"; };
+		F12C1AE12F57E6CB00BA3E4E /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
+		F12C1AE22F57E6CB00BA3E4E /* CarPlayTemplateBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayTemplateBuilder.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -40,6 +45,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F2B000012F6A000100000001 /* AudioBannerFeature in Frameworks */,
 				D975EDE22A4795BD009DE942 /* AppStructureFeature in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -78,6 +84,8 @@
 			isa = PBXGroup;
 			children = (
 				D975EDC52A4791D6009DE942 /* AppDelegate.swift */,
+				F12C1AE12F57E6CB00BA3E4E /* CarPlaySceneDelegate.swift */,
+				F12C1AE22F57E6CB00BA3E4E /* CarPlayTemplateBuilder.swift */,
 				D975EDC72A4791D6009DE942 /* SceneDelegate.swift */,
 				D975EDE42A47960D009DE942 /* Container.swift */,
 				D975EDE62A4796AA009DE942 /* Analytics.swift */,
@@ -123,6 +131,7 @@
 			);
 			name = QuranEngineApp;
 			packageProductDependencies = (
+				F2B000022F6A000100000001 /* AudioBannerFeature */,
 				D975EDE12A4795BD009DE942 /* AppStructureFeature */,
 			);
 			productName = QuranEngineApp;
@@ -181,12 +190,14 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
-		/* Begin PBXSourcesBuildPhase section */
+/* Begin PBXSourcesBuildPhase section */
 		D975EDBE2A4791D6009DE942 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				D975EDC62A4791D6009DE942 /* AppDelegate.swift in Sources */,
+				F12C1AE42F57E6CB00BA3E4E /* CarPlayTemplateBuilder.swift in Sources */,
+				F12C1AE52F57E6CB00BA3E4E /* CarPlaySceneDelegate.swift in Sources */,
 				D975EDE52A47960D009DE942 /* Container.swift in Sources */,
 				D975EDE72A4796AA009DE942 /* Analytics.swift in Sources */,
 				D975EDC82A4791D6009DE942 /* SceneDelegate.swift in Sources */,
@@ -423,6 +434,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D975EDEB2A479A50009DE942 /* XCLocalSwiftPackageReference ".." */;
 			productName = AppStructureFeature;
+		};
+		F2B000022F6A000100000001 /* AudioBannerFeature */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D975EDEB2A479A50009DE942 /* XCLocalSwiftPackageReference ".." */;
+			productName = AudioBannerFeature;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Example/QuranEngineApp/Classes/AppDelegate.swift
+++ b/Example/QuranEngineApp/Classes/AppDelegate.swift
@@ -1,10 +1,5 @@
-//
-//  AppDelegate.swift
-//  QuranEngineApp
-//
-//  Created by Mohamed Afifi on 2023-06-24.
-//
-
+import AudioBannerFeature
+import CarPlay
 import AppStructureFeature
 import Logging
 import NoorFont
@@ -20,6 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         FontName.registerFonts()
         LoggingSystem.bootstrap(StreamLogHandler.standardError)
+        AudioPlaybackControllerStore.setUpIfNeeded(container: container)
 
         Task {
             // Eagerly load download manager to handle any background downloads.
@@ -34,8 +30,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     // MARK: UISceneSession Lifecycle
 
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        switch connectingSceneSession.role {
+        case .carTemplateApplication:
+            UISceneConfiguration(
+                name: "CarPlay Configuration",
+                sessionRole: connectingSceneSession.role
+            )
+        default:
+            UISceneConfiguration(
+                name: "Default Configuration",
+                sessionRole: connectingSceneSession.role
+            )
+        }
     }
 
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {

--- a/Example/QuranEngineApp/Classes/CarPlaySceneDelegate.swift
+++ b/Example/QuranEngineApp/Classes/CarPlaySceneDelegate.swift
@@ -1,0 +1,1007 @@
+import AudioBannerFeature
+import CarPlay
+import MediaPlayer
+import QueuePlayer
+import QuranAudio
+import QuranAudioKit
+import QuranKit
+import ReciterService
+import UIKit
+
+@MainActor
+final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
+    private var interfaceController: CPInterfaceController?
+    private var playbackController: AudioPlaybackController?
+    private var playbackObserverId: UUID?
+    private var chaptersTemplate: CPListTemplate?
+    private var recitersTemplate: CPListTemplate?
+    private var playbackModesTemplate: CPListTemplate?
+    private var customPlaybackTemplate: CPListTemplate?
+    private var chapters: [ChapterInfo] = []
+    private var reciters: [Reciter] = []
+    private let audioPreferences = AudioPreferences.shared
+    private var selectedSurahNumber = 1
+    private var selectedReciterId: Int?
+    private var selectedPlaybackMode = AudioEnd.juz
+    private var customPlaybackSelection: CarPlayVersePlaybackSelection?
+    private var customPlaybackStatus: CarPlayPlaybackStatus = .ready
+    private var customPlaybackAvailabilityTask: Task<Void, Never>?
+    private var lastObservedPlaybackState: AudioPlaybackController.PlaybackState?
+    private var isPresentingNowPlaying = false
+    private let versePickerLeafSize = 10
+    private var chapterPickerListLimit: Int { max(Int(CPListTemplate.maximumItemCount), 1) }
+
+    func templateApplicationScene(
+        _ templateApplicationScene: CPTemplateApplicationScene,
+        didConnect interfaceController: CPInterfaceController
+    ) {
+        self.interfaceController = interfaceController
+        chapters = createChapters()
+
+        guard let playbackController = AudioPlaybackControllerStore.shared else {
+            print("[CarPlay] No shared AudioPlaybackController available")
+            return
+        }
+
+        self.playbackController = playbackController
+        observePlaybackController(playbackController)
+        selectedPlaybackMode = audioPreferences.audioEnd
+
+        Task { @MainActor in
+            let reciters = await playbackController.getReciters()
+            self.reciters = reciters
+            let snapshot = playbackController.snapshot
+            selectedSurahNumber = snapshot.surahNumber ?? selectedSurahNumber
+            selectedReciterId = snapshot.reciter?.id ?? reciters.first?.id
+            resetCustomPlaybackSelection()
+
+            let builder = CarPlayTemplateBuilder.shared
+            let chaptersTemplate: CPListTemplate = if chapters.count > chapterPickerListLimit {
+                builder.makeChapterBucketTemplate(
+                    title: "Quran Chapters",
+                    tabTitle: "Surahs",
+                    tabImage: "book.closed",
+                    buckets: chapterBuckets(for: chapters),
+                    selectedChapterNumber: selectedSurahNumber,
+                    selectionHandler: { [weak self] bucket in
+                        self?.didSelectChapterBucket(bucket)
+                    }
+                )
+            } else {
+                builder.makeChapterListTemplate(
+                    chapters: chapters,
+                    selectedSurahNumber: selectedSurahNumber,
+                    selectedSurahStatus: selectedSurahStatusDetail,
+                    selectionHandler: { [weak self] chapter in
+                        self?.didSelectChapter(chapter)
+                    }
+                )
+            }
+            let recitersTemplate = builder.makeRecitersTemplate(
+                reciters: reciterInfos(),
+                selectedReciterId: selectedReciterId,
+                selectionHandler: { [weak self] reciter in
+                    self?.didSelectReciter(reciter)
+                }
+            )
+            let playbackModesTemplate = builder.makePlaybackModesTemplate(
+                playbackOptions: playbackOptions,
+                selectedMode: selectedPlaybackMode,
+                customPlaybackSummary: customPlaybackSummary,
+                selectionHandler: { [weak self] option in
+                    self?.didSelectPlaybackOption(option)
+                }
+            )
+
+            self.chaptersTemplate = chaptersTemplate
+            self.recitersTemplate = recitersTemplate
+            self.playbackModesTemplate = playbackModesTemplate
+
+            do {
+                let requestedTemplates: [CPTemplate] = [
+                    chaptersTemplate,
+                    recitersTemplate,
+                    playbackModesTemplate,
+                ]
+                let maxTabCount = max(Int(CPTabBarTemplate.maximumTabCount), 1)
+                let rootTemplates = Array(requestedTemplates.prefix(maxTabCount))
+                print(
+                    "[CarPlay] Root templates requested=\(requestedTemplates.count), maxTabCount=\(maxTabCount)"
+                )
+
+                let rootTemplate = builder.makeRootTemplate(templates: rootTemplates)
+                try await interfaceController.setRootTemplate(rootTemplate, animated: true)
+                refreshTemplates()
+                updateNowPlayingInfo(with: snapshot)
+            } catch {
+                print("[CarPlay] Failed to set root template: \(error)")
+            }
+        }
+    }
+
+    private func observePlaybackController(_ playbackController: AudioPlaybackController) {
+        playbackObserverId = playbackController.addObserver { [weak self] snapshot in
+            self?.handlePlaybackSnapshot(snapshot)
+        }
+    }
+
+    private func handlePlaybackSnapshot(_ snapshot: AudioPlaybackController.Snapshot) {
+        if let surahNumber = snapshot.surahNumber {
+            selectedSurahNumber = surahNumber
+        }
+        if let reciterId = snapshot.reciter?.id {
+            selectedReciterId = reciterId
+        }
+
+        synchronizeCustomPlaybackStatus(with: snapshot)
+        refreshTemplates()
+        updateNowPlayingInfo(with: snapshot)
+
+        if case .playing = snapshot.playbackState, !isPlaying(lastObservedPlaybackState) {
+            Task { @MainActor in
+                await presentNowPlayingIfNeeded()
+            }
+        }
+
+        lastObservedPlaybackState = snapshot.playbackState
+    }
+
+    private func didSelectChapter(_ chapter: ChapterInfo) {
+        selectedSurahNumber = chapter.number
+        resetCustomPlaybackSelection()
+        refreshTemplates()
+        Task { @MainActor in
+            await playCurrentSelection()
+        }
+    }
+
+    private func didSelectReciter(_ reciterInfo: ReciterInfo) {
+        guard let playbackController,
+              let reciter = reciters.first(where: { $0.id == reciterInfo.id }) else {
+            return
+        }
+
+        selectedReciterId = reciter.id
+        playbackController.setReciter(reciter)
+        refreshCustomPlaybackAvailability()
+        refreshTemplates()
+        updateNowPlayingInfo(with: playbackController.snapshot)
+    }
+
+    private func didSelectPlaybackOption(_ option: CarPlayPlaybackOption) {
+        switch option {
+        case .audioEnd(let mode):
+            selectedPlaybackMode = mode
+            audioPreferences.audioEnd = mode
+            refreshTemplates()
+            Task { @MainActor in
+                await playCurrentSelection()
+            }
+        case .selectVerses:
+            Task { @MainActor in
+                await showCustomPlaybackTemplate()
+            }
+        }
+    }
+
+    private func playCurrentSelection() async {
+        guard let playbackController else {
+            return
+        }
+
+        let quran = Quran.hafsMadani1405
+        guard quran.suras.indices.contains(selectedSurahNumber - 1) else {
+            return
+        }
+
+        let surah = quran.suras[selectedSurahNumber - 1]
+        let request = playbackRequest(for: surah, audioEnd: selectedPlaybackMode)
+
+        do {
+            try await playbackController.play(
+                from: request.start,
+                to: request.end,
+                verseRuns: request.verseRuns,
+                listRuns: request.listRuns
+            )
+            updateNowPlayingInfo(with: playbackController.snapshot)
+            await presentNowPlayingIfNeeded()
+        } catch {
+            await presentPlaybackFailureAlert()
+            print("[CarPlay] Failed to play surah \(selectedSurahNumber): \(error)")
+        }
+    }
+
+    private func presentNowPlayingIfNeeded() async {
+        guard let interfaceController,
+              !isPresentingNowPlaying,
+              interfaceController.topTemplate !== CPNowPlayingTemplate.shared else {
+            return
+        }
+
+        do {
+            isPresentingNowPlaying = true
+            defer { isPresentingNowPlaying = false }
+            try await interfaceController.pushTemplate(CPNowPlayingTemplate.shared, animated: true)
+        } catch {
+            print("[CarPlay] Failed to push now playing template: \(error)")
+        }
+    }
+
+    private func refreshTemplates() {
+        let builder = CarPlayTemplateBuilder.shared
+
+        if let chaptersTemplate {
+            if chapters.count > chapterPickerListLimit {
+                builder.updateChapterBucketTemplate(
+                    chaptersTemplate,
+                    title: "Quran Chapters",
+                    buckets: chapterBuckets(for: chapters),
+                    selectedChapterNumber: selectedSurahNumber,
+                    selectionHandler: { [weak self] bucket in
+                        self?.didSelectChapterBucket(bucket)
+                    }
+                )
+            } else {
+                builder.updateChapterListTemplate(
+                    chaptersTemplate,
+                    chapters: chapters,
+                    selectedSurahNumber: selectedSurahNumber,
+                    selectedSurahStatus: selectedSurahStatusDetail,
+                    selectionHandler: { [weak self] chapter in
+                        self?.didSelectChapter(chapter)
+                    }
+                )
+            }
+        }
+
+        if let recitersTemplate {
+            builder.updateRecitersTemplate(
+                recitersTemplate,
+                reciters: reciterInfos(),
+                selectedReciterId: selectedReciterId,
+                selectionHandler: { [weak self] reciter in
+                    self?.didSelectReciter(reciter)
+                }
+            )
+        }
+
+        if let playbackModesTemplate {
+            builder.updatePlaybackModesTemplate(
+                playbackModesTemplate,
+                playbackOptions: playbackOptions,
+                selectedMode: selectedPlaybackMode,
+                customPlaybackSummary: customPlaybackSummary,
+                selectionHandler: { [weak self] option in
+                    self?.didSelectPlaybackOption(option)
+                }
+            )
+        }
+
+        refreshCustomPlaybackTemplate()
+    }
+
+    private func updateNowPlayingInfo(with snapshot: AudioPlaybackController.Snapshot) {
+        var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+
+        if let title = snapshot.surahTitle {
+            info[MPMediaItemPropertyTitle] = title
+        }
+        if let reciterName = snapshot.reciterName {
+            info[MPMediaItemPropertyArtist] = reciterName
+        }
+
+        let existingRate = (info[MPNowPlayingInfoPropertyPlaybackRate] as? NSNumber)?.floatValue ?? 1
+        let playbackRate: Float = switch snapshot.playbackState {
+        case .playing:
+            existingRate
+        case .paused, .stopped, .downloading:
+            0
+        }
+        info[MPNowPlayingInfoPropertyPlaybackRate] = playbackRate
+
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = info.isEmpty ? nil : info
+    }
+
+    private func createChapters() -> [ChapterInfo] {
+        (1 ... 114).map { number in
+            ChapterInfo(id: number, number: number, name: AudioPlaybackController.surahTitle(for: number))
+        }
+    }
+
+    private func reciterInfos() -> [ReciterInfo] {
+        reciters.map { ReciterInfo(id: $0.id, name: $0.localizedName) }
+    }
+
+    private var playbackOptions: [CarPlayPlaybackOption] {
+        [.audioEnd(.juz), .audioEnd(.sura), .audioEnd(.page), .selectVerses]
+    }
+
+    private var customPlaybackSummary: String? {
+        guard let selection = customPlaybackSelection else {
+            return nil
+        }
+        let rangeSummary: String
+        if selection.start.sura == selection.end.sura {
+            rangeSummary = "Ayahs \(selection.start.ayah)-\(selection.end.ayah)"
+        } else {
+            rangeSummary = "\(selection.start.ayah)-\(selection.end.ayah)"
+        }
+        guard let statusSummary = customPlaybackStatus.summaryText else {
+            return rangeSummary
+        }
+        return "\(rangeSummary) - \(statusSummary)"
+    }
+
+    private func isPlaying(_ state: AudioPlaybackController.PlaybackState?) -> Bool {
+        guard let state else {
+            return false
+        }
+        if case .playing = state {
+            return true
+        }
+        return false
+    }
+
+    private func playbackRequest(
+        for surah: Sura,
+        audioEnd: AudioEnd
+    ) -> (start: AyahNumber, end: AyahNumber, verseRuns: Runs, listRuns: Runs) {
+        let start = surah.firstVerse
+        let end = audioEnd.findLastAyah(startAyah: start)
+        return (start, end, .one, .one)
+    }
+
+    private func resetCustomPlaybackSelection() {
+        guard let surah = selectedSurah else {
+            customPlaybackSelection = nil
+            customPlaybackStatus = .ready
+            return
+        }
+        customPlaybackSelection = CarPlayVersePlaybackSelection(
+            start: surah.firstVerse,
+            end: surah.lastVerse,
+            verseRuns: .one,
+            listRuns: .one
+        )
+        customPlaybackStatus = .ready
+        refreshCustomPlaybackAvailability()
+        refreshCustomPlaybackTemplate()
+    }
+
+    private func refreshCustomPlaybackTemplate() {
+        guard let customPlaybackTemplate,
+              let selection = customPlaybackSelection,
+              let surah = selectedSurah else {
+            return
+        }
+        CarPlayTemplateBuilder.shared.updateCustomPlaybackTemplate(
+            customPlaybackTemplate,
+            selection: selection,
+            surahTitle: AudioPlaybackController.surahTitle(for: surah.suraNumber, withNumber: true),
+            playbackStatus: customPlaybackStatus,
+            actionHandler: { [weak self] action in
+                self?.didSelectCustomPlaybackAction(action)
+            }
+        )
+    }
+
+    private func showCustomPlaybackTemplate() async {
+        guard let interfaceController,
+              let selection = customPlaybackSelection,
+              let surah = selectedSurah else {
+            return
+        }
+
+        let template: CPListTemplate
+        if let customPlaybackTemplate {
+            template = customPlaybackTemplate
+            refreshCustomPlaybackTemplate()
+        } else {
+            let newTemplate = CarPlayTemplateBuilder.shared.makeCustomPlaybackTemplate(
+                selection: selection,
+                surahTitle: AudioPlaybackController.surahTitle(for: surah.suraNumber, withNumber: true),
+                playbackStatus: customPlaybackStatus,
+                actionHandler: { [weak self] action in
+                    self?.didSelectCustomPlaybackAction(action)
+                }
+            )
+            customPlaybackTemplate = newTemplate
+            template = newTemplate
+        }
+
+        guard interfaceController.topTemplate !== template else {
+            return
+        }
+
+        do {
+            try await interfaceController.pushTemplate(template, animated: true)
+        } catch {
+            print("[CarPlay] Failed to push custom playback template: \(error)")
+        }
+    }
+
+    private func didSelectCustomPlaybackAction(_ action: CarPlayCustomPlaybackAction) {
+        switch action {
+        case .selectSurah:
+            Task { @MainActor in
+                await showCustomPlaybackSurahPicker()
+            }
+        case .selectStartVerse:
+            Task { @MainActor in
+                await showVersePicker(forStartVerse: true)
+            }
+        case .selectEndVerse:
+            Task { @MainActor in
+                await showVersePicker(forStartVerse: false)
+            }
+        case .selectVerseRuns(let runs):
+            updateCustomPlaybackSelection {
+                $0.verseRuns = runs
+            }
+        case .selectListRuns(let runs):
+            updateCustomPlaybackSelection {
+                $0.listRuns = runs
+            }
+        case .playSelection:
+            Task { @MainActor in
+                await playCustomSelection()
+            }
+        }
+    }
+
+    private func showCustomPlaybackSurahPicker() async {
+        guard let interfaceController else {
+            return
+        }
+
+        let template: CPListTemplate = if chapters.count > chapterPickerListLimit {
+            CarPlayTemplateBuilder.shared.makeChapterBucketTemplate(
+                title: "Select Surah",
+                buckets: chapterBuckets(for: chapters),
+                selectedChapterNumber: selectedSurahNumber,
+                selectionHandler: { [weak self] bucket in
+                    self?.didSelectCustomPlaybackSurahBucket(bucket)
+                }
+            )
+        } else {
+            CarPlayTemplateBuilder.shared.makeSurahPickerTemplate(
+                chapters: chapters,
+                selectedSurahNumber: selectedSurahNumber,
+                selectionHandler: { [weak self] chapter in
+                    self?.didSelectCustomPlaybackSurah(chapter)
+                }
+            )
+        }
+
+        do {
+            try await interfaceController.pushTemplate(template, animated: true)
+        } catch {
+            print("[CarPlay] Failed to push surah picker template: \(error)")
+        }
+    }
+
+    private func didSelectChapterBucket(_ bucket: CarPlayChapterBucket) {
+        Task { @MainActor in
+            await showChapterPicker(
+                title: "Quran Chapters \(chapterRangeTitle(bucket.range))",
+                chapters: chapters(in: bucket),
+                selectionHandler: { [weak self] chapter in
+                    self?.didSelectChapter(chapter)
+                }
+            )
+        }
+    }
+
+    private func didSelectCustomPlaybackSurahBucket(_ bucket: CarPlayChapterBucket) {
+        Task { @MainActor in
+            await showChapterPicker(
+                title: "Select Surah \(chapterRangeTitle(bucket.range))",
+                chapters: chapters(in: bucket),
+                selectionHandler: { [weak self] chapter in
+                    self?.didSelectCustomPlaybackSurah(chapter)
+                }
+            )
+        }
+    }
+
+    private func didSelectCustomPlaybackSurah(_ chapter: ChapterInfo) {
+        selectedSurahNumber = chapter.number
+        guard let surah = selectedSurah else {
+            return
+        }
+
+        customPlaybackSelection = CarPlayVersePlaybackSelection(
+            start: surah.firstVerse,
+            end: surah.lastVerse,
+            verseRuns: customPlaybackSelection?.verseRuns ?? .one,
+            listRuns: customPlaybackSelection?.listRuns ?? .one
+        )
+        customPlaybackStatus = .ready
+        refreshCustomPlaybackAvailability()
+        refreshTemplates()
+
+        Task { @MainActor in
+            guard let interfaceController else {
+                return
+            }
+            do {
+                if let customPlaybackTemplate {
+                    try await interfaceController.pop(to: customPlaybackTemplate, animated: true)
+                } else {
+                    try await interfaceController.popTemplate(animated: true)
+                }
+            } catch {
+                print("[CarPlay] Failed to pop surah picker template: \(error)")
+            }
+        }
+    }
+
+    private func showChapterPicker(
+        title: String,
+        chapters: [ChapterInfo],
+        selectionHandler: @escaping (ChapterInfo) -> Void
+    ) async {
+        guard let interfaceController else {
+            return
+        }
+
+        let template = CarPlayTemplateBuilder.shared.makeSurahPickerTemplate(
+            title: title,
+            chapters: chapters,
+            selectedSurahNumber: selectedSurahNumber,
+            selectionHandler: selectionHandler
+        )
+
+        do {
+            try await interfaceController.pushTemplate(template, animated: true)
+        } catch {
+            print("[CarPlay] Failed to push chapter picker template: \(error)")
+        }
+    }
+
+    private func showVersePicker(forStartVerse: Bool) async {
+        guard let interfaceController,
+              let selection = customPlaybackSelection,
+              let surah = selectedSurah else {
+            return
+        }
+
+        let allowedRange = allowedVerseRange(forStartVerse: forStartVerse, selection: selection, surah: surah)
+        let selectedAyah = min(
+            max((forStartVerse ? selection.start : selection.end).ayah, allowedRange.lowerBound),
+            allowedRange.upperBound
+        )
+        let selectedVerse = AyahNumber(sura: surah, ayah: selectedAyah) ?? surah.firstVerse
+        let title = forStartVerse ? "Select Start Verse" : "Select End Verse"
+        let verses = surah.verses.filter { allowedRange.contains($0.ayah) }
+        let bucketNodes = versePickerNodes(for: allowedRange)
+        print(
+            "[CarPlay] Preparing verse picker: surah=\(surah.suraNumber), selectedVerse=\(selectedVerse.ayah), allowedRange=\(rangeTitle(allowedRange)), verseCount=\(verses.count), maxItems=\(versePickerListLimit), leafBucketSize=\(versePickerLeafSize), rootBucketCount=\(bucketNodes.count)"
+        )
+
+        if verses.count <= versePickerListLimit {
+            await showExactVersePicker(
+                using: interfaceController,
+                title: title,
+                surah: surah,
+                range: allowedRange,
+                selectedVerse: selectedVerse,
+                forStartVerse: forStartVerse
+            )
+        } else {
+            await showVerseBucketPicker(
+                using: interfaceController,
+                title: title,
+                surah: surah,
+                nodes: bucketNodes,
+                selectedVerse: selectedVerse,
+                forStartVerse: forStartVerse
+            )
+        }
+    }
+
+    private func didSelectVerse(_ verse: AyahNumber, forStartVerse: Bool) {
+        updateCustomPlaybackSelection { selection in
+            if forStartVerse {
+                selection.start = verse
+                if selection.end < verse {
+                    selection.end = verse
+                }
+            } else {
+                selection.end = verse
+                if verse < selection.start {
+                    selection.start = verse
+                }
+            }
+        }
+
+        Task { @MainActor in
+            guard let interfaceController else {
+                return
+            }
+            do {
+                if let customPlaybackTemplate {
+                    try await interfaceController.pop(to: customPlaybackTemplate, animated: true)
+                } else {
+                    try await interfaceController.popTemplate(animated: true)
+                }
+            } catch {
+                print("[CarPlay] Failed to pop verse picker template: \(error)")
+            }
+        }
+    }
+
+    private func playCustomSelection() async {
+        guard let playbackController,
+              let selection = customPlaybackSelection else {
+            return
+        }
+
+        if case .downloading = customPlaybackStatus {
+            return
+        }
+
+        selectedSurahNumber = selection.start.sura.suraNumber
+
+        do {
+            try await playbackController.play(
+                from: selection.start,
+                to: selection.end,
+                verseRuns: selection.verseRuns,
+                listRuns: selection.listRuns
+            )
+            refreshTemplates()
+            updateNowPlayingInfo(with: playbackController.snapshot)
+            await presentNowPlayingIfNeeded()
+        } catch {
+            customPlaybackStatus = .failed(message: "Check the audio download or your network connection, then try again.")
+            refreshTemplates()
+            await presentPlaybackFailureAlert()
+            print("[CarPlay] Failed to play selected verses: \(error)")
+        }
+    }
+
+    private func updateCustomPlaybackSelection(
+        _ updates: (inout CarPlayVersePlaybackSelection) -> Void
+    ) {
+        guard var selection = customPlaybackSelection else {
+            return
+        }
+        updates(&selection)
+        customPlaybackSelection = selection
+        customPlaybackStatus = .ready
+        refreshCustomPlaybackAvailability()
+        refreshTemplates()
+    }
+
+    private var selectedSurah: Sura? {
+        let quran = Quran.hafsMadani1405
+        guard quran.suras.indices.contains(selectedSurahNumber - 1) else {
+            return nil
+        }
+        return quran.suras[selectedSurahNumber - 1]
+    }
+
+    private var selectedReciter: Reciter? {
+        if let selectedReciterId {
+            return reciters.first { $0.id == selectedReciterId } ?? reciters.first
+        }
+        return reciters.first
+    }
+
+    private var selectedSurahStatusDetail: String? {
+        guard let snapshot = playbackController?.snapshot,
+              snapshot.surahNumber == selectedSurahNumber else {
+            return nil
+        }
+
+        switch snapshot.playbackState {
+        case .downloading(let progress):
+            let percentage = Int((progress * 100).rounded())
+            if percentage > 0 {
+                return "Downloading audio... \(percentage)%"
+            }
+            return "Downloading audio..."
+        case .playing:
+            return "Playing"
+        case .paused:
+            return "Paused"
+        case .stopped:
+            return nil
+        }
+    }
+
+    private var versePickerListLimit: Int {
+        max(Int(CPListTemplate.maximumItemCount), 1)
+    }
+
+    private func chapterBuckets(for chapters: [ChapterInfo]) -> [CarPlayChapterBucket] {
+        stride(from: 0, to: chapters.count, by: chapterPickerListLimit).map { start in
+            let end = min(start + chapterPickerListLimit, chapters.count)
+            let chunk = Array(chapters[start ..< end])
+            return CarPlayChapterBucket(range: chunk.first!.number ... chunk.last!.number)
+        }
+    }
+
+    private func chapters(in bucket: CarPlayChapterBucket) -> [ChapterInfo] {
+        chapters.filter { bucket.range.contains($0.number) }
+    }
+
+    private func refreshCustomPlaybackAvailability() {
+        customPlaybackAvailabilityTask?.cancel()
+
+        guard let playbackController,
+              let selection = customPlaybackSelection,
+              let reciter = selectedReciter else {
+            return
+        }
+
+        let expectedSelection = selection
+        let expectedReciter = reciter
+
+        customPlaybackAvailabilityTask = Task { [weak self] in
+            let availability = await playbackController.audioAvailability(
+                reciter: expectedReciter,
+                from: expectedSelection.start,
+                to: expectedSelection.end
+            )
+
+            guard !Task.isCancelled else {
+                return
+            }
+
+            await MainActor.run {
+                guard let self,
+                      self.customPlaybackSelection == expectedSelection,
+                      self.selectedReciter?.id == expectedReciter.id else {
+                    return
+                }
+
+                switch availability {
+                case .downloaded:
+                    self.customPlaybackStatus = .ready
+                case .downloading(let progress):
+                    self.customPlaybackStatus = .downloading(progress: progress)
+                case .downloadRequired:
+                    if case .failed = self.customPlaybackStatus {
+                        return
+                    }
+                    self.customPlaybackStatus = .downloadRequired
+                }
+                self.refreshTemplates()
+            }
+        }
+    }
+
+    private func synchronizeCustomPlaybackStatus(with snapshot: AudioPlaybackController.Snapshot) {
+        guard isSnapshotForCustomSelection(snapshot) else {
+            return
+        }
+
+        switch snapshot.playbackState {
+        case .downloading(let progress):
+            customPlaybackStatus = .downloading(progress: progress)
+        case .playing, .paused:
+            customPlaybackStatus = .ready
+        case .stopped:
+            refreshCustomPlaybackAvailability()
+            return
+        }
+    }
+
+    private func isSnapshotForCustomSelection(_ snapshot: AudioPlaybackController.Snapshot) -> Bool {
+        guard let request = snapshot.request,
+              let selection = customPlaybackSelection else {
+            return false
+        }
+        return request.start == selection.start
+            && request.end == selection.end
+            && request.verseRuns == selection.verseRuns
+            && request.listRuns == selection.listRuns
+    }
+
+    private func allowedVerseRange(
+        forStartVerse: Bool,
+        selection: CarPlayVersePlaybackSelection,
+        surah: Sura
+    ) -> ClosedRange<Int> {
+        let lastAyah = surah.lastVerse.ayah
+        if forStartVerse {
+            return 1 ... lastAyah
+        }
+        return selection.start.ayah ... lastAyah
+    }
+
+    private func versePickerNodes(for allowedRange: ClosedRange<Int>) -> [VersePickerNode] {
+        let leafNodes = stride(
+            from: allowedRange.lowerBound,
+            through: allowedRange.upperBound,
+            by: versePickerLeafSize
+        ).map { start in
+            let end = min(start + versePickerLeafSize - 1, allowedRange.upperBound)
+            return VersePickerNode(range: start ... end, children: [])
+        }
+
+        guard leafNodes.count > versePickerListLimit else {
+            return leafNodes
+        }
+
+        var currentLevel = leafNodes
+        while currentLevel.count > versePickerListLimit {
+            let previousLevel = currentLevel
+            currentLevel = stride(from: 0, to: previousLevel.count, by: versePickerListLimit).map { start in
+                let end = min(start + versePickerListLimit, previousLevel.count)
+                let children = Array(previousLevel[start ..< end])
+                return VersePickerNode(
+                    range: children.first!.range.lowerBound ... children.last!.range.upperBound,
+                    children: children
+                )
+            }
+        }
+        return currentLevel
+    }
+
+    private func showVerseBucketPicker(
+        using interfaceController: CPInterfaceController,
+        title: String,
+        surah: Sura,
+        nodes: [VersePickerNode],
+        selectedVerse: AyahNumber,
+        forStartVerse: Bool
+    ) async {
+        let buckets = nodes.map { CarPlayVerseBucket(range: $0.range) }
+        let template = CarPlayTemplateBuilder.shared.makeVerseBucketTemplate(
+            title: title,
+            buckets: buckets,
+            selectedVerse: selectedVerse,
+            selectionHandler: { [weak self] bucket in
+                self?.didSelectVerseBucket(
+                    bucket,
+                    from: nodes,
+                    surah: surah,
+                    title: title,
+                    forStartVerse: forStartVerse
+                )
+            }
+        )
+
+        do {
+            try await interfaceController.pushTemplate(template, animated: true)
+        } catch {
+            print("[CarPlay] Failed to push verse bucket template: \(error)")
+        }
+    }
+
+    private func didSelectVerseBucket(
+        _ bucket: CarPlayVerseBucket,
+        from nodes: [VersePickerNode],
+        surah: Sura,
+        title: String,
+        forStartVerse: Bool
+    ) {
+        guard let node = nodes.first(where: { $0.range == bucket.range }),
+              let interfaceController else {
+            return
+        }
+
+        let selectedVerse = forStartVerse
+            ? (customPlaybackSelection?.start ?? surah.firstVerse)
+            : (customPlaybackSelection?.end ?? surah.lastVerse)
+        let nextTitle = "\(title) \(rangeTitle(bucket.range))"
+
+        Task { @MainActor in
+            if node.children.isEmpty {
+                await showExactVersePicker(
+                    using: interfaceController,
+                    title: nextTitle,
+                    surah: surah,
+                    range: node.range,
+                    selectedVerse: selectedVerse,
+                    forStartVerse: forStartVerse
+                )
+            } else {
+                await showVerseBucketPicker(
+                    using: interfaceController,
+                    title: nextTitle,
+                    surah: surah,
+                    nodes: node.children,
+                    selectedVerse: selectedVerse,
+                    forStartVerse: forStartVerse
+                )
+            }
+        }
+    }
+
+    private func showExactVersePicker(
+        using interfaceController: CPInterfaceController,
+        title: String,
+        surah: Sura,
+        range: ClosedRange<Int>,
+        selectedVerse: AyahNumber,
+        forStartVerse: Bool
+    ) async {
+        let verses = surah.verses.filter { range.contains($0.ayah) }
+        print(
+            "[CarPlay] Exact verse picker: surah=\(surah.suraNumber), range=\(range.lowerBound)-\(range.upperBound), verseCount=\(verses.count), selectedVerse=\(selectedVerse.ayah)"
+        )
+
+        let template = CarPlayTemplateBuilder.shared.makeVersePickerTemplate(
+            title: title,
+            verses: verses,
+            selectedVerse: selectedVerse,
+            selectionHandler: { [weak self] verse in
+                self?.didSelectVerse(verse, forStartVerse: forStartVerse)
+            }
+        )
+
+        do {
+            try await interfaceController.pushTemplate(template, animated: true)
+        } catch {
+            print("[CarPlay] Failed to push verse picker template: \(error)")
+        }
+    }
+
+    private func rangeTitle(_ range: ClosedRange<Int>) -> String {
+        if range.lowerBound == range.upperBound {
+            return "Ayah \(range.lowerBound)"
+        }
+        return "\(range.lowerBound)-\(range.upperBound)"
+    }
+
+    private func chapterRangeTitle(_ range: ClosedRange<Int>) -> String {
+        if range.lowerBound == range.upperBound {
+            return "Surah \(range.lowerBound)"
+        }
+        return "\(range.lowerBound)-\(range.upperBound)"
+    }
+
+    private func presentPlaybackFailureAlert() async {
+        guard let interfaceController else {
+            return
+        }
+
+        let action = CPAlertAction(title: "OK", style: .default) { _ in }
+        let template = CPAlertTemplate(
+            titleVariants: [
+                "Could not play audio. Check the download and try again.",
+                "Could not play audio",
+            ],
+            actions: [action]
+        )
+
+        do {
+            try await interfaceController.presentTemplate(template, animated: true)
+        } catch {
+            print("[CarPlay] Failed to present playback alert: \(error)")
+        }
+    }
+}
+
+struct ChapterInfo {
+    let id: Int
+    let number: Int
+    let name: String
+}
+
+private extension AudioEnd {
+    func findLastAyah(startAyah: AyahNumber) -> AyahNumber {
+        let pageLastVerse = PageBasedLastAyahFinder().findLastAyah(startAyah: startAyah)
+        let lastVerse: AyahNumber = switch self {
+        case .juz:
+            JuzBasedLastAyahFinder().findLastAyah(startAyah: startAyah)
+        case .sura:
+            SuraBasedLastAyahFinder().findLastAyah(startAyah: startAyah)
+        case .page:
+            pageLastVerse
+        case .quran:
+            QuranBasedLastAyahFinder().findLastAyah(startAyah: startAyah)
+        }
+        return max(lastVerse, pageLastVerse)
+    }
+}
+
+private struct VersePickerNode: Equatable {
+    let range: ClosedRange<Int>
+    let children: [VersePickerNode]
+}

--- a/Example/QuranEngineApp/Classes/CarPlaySceneDelegate.swift
+++ b/Example/QuranEngineApp/Classes/CarPlaySceneDelegate.swift
@@ -961,7 +961,9 @@ final class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegat
             return
         }
 
-        let action = CPAlertAction(title: "OK", style: .default) { _ in }
+        let action = CPAlertAction(title: "OK", style: .default) { [weak interfaceController] _ in
+            interfaceController?.dismissTemplate(animated: true, completion: nil)
+        }
         let template = CPAlertTemplate(
             titleVariants: [
                 "Could not play audio. Check the download and try again.",

--- a/Example/QuranEngineApp/Classes/CarPlayTemplateBuilder.swift
+++ b/Example/QuranEngineApp/Classes/CarPlayTemplateBuilder.swift
@@ -1,0 +1,568 @@
+//
+//  CarPlayTemplateBuilder.swift
+//  QuranEngineApp
+//
+//  Created for CarPlay support
+//
+import AudioBannerFeature
+import CarPlay
+import QueuePlayer
+import QuranAudio
+import QuranAudioKit
+import QuranKit
+import UIKit
+
+struct ReciterInfo: Equatable {
+    let id: Int
+    let name: String
+}
+
+enum CarPlayPlaybackOption: Equatable {
+    case audioEnd(AudioEnd)
+    case selectVerses
+
+    var title: String {
+        switch self {
+        case .audioEnd(let audioEnd):
+            audioEnd.name
+        case .selectVerses:
+            "Select verses"
+        }
+    }
+}
+
+enum CarPlayCustomPlaybackAction {
+    case selectSurah
+    case selectStartVerse
+    case selectEndVerse
+    case selectVerseRuns(Runs)
+    case selectListRuns(Runs)
+    case playSelection
+}
+
+struct CarPlayVersePlaybackSelection: Equatable {
+    var start: AyahNumber
+    var end: AyahNumber
+    var verseRuns: Runs
+    var listRuns: Runs
+}
+
+struct CarPlayVerseBucket: Equatable {
+    let range: ClosedRange<Int>
+}
+
+struct CarPlayChapterBucket: Equatable {
+    let range: ClosedRange<Int>
+}
+
+enum CarPlayPlaybackStatus: Equatable {
+    case ready
+    case downloadRequired
+    case downloading(progress: Double)
+    case failed(message: String)
+
+    var summaryText: String? {
+        switch self {
+        case .ready:
+            nil
+        case .downloadRequired:
+            "Download required"
+        case .downloading:
+            "Downloading audio"
+        case .failed:
+            "Audio unavailable"
+        }
+    }
+
+    var titleText: String? {
+        switch self {
+        case .ready:
+            nil
+        case .downloadRequired:
+            "Download required to play"
+        case .downloading:
+            "Downloading audio..."
+        case .failed:
+            "Audio unavailable"
+        }
+    }
+
+    var detailText: String? {
+        switch self {
+        case .ready:
+            return nil
+        case .downloadRequired:
+            return "Tap play to download this range, then playback will start."
+        case .downloading(let progress):
+            let percentage = Int((progress * 100).rounded())
+            if percentage > 0 {
+                return "Playback will start automatically. \(percentage)% downloaded."
+            }
+            return "Playback will start automatically."
+        case .failed(let message):
+            return message
+        }
+    }
+
+    var isPlayActionEnabled: Bool {
+        switch self {
+        case .downloading:
+            false
+        case .ready, .downloadRequired, .failed:
+            true
+        }
+    }
+}
+
+final class CarPlayTemplateBuilder {
+    static let shared = CarPlayTemplateBuilder()
+
+    func makeChapterListTemplate(
+        chapters: [ChapterInfo],
+        selectedSurahNumber: Int?,
+        selectedSurahStatus: String?,
+        selectionHandler: @escaping (ChapterInfo) -> Void
+    ) -> CPListTemplate {
+        let template = configuredTemplate(
+            title: "Quran Chapters",
+            tabTitle: "Surahs",
+            tabImage: "book.closed"
+        )
+        updateChapterListTemplate(
+            template,
+            chapters: chapters,
+            selectedSurahNumber: selectedSurahNumber,
+            selectedSurahStatus: selectedSurahStatus,
+            selectionHandler: selectionHandler
+        )
+        return template
+    }
+
+    func updateChapterListTemplate(
+        _ template: CPListTemplate,
+        chapters: [ChapterInfo],
+        selectedSurahNumber: Int?,
+        selectedSurahStatus: String?,
+        selectionHandler: @escaping (ChapterInfo) -> Void
+    ) {
+        let items: [CPListItem] = chapters.map { chapter in
+            let isSelected = chapter.number == selectedSurahNumber
+            let item = CPListItem(
+                text: "\(chapter.number). \(chapter.name)",
+                detailText: isSelected ? (selectedSurahStatus ?? "Current surah") : nil
+            )
+            item.handler = { _, completion in
+                selectionHandler(chapter)
+                completion()
+            }
+            return item
+        }
+        template.updateSections([CPListSection(items: items)])
+        logTemplate("chapters", requestedItems: items.count, requestedSections: 1, template: template)
+    }
+
+    func makeRecitersTemplate(
+        reciters: [ReciterInfo],
+        selectedReciterId: Int?,
+        selectionHandler: @escaping (ReciterInfo) -> Void
+    ) -> CPListTemplate {
+        let template = configuredTemplate(
+            title: "Reciters",
+            tabTitle: "Reciters",
+            tabImage: "person.wave.2"
+        )
+        updateRecitersTemplate(
+            template,
+            reciters: reciters,
+            selectedReciterId: selectedReciterId,
+            selectionHandler: selectionHandler
+        )
+        return template
+    }
+
+    func updateRecitersTemplate(
+        _ template: CPListTemplate,
+        reciters: [ReciterInfo],
+        selectedReciterId: Int?,
+        selectionHandler: @escaping (ReciterInfo) -> Void
+    ) {
+        let items: [CPListItem] = reciters.map { reciter in
+            let isSelected = reciter.id == selectedReciterId
+            let item = CPListItem(
+                text: reciter.name,
+                detailText: isSelected ? "Current reciter" : nil
+            )
+            item.handler = { _, completion in
+                selectionHandler(reciter)
+                completion()
+            }
+            return item
+        }
+        template.updateSections([CPListSection(items: items)])
+    }
+
+    func makePlaybackModesTemplate(
+        playbackOptions: [CarPlayPlaybackOption],
+        selectedMode: AudioEnd,
+        customPlaybackSummary: String?,
+        selectionHandler: @escaping (CarPlayPlaybackOption) -> Void
+    ) -> CPListTemplate {
+        let template = configuredTemplate(
+            title: "Playback Options",
+            tabTitle: "Playback",
+            tabImage: "waveform"
+        )
+        updatePlaybackModesTemplate(
+            template,
+            playbackOptions: playbackOptions,
+            selectedMode: selectedMode,
+            customPlaybackSummary: customPlaybackSummary,
+            selectionHandler: selectionHandler
+        )
+        return template
+    }
+
+    func updatePlaybackModesTemplate(
+        _ template: CPListTemplate,
+        playbackOptions: [CarPlayPlaybackOption],
+        selectedMode: AudioEnd,
+        customPlaybackSummary: String?,
+        selectionHandler: @escaping (CarPlayPlaybackOption) -> Void
+    ) {
+        let items: [CPListItem] = playbackOptions.map { option in
+            let item = CPListItem(
+                text: option.title,
+                detailText: detailText(
+                    for: option,
+                    selectedMode: selectedMode,
+                    customPlaybackSummary: customPlaybackSummary
+                )
+            )
+            item.handler = { _, completion in
+                selectionHandler(option)
+                completion()
+            }
+            return item
+        }
+        template.updateSections([CPListSection(items: items)])
+    }
+
+    func makeCustomPlaybackTemplate(
+        selection: CarPlayVersePlaybackSelection,
+        surahTitle: String,
+        playbackStatus: CarPlayPlaybackStatus,
+        actionHandler: @escaping (CarPlayCustomPlaybackAction) -> Void
+    ) -> CPListTemplate {
+        let template = CPListTemplate(title: "Select Verses", sections: [])
+        updateCustomPlaybackTemplate(
+            template,
+            selection: selection,
+            surahTitle: surahTitle,
+            playbackStatus: playbackStatus,
+            actionHandler: actionHandler
+        )
+        return template
+    }
+
+    func updateCustomPlaybackTemplate(
+        _ template: CPListTemplate,
+        selection: CarPlayVersePlaybackSelection,
+        surahTitle: String,
+        playbackStatus: CarPlayPlaybackStatus,
+        actionHandler: @escaping (CarPlayCustomPlaybackAction) -> Void
+    ) {
+        let surahItem = CPListItem(text: "Selected surah", detailText: surahTitle)
+        surahItem.handler = { _, completion in
+            actionHandler(.selectSurah)
+            completion()
+        }
+
+        let fromItem = CPListItem(text: "From", detailText: verseTitle(for: selection.start))
+        fromItem.handler = { _, completion in
+            actionHandler(.selectStartVerse)
+            completion()
+        }
+
+        let toItem = CPListItem(text: "To", detailText: verseTitle(for: selection.end))
+        toItem.handler = { _, completion in
+            actionHandler(.selectEndVerse)
+            completion()
+        }
+
+        let verseRunsItems = runsItems(
+            selected: selection.verseRuns,
+            selectionHandler: { actionHandler(.selectVerseRuns($0)) }
+        )
+        let listRunsItems = runsItems(
+            selected: selection.listRuns,
+            selectionHandler: { actionHandler(.selectListRuns($0)) }
+        )
+
+        let playItem = CPListItem(
+            text: "Play selected verses",
+            detailText: "\(selection.start.ayah)-\(selection.end.ayah)"
+        )
+        playItem.isEnabled = playbackStatus.isPlayActionEnabled
+        playItem.handler = { _, completion in
+            actionHandler(.playSelection)
+            completion()
+        }
+
+        var playbackItems = [CPListItem]()
+        if let statusTitle = playbackStatus.titleText {
+            let statusItem = CPListItem(text: statusTitle, detailText: playbackStatus.detailText)
+            statusItem.isEnabled = false
+            playbackItems.append(statusItem)
+        }
+        playbackItems.append(playItem)
+
+        let sections = [
+            CPListSection(items: [surahItem]),
+            CPListSection(items: [fromItem, toItem], header: "Playing Verses", sectionIndexTitle: nil),
+            CPListSection(items: verseRunsItems, header: "Play Each Verse", sectionIndexTitle: nil),
+            CPListSection(items: listRunsItems, header: "Play Set Of Verses", sectionIndexTitle: nil),
+            CPListSection(items: playbackItems, header: "Playback", sectionIndexTitle: nil),
+        ]
+
+        template.updateSections(sections)
+        logTemplate(
+            "customPlayback",
+            requestedItems: sections.reduce(0) { $0 + $1.items.count },
+            requestedSections: sections.count,
+            template: template
+        )
+    }
+
+    func makeVersePickerTemplate(
+        title: String,
+        verses: [AyahNumber],
+        selectedVerse: AyahNumber,
+        selectionHandler: @escaping (AyahNumber) -> Void
+    ) -> CPListTemplate {
+        let template = CPListTemplate(title: title, sections: [])
+        updateVersePickerTemplate(
+            template,
+            title: title,
+            verses: verses,
+            selectedVerse: selectedVerse,
+            selectionHandler: selectionHandler
+        )
+        return template
+    }
+
+    func updateVersePickerTemplate(
+        _ template: CPListTemplate,
+        title: String,
+        verses: [AyahNumber],
+        selectedVerse: AyahNumber,
+        selectionHandler: @escaping (AyahNumber) -> Void
+    ) {
+        let items: [CPListItem] = verses.map { verse in
+            let item = CPListItem(
+                text: "Ayah \(verse.ayah)",
+                detailText: verse == selectedVerse ? "Current value" : nil
+            )
+            item.handler = { _, completion in
+                selectionHandler(verse)
+                completion()
+            }
+            return item
+        }
+        template.updateSections([CPListSection(items: items)])
+        logTemplate("exactVersePicker(\(title))", requestedItems: items.count, requestedSections: 1, template: template)
+    }
+
+    func makeVerseBucketTemplate(
+        title: String,
+        buckets: [CarPlayVerseBucket],
+        selectedVerse: AyahNumber,
+        selectionHandler: @escaping (CarPlayVerseBucket) -> Void
+    ) -> CPListTemplate {
+        let template = CPListTemplate(title: title, sections: [])
+        let items: [CPListItem] = buckets.map { bucket in
+            let item = CPListItem(
+                text: rangeTitle(for: bucket.range),
+                detailText: bucket.range.contains(selectedVerse.ayah) ? "Current value" : nil
+            )
+            item.handler = { _, completion in
+                selectionHandler(bucket)
+                completion()
+            }
+            return item
+        }
+        template.updateSections([CPListSection(items: items)])
+        logTemplate("bucketVersePicker(\(title))", requestedItems: items.count, requestedSections: 1, template: template)
+        return template
+    }
+
+    func makeChapterBucketTemplate(
+        title: String,
+        tabTitle: String? = nil,
+        tabImage: String? = nil,
+        buckets: [CarPlayChapterBucket],
+        selectedChapterNumber: Int,
+        selectionHandler: @escaping (CarPlayChapterBucket) -> Void
+    ) -> CPListTemplate {
+        let template = CPListTemplate(title: title, sections: [])
+        template.tabTitle = tabTitle
+        if let tabImage {
+            template.tabImage = UIImage(systemName: tabImage)
+        }
+        updateChapterBucketTemplate(
+            template,
+            title: title,
+            buckets: buckets,
+            selectedChapterNumber: selectedChapterNumber,
+            selectionHandler: selectionHandler
+        )
+        return template
+    }
+
+    func updateChapterBucketTemplate(
+        _ template: CPListTemplate,
+        title: String,
+        buckets: [CarPlayChapterBucket],
+        selectedChapterNumber: Int,
+        selectionHandler: @escaping (CarPlayChapterBucket) -> Void
+    ) {
+        let items: [CPListItem] = buckets.map { bucket in
+            let item = CPListItem(
+                text: chapterRangeTitle(for: bucket.range),
+                detailText: bucket.range.contains(selectedChapterNumber) ? "Current surah" : nil
+            )
+            item.handler = { _, completion in
+                selectionHandler(bucket)
+                completion()
+            }
+            return item
+        }
+        template.updateSections([CPListSection(items: items)])
+        logTemplate("chapterBuckets(\(title))", requestedItems: items.count, requestedSections: 1, template: template)
+    }
+
+    func makeSurahPickerTemplate(
+        title: String = "Select Surah",
+        chapters: [ChapterInfo],
+        selectedSurahNumber: Int,
+        selectionHandler: @escaping (ChapterInfo) -> Void
+    ) -> CPListTemplate {
+        let template = CPListTemplate(title: title, sections: [])
+        let items: [CPListItem] = chapters.map { chapter in
+            let item = CPListItem(
+                text: "\(chapter.number). \(chapter.name)",
+                detailText: chapter.number == selectedSurahNumber ? "Current value" : nil
+            )
+            item.handler = { _, completion in
+                selectionHandler(chapter)
+                completion()
+            }
+            return item
+        }
+        template.updateSections([CPListSection(items: items)])
+        logTemplate("surahPicker(\(title))", requestedItems: items.count, requestedSections: 1, template: template)
+        return template
+    }
+
+    func makeRootTemplate(templates: [CPTemplate]) -> CPTabBarTemplate {
+        CPTabBarTemplate(templates: templates)
+    }
+
+    private func configuredTemplate(title: String, tabTitle: String, tabImage: String) -> CPListTemplate {
+        let template = CPListTemplate(title: title, sections: [])
+        template.tabTitle = tabTitle
+        template.tabImage = UIImage(systemName: tabImage)
+        return template
+    }
+
+    private func detailText(
+        for option: CarPlayPlaybackOption,
+        selectedMode: AudioEnd,
+        customPlaybackSummary: String?
+    ) -> String? {
+        switch option {
+        case .audioEnd(let audioEnd):
+            return audioEnd == selectedMode ? "Current mode" : nil
+        case .selectVerses:
+            return customPlaybackSummary ?? "Choose a verse range"
+        }
+    }
+
+    private func runsItems(
+        selected: Runs,
+        selectionHandler: @escaping (Runs) -> Void
+    ) -> [CPListItem] {
+        CarPlayRuns.allCases.map { run in
+            let item = CPListItem(
+                text: run.title,
+                detailText: run.runs == selected ? "Current value" : nil
+            )
+            item.handler = { _, completion in
+                selectionHandler(run.runs)
+                completion()
+            }
+            return item
+        }
+    }
+
+    private func verseTitle(for ayah: AyahNumber) -> String {
+        "\(ayah.sura.suraNumber). \(AudioPlaybackController.surahTitle(for: ayah.sura.suraNumber)) - Ayah \(ayah.ayah)"
+    }
+
+    private func rangeTitle(for range: ClosedRange<Int>) -> String {
+        if range.lowerBound == range.upperBound {
+            return "Ayah \(range.lowerBound)"
+        }
+        return "Ayahs \(range.lowerBound)-\(range.upperBound)"
+    }
+
+    private func chapterRangeTitle(for range: ClosedRange<Int>) -> String {
+        if range.lowerBound == range.upperBound {
+            return "Surah \(range.lowerBound)"
+        }
+        return "Surahs \(range.lowerBound)-\(range.upperBound)"
+    }
+
+    private func logTemplate(
+        _ name: String,
+        requestedItems: Int,
+        requestedSections: Int,
+        template: CPListTemplate
+    ) {
+        print(
+            "[CarPlay] Template \(name): requestedItems=\(requestedItems), requestedSections=\(requestedSections), displayedItems=\(template.itemCount), displayedSections=\(template.sectionCount), maxItems=\(CPListTemplate.maximumItemCount), maxSections=\(CPListTemplate.maximumSectionCount)"
+        )
+    }
+}
+
+private enum CarPlayRuns: CaseIterable {
+    case one
+    case two
+    case three
+    case loop
+
+    var runs: Runs {
+        switch self {
+        case .one:
+            .one
+        case .two:
+            .two
+        case .three:
+            .three
+        case .loop:
+            .indefinite
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .one:
+            "1 time"
+        case .two:
+            "2 times"
+        case .three:
+            "3 times"
+        case .loop:
+            "Loop"
+        }
+    }
+}

--- a/Example/QuranEngineApp/Info.plist
+++ b/Example/QuranEngineApp/Info.plist
@@ -2,25 +2,36 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleURLTypes</key>
-    <array>
-        <dict>
-            <key>CFBundleURLName</key>
-            <string>com.quran.QuranEngineApp</string>
-            <key>CFBundleURLSchemes</key>
-            <array>
-                <string>com.quran.oauth</string>
-                <string>quran</string>
-                <string>quran-ios</string>
-            </array>
-        </dict>
-    </array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.quran.QuranEngineApp</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.quran.oauth</string>
+				<string>quran</string>
+				<string>quran-ios</string>
+			</array>
+		</dict>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>
-		<false/>
+		<true/>
 		<key>UISceneConfigurations</key>
 		<dict>
+			<key>CPTemplateApplicationSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>CPTemplateApplicationScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>CarPlay Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).CarPlaySceneDelegate</string>
+				</dict>
+			</array>
 			<key>UIWindowSceneSessionRoleApplication</key>
 			<array>
 				<dict>
@@ -32,5 +43,9 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 </dict>
 </plist>

--- a/Features/AudioBannerFeature/AudioBannerBuilder.swift
+++ b/Features/AudioBannerFeature/AudioBannerBuilder.swift
@@ -16,24 +16,22 @@ import UIKit
 
 @MainActor
 public struct AudioBannerBuilder {
-    // MARK: Lifecycle
-
     public init(container: AppDependencies) {
         self.container = container
     }
-
-    // MARK: Public
-
     public func build(withListener listener: AudioBannerListener) -> (UIViewController, AudioBannerViewModel) {
+        AudioPlaybackControllerStore.setUpIfNeeded(container: container)
+        let playbackController = AudioPlaybackControllerStore.shared!
+
+        let reciterRetriever = ReciterDataRetriever()
+        let recentRecitersService = RecentRecitersService()
+
         let viewModel = AudioBannerViewModel(
             analytics: container.analytics,
-            reciterRetreiver: ReciterDataRetriever(),
-            recentRecitersService: RecentRecitersService(),
-            audioPlayer: QuranAudioPlayer(),
-            downloader: QuranAudioDownloader(
-                baseURL: container.filesAppHost,
-                downloader: container.downloadManager
-            ),
+            reciterRetreiver: reciterRetriever,
+            recentRecitersService: recentRecitersService,
+            downloader: playbackController.audioDownloader,
+            playbackController: playbackController,
             reciterListBuilder: ReciterListBuilder(),
             advancedAudioOptionsBuilder: AdvancedAudioOptionsBuilder()
         )
@@ -45,8 +43,5 @@ public struct AudioBannerBuilder {
         viewModel.listener = listener
         return (viewController, viewModel)
     }
-
-    // MARK: Internal
-
     let container: AppDependencies
 }

--- a/Features/AudioBannerFeature/AudioBannerViewModel.swift
+++ b/Features/AudioBannerFeature/AudioBannerViewModel.swift
@@ -31,7 +31,7 @@ public protocol AudioBannerListener: AnyObject {
     func highlightReadingAyah(_ ayah: AyahNumber?)
 }
 
-private enum PlaybackState {
+private enum PlaybackState: Equatable {
     case playing
     case paused
     case stopped
@@ -48,22 +48,21 @@ public final class AudioBannerViewModel: ObservableObject {
         analytics: AnalyticsLibrary,
         reciterRetreiver: ReciterDataRetriever,
         recentRecitersService: RecentRecitersService,
-        audioPlayer: QuranAudioPlayer,
         downloader: QuranAudioDownloader,
+        playbackController: AudioPlaybackController,
         reciterListBuilder: ReciterListBuilder,
         advancedAudioOptionsBuilder: AdvancedAudioOptionsBuilder
     ) {
         self.analytics = analytics
         self.reciterRetreiver = reciterRetreiver
         self.recentRecitersService = recentRecitersService
-        self.audioPlayer = audioPlayer
         self.downloader = downloader
+        self.playbackController = playbackController
         self.reciterListBuilder = reciterListBuilder
         self.advancedAudioOptionsBuilder = advancedAudioOptionsBuilder
         playbackRate = AudioPreferences.shared.playbackRate
 
-        setUpAudioPlayerActions()
-        setUpRemoteCommandHandler()
+        observePlaybackController()
 
         AudioPreferences.shared.$playbackRate.assign(to: &$playbackRate)
     }
@@ -96,7 +95,6 @@ public final class AudioBannerViewModel: ObservableObject {
     }
 
     func start() async {
-        remoteCommandsHandler?.startListeningToPlayCommand()
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(applicationDidBecomeActive),
@@ -119,25 +117,25 @@ public final class AudioBannerViewModel: ObservableObject {
                 }.asCancellableTask()
             )
         }
+
+        synchronizePlayback(with: playbackController.snapshot)
     }
 
     func updatePlaybackRate(to rate: Float) {
         AudioPreferences.shared.playbackRate = rate
-        audioPlayer.setRate(rate)
+        playbackController.setRate(rate)
     }
 
     // MARK: Private
 
     private var audioRange: AudioRange?
-
+    private let playbackController: AudioPlaybackController
     private let analytics: AnalyticsLibrary
     private let reciterRetreiver: ReciterDataRetriever
     private let recentRecitersService: RecentRecitersService
     private let preferences = ReciterPreferences.shared
     private let lastAyahFinder: LastAyahFinder = PreferencesLastAyahFinder.shared
-    private let audioPlayer: QuranAudioPlayer
     private let downloader: QuranAudioDownloader
-    private var remoteCommandsHandler: RemoteCommandsHandler?
     private let reciterListBuilder: ReciterListBuilder
     private let advancedAudioOptionsBuilder: AdvancedAudioOptionsBuilder
 
@@ -145,6 +143,7 @@ public final class AudioBannerViewModel: ObservableObject {
     private var listRuns: Runs = .one
     private var reciters: [Reciter] = []
     private var cancellableTasks: Set<CancellableTask> = []
+    private var playbackObserverId: UUID?
 
     @Published private var playingState: PlaybackState = .stopped {
         didSet {
@@ -171,9 +170,6 @@ public final class AudioBannerViewModel: ObservableObject {
             crasher.setValue(selectedReciter.id, forKey: .reciterId)
         }
         listener?.highlightReadingAyah(nil)
-
-        remoteCommandsHandler?.stopListening()
-        remoteCommandsHandler?.startListeningToPlayCommand()
     }
 
     @objc
@@ -184,7 +180,7 @@ public final class AudioBannerViewModel: ObservableObject {
     }
 
     private func selectReciter(_ reciter: Reciter) {
-        preferences.lastSelectedReciterId = reciter.id
+        playbackController.setReciter(reciter)
     }
 
     // MARK: - Playback Controls
@@ -206,85 +202,76 @@ public final class AudioBannerViewModel: ObservableObject {
     }
 
     private func play(from: AyahNumber, to: AyahNumber?, verseRuns: Runs, listRuns: Runs) {
-        guard let selectedReciter else {
+        guard selectedReciter != nil else {
             return
         }
-        audioPlayer.stopAudio()
+
         let end = to ?? lastAyahFinder.findLastAyah(startAyah: from)
         audioRange = (start: from, end: end)
         self.verseRuns = verseRuns
         self.listRuns = listRuns
 
-        recentRecitersService.updateRecentRecitersList(selectedReciter)
-
         cancellableTasks.task { [weak self] in
+            guard let self else { return }
+
             do {
-                let downloaded = await self?.downloader.downloaded(reciter: selectedReciter, from: from, to: end) ?? true
-                logger.info("AudioBanner: reciter downloaded? \(downloaded)")
-                if !downloaded {
-                    self?.startDownloading()
-                    let download = try await self?.downloader.download(from: from, to: end, reciter: selectedReciter)
-                    guard let download else {
-                        logger.info("AudioBanner: couldn't create a download request")
-                        return
+                if let reciter = selectedReciter {
+                    let downloaded = await downloader.downloaded(reciter: reciter, from: from, to: end)
+                    logger.info("AudioBanner: reciter downloaded? \(downloaded)")
+                    if !downloaded {
+                        startDownloading()
                     }
-
-                    await self?.observe([download])
-
-                    for try await _ in download.progress { }
-
-                    logger.info("AudioBanner: download completed")
                 }
 
-                guard let self else {
-                    return
-                }
-
-                try await audioPlayer.play(
-                    reciter: selectedReciter,
-                    rate: playbackRate,
-                    from: from, to: end,
-                    verseRuns: verseRuns, listRuns: listRuns
+                try await playbackController.play(
+                    from: from,
+                    to: end,
+                    verseRuns: verseRuns,
+                    listRuns: listRuns
                 )
                 playingStarted()
             } catch {
-                self?.playbackFailed(error)
+                playbackFailed(error)
             }
         }
     }
 
     private func togglePlayPause() {
         switch playingState {
-        case .playing: pause()
-        case .paused: resume()
-        default:
-            logger.error("Invalid playingState \(playingState) found while trying to pause/resume playback")
+        case .playing:
+            pause()
+        case .paused:
+            resume()
+        case .stopped:
+            handlePlayCommand()
+        case .downloading:
+            break
         }
     }
-
     private func pause() {
         playingState = .paused
-        audioPlayer.pauseAudio()
+        playbackController.pause()
     }
 
     private func resume() {
         playingState = .playing
-        audioPlayer.resumeAudio()
+        playbackController.resume()
     }
 
     private func stepForward() {
-        audioPlayer.stepForward()
+        playingState = .playing
+        playbackController.stepForward()
     }
 
     private func stepBackward() {
-        audioPlayer.stepBackward()
+        playingState = .playing
+        playbackController.stepBackward()
     }
 
     private func stop() {
         audioRange = nil
-        audioPlayer.stopAudio()
+        playbackController.stop()
     }
-
     // MARK: - Downloading
 
     private func observe(_ downloads: [DownloadBatchResponse]) async {
@@ -307,17 +294,7 @@ public final class AudioBannerViewModel: ObservableObject {
         playbackEnded()
     }
 
-    // MARK: - Audio Interactor Delegate
-
-    private func setUpAudioPlayerActions() {
-        let actions = QuranAudioPlayerActions(
-            playbackEnded: { [weak self] in self?.playbackEnded() },
-            playbackPaused: { [weak self] in self?.playbackPaused() },
-            playbackResumed: { [weak self] in self?.playbackResumed() },
-            playing: { [weak self] in self?.playing(ayah: $0) }
-        )
-        audioPlayer.setActions(actions)
-    }
+    // MARK: - Shared Playback
 
     private func playbackPaused() {
         logger.info("AudioBanner: playback paused")
@@ -333,6 +310,44 @@ public final class AudioBannerViewModel: ObservableObject {
         logger.info("AudioBanner: playing verse \(ayah)")
         crasher.setValue(ayah, forKey: .playingAyah)
         listener?.highlightReadingAyah(ayah)
+    }
+
+    private func observePlaybackController() {
+        playbackObserverId = playbackController.addObserver { [weak self] snapshot in
+            self?.synchronizePlayback(with: snapshot)
+        }
+    }
+
+    private func synchronizePlayback(with snapshot: AudioPlaybackController.Snapshot) {
+        if let request = snapshot.request {
+            audioRange = (start: request.start, end: request.end)
+            verseRuns = request.verseRuns
+            listRuns = request.listRuns
+        }
+
+        if let reciter = snapshot.reciter, !reciters.contains(reciter) {
+            reciters.append(reciter)
+            reciters.sort { $0.localizedName.localizedCaseInsensitiveCompare($1.localizedName) == .orderedAscending }
+        }
+
+        if let ayah = snapshot.currentAyah {
+            playing(ayah: ayah)
+        } else if case .stopped = snapshot.playbackState {
+            listener?.highlightReadingAyah(nil)
+        }
+
+        switch snapshot.playbackState {
+        case .playing:
+            playingState = .playing
+        case .paused:
+            playbackPaused()
+        case .stopped:
+            if playingState != .stopped {
+                playbackEnded()
+            }
+        case .downloading(let progress):
+            playingState = .downloading(progress: progress)
+        }
     }
 
     // MARK: - State changes
@@ -371,7 +386,6 @@ public final class AudioBannerViewModel: ObservableObject {
         logger.info("AudioBanner: playing started")
         cancellableTasks = []
         crasher.setValue(false, forKey: .downloadingQuran)
-        remoteCommandsHandler?.startListening()
         playingState = .playing
 
         guard let audioRange else {
@@ -434,23 +448,24 @@ extension AudioBannerViewModel {
 }
 
 extension AudioBannerViewModel {
-    private func setUpRemoteCommandHandler() {
-        let remoteActions = RemoteCommandActions(
-            play: { [weak self] in self?.handlePlayCommand() },
-            pause: { [weak self] in self?.handlePauseCommand() },
-            togglePlayPause: { [weak self] in self?.handleTogglePlayPauseCommand() },
-            nextTrack: { [weak self] in self?.handleNextTrackCommand() },
-            previousTrack: { [weak self] in self?.handlePreviousTrackCommand() }
-        )
-        remoteCommandsHandler = RemoteCommandsHandler(center: .shared(), actions: remoteActions)
-    }
-
     private func handlePlayCommand() {
         logger.info("AudioBanner: play command fired. State: \(playingState)")
         switch playingState {
-        case .stopped: playStartingCurrentPage()
-        case .paused, .playing: resume()
-        case .downloading: break
+        case .stopped:
+            if let audioRange {
+                play(
+                    from: audioRange.start,
+                    to: audioRange.end,
+                    verseRuns: verseRuns,
+                    listRuns: listRuns
+                )
+            } else {
+                playStartingCurrentPage()
+            }
+        case .paused, .playing:
+            resume()
+        case .downloading:
+            break
         }
     }
 
@@ -483,7 +498,7 @@ extension AudioBannerViewModel: ReciterListListener {
 
     public func onSelectedReciterChanged(to reciter: Reciter) {
         logger.info("AudioBanner: onSelectedReciterChanged to \(reciter.id)")
-        selectReciter(reciter)
+        playbackController.setReciter(reciter)
         playingState = .stopped
     }
 }

--- a/Features/AudioBannerFeature/AudioPlaybackController.swift
+++ b/Features/AudioBannerFeature/AudioPlaybackController.swift
@@ -1,0 +1,533 @@
+//
+//  AudioPlaybackController.md
+//  QuranEngineApp
+//
+//  Created by aom on 3/9/26.
+//
+
+
+import Foundation
+import MediaPlayer
+import QueuePlayer
+import QuranAudio
+import QuranAudioKit
+import QuranKit
+import ReciterService
+
+@MainActor
+public final class AudioPlaybackController {
+    public struct PlaybackRequest: Equatable {
+        public let start: AyahNumber
+        public let end: AyahNumber
+        public let verseRuns: Runs
+        public let listRuns: Runs
+    }
+
+    public enum PlaybackState: Equatable {
+        case stopped
+        case playing
+        case paused
+        case downloading(progress: Double)
+    }
+
+    public enum AudioAvailability: Equatable {
+        case downloaded
+        case downloading(progress: Double)
+        case downloadRequired
+    }
+
+    public struct Snapshot {
+        public let playbackState: PlaybackState
+        public let request: PlaybackRequest?
+        public let currentAyah: AyahNumber?
+        public let reciter: Reciter?
+
+        public var surahNumber: Int? {
+            request?.start.sura.suraNumber
+        }
+
+        public var surahTitle: String? {
+            surahNumber.map { AudioPlaybackController.surahTitle(for: $0, withNumber: true) }
+        }
+
+        public var reciterName: String? {
+            reciter?.localizedName
+        }
+    }
+
+    public typealias Observer = @MainActor (Snapshot) -> Void
+
+    private let audioPlayer: QuranAudioPlayer
+    private let downloader: QuranAudioDownloader
+    private let recentRecitersService: RecentRecitersService
+    private let preferences = ReciterPreferences.shared
+    private let reciterRetriever: ReciterDataRetriever
+    private let nowPlaying = NowPlayingUpdater(center: .default())
+    private var remoteCommandsHandler: AudioPlaybackRemoteCommandsHandler?
+    private var reciters: [Reciter] = []
+    private var currentRequest: PlaybackRequest?
+    private var currentAyah: AyahNumber?
+    private var currentReciter: Reciter?
+    private var playbackState: PlaybackState = .stopped
+    private var observers: [UUID: Observer] = [:]
+
+    var player: QuranAudioPlayer { audioPlayer }
+    var audioDownloader: QuranAudioDownloader { downloader }
+
+    public init(
+        audioPlayer: QuranAudioPlayer,
+        downloader: QuranAudioDownloader,
+        reciterRetriever: ReciterDataRetriever,
+        recentRecitersService: RecentRecitersService
+    ) {
+        self.audioPlayer = audioPlayer
+        self.downloader = downloader
+        self.reciterRetriever = reciterRetriever
+        self.recentRecitersService = recentRecitersService
+
+        setUpAudioPlayerActions()
+        setUpRemoteCommandHandler()
+        updateRemoteCommandAvailability()
+    }
+
+    public var snapshot: Snapshot {
+        Snapshot(
+            playbackState: playbackState,
+            request: currentRequest,
+            currentAyah: currentAyah,
+            reciter: selectedReciter
+        )
+    }
+
+    @discardableResult
+    public func addObserver(_ observer: @escaping Observer) -> UUID {
+        let id = UUID()
+        observers[id] = observer
+        observer(snapshot)
+        return id
+    }
+
+    public func removeObserver(_ id: UUID) {
+        observers.removeValue(forKey: id)
+    }
+
+    public func getReciters() async -> [Reciter] {
+        if reciters.isEmpty {
+            reciters = await reciterRetriever.getReciters()
+            publishSnapshot()
+        }
+        return reciters
+    }
+
+    public func audioAvailability(
+        reciter: Reciter,
+        from start: AyahNumber,
+        to end: AyahNumber
+    ) async -> AudioAvailability {
+        if await downloader.downloaded(reciter: reciter, from: start, to: end) {
+            return .downloaded
+        }
+
+        if let runningDownload = Set(await downloader.runningAudioDownloads()).firstMatches(reciter) {
+            return .downloading(progress: runningDownload.currentProgress.progress)
+        }
+
+        return .downloadRequired
+    }
+
+    public func playSurah(_ surahNumber: Int) async throws {
+        let quran = Quran.hafsMadani1405
+        guard surahNumber >= 1, surahNumber <= quran.suras.count else {
+            return
+        }
+
+        let sura = quran.suras[surahNumber - 1]
+        try await play(from: sura.firstVerse, to: sura.lastVerse)
+    }
+
+    public func play(
+        from: AyahNumber,
+        to: AyahNumber?,
+        verseRuns: Runs = .one,
+        listRuns: Runs = .one
+    ) async throws {
+        guard let reciter = await resolveSelectedReciter() else {
+            return
+        }
+
+        if playbackState != .stopped {
+            audioPlayer.stopAudio()
+        }
+
+        let end = to ?? from.page.lastVerse
+        let request = PlaybackRequest(start: from, end: end, verseRuns: verseRuns, listRuns: listRuns)
+        currentRequest = request
+        currentAyah = from
+        currentReciter = reciter
+        recentRecitersService.updateRecentRecitersList(reciter)
+        publishSnapshot()
+        updateNowPlayingMetadata()
+
+        let alreadyDownloaded = await downloader.downloaded(
+            reciter: reciter,
+            from: from,
+            to: end
+        )
+
+        do {
+            if !alreadyDownloaded {
+                updatePlaybackState(.downloading(progress: 0))
+                let response = try await downloader.download(
+                    from: from,
+                    to: end,
+                    reciter: reciter
+                )
+                for try await progress in response.progress {
+                    updatePlaybackState(.downloading(progress: progress.progress))
+                }
+            }
+
+            try await audioPlayer.play(
+                reciter: reciter,
+                rate: AudioPreferences.shared.playbackRate,
+                from: from,
+                to: end,
+                verseRuns: verseRuns,
+                listRuns: listRuns
+            )
+            updatePlaybackState(.playing)
+            updateNowPlayingMetadata()
+        } catch {
+            currentAyah = nil
+            updatePlaybackState(.stopped)
+            updateNowPlayingMetadata(playbackRate: 0)
+            throw error
+        }
+    }
+
+    public func setReciter(_ reciter: Reciter) {
+        if !reciters.contains(reciter) {
+            reciters.append(reciter)
+            reciters.sort { $0.localizedName.localizedCaseInsensitiveCompare($1.localizedName) == .orderedAscending }
+        }
+        currentReciter = reciter
+        preferences.lastSelectedReciterId = reciter.id
+        publishSnapshot()
+        updateNowPlayingMetadata()
+    }
+
+    public func pause() {
+        audioPlayer.pauseAudio()
+        updatePlaybackState(.paused)
+        updateNowPlayingMetadata(playbackRate: 0)
+    }
+
+    public func resume() {
+        audioPlayer.resumeAudio()
+        updatePlaybackState(.playing)
+        updateNowPlayingMetadata(playbackRate: AudioPreferences.shared.playbackRate)
+    }
+
+    public func stop() {
+        audioPlayer.stopAudio()
+        currentAyah = nil
+        updatePlaybackState(.stopped)
+        updateNowPlayingMetadata(playbackRate: 0)
+    }
+
+    public func stepForward() {
+        audioPlayer.stepForward()
+        updatePlaybackState(.playing)
+        updateNowPlayingMetadata(playbackRate: AudioPreferences.shared.playbackRate)
+    }
+
+    public func stepBackward() {
+        audioPlayer.stepBackward()
+        updatePlaybackState(.playing)
+        updateNowPlayingMetadata(playbackRate: AudioPreferences.shared.playbackRate)
+    }
+
+    public func setRate(_ rate: Float) {
+        AudioPreferences.shared.playbackRate = rate
+        audioPlayer.setRate(rate)
+
+        if case .playing = playbackState {
+            updateNowPlayingMetadata(playbackRate: rate)
+        }
+    }
+
+    public nonisolated static func surahTitle(for surahNumber: Int, withNumber: Bool = false) -> String {
+        let name = audioPlaybackChapterNames[safe: surahNumber - 1] ?? "Surah \(surahNumber)"
+        if withNumber {
+            return "\(surahNumber). \(name)"
+        }
+        return name
+    }
+
+    private var selectedReciter: Reciter? {
+        currentReciter ?? selectedReciter(from: reciters)
+    }
+
+    private func resolveSelectedReciter() async -> Reciter? {
+        let reciters = await getReciters()
+        let reciter = currentReciter.flatMap { current in
+            reciters.first { $0.id == current.id }
+        } ?? selectedReciter(from: reciters) ?? reciters.first
+        currentReciter = reciter
+        publishSnapshot()
+        return reciter
+    }
+
+    private func publishSnapshot() {
+        let snapshot = snapshot
+        let callbacks = Array(observers.values)
+        for callback in callbacks {
+            callback(snapshot)
+        }
+    }
+
+    private func updatePlaybackState(_ state: PlaybackState) {
+        playbackState = state
+        publishSnapshot()
+        updateRemoteCommandAvailability()
+    }
+
+    private func updateRemoteCommandAvailability() {
+        remoteCommandsHandler?.update(
+            state: playbackState,
+            hasPlaybackRequest: currentRequest != nil
+        )
+    }
+
+    private func updateNowPlayingMetadata(playbackRate: Float? = nil) {
+        guard let request = currentRequest else {
+            return
+        }
+
+        let rate: Float
+        if let playbackRate {
+            rate = playbackRate
+        } else {
+            switch playbackState {
+            case .playing: rate = AudioPreferences.shared.playbackRate
+            case .paused, .stopped, .downloading: rate = 0
+            }
+        }
+
+        nowPlaying.update(info: .init(
+            title: Self.surahTitle(for: request.start.sura.suraNumber, withNumber: true),
+            artist: selectedReciter?.localizedName ?? "",
+            image: nil
+        ))
+        nowPlaying.update(rate: rate)
+    }
+
+    private func setUpAudioPlayerActions() {
+        let actions = QuranAudioPlayerActions(
+            playbackEnded: { [weak self] in self?.playbackEnded() },
+            playbackPaused: { [weak self] in self?.playbackPaused() },
+            playbackResumed: { [weak self] in self?.playbackResumed() },
+            playing: { [weak self] in self?.playing(ayah: $0) }
+        )
+        audioPlayer.setActions(actions)
+    }
+
+    private func playbackEnded() {
+        currentAyah = nil
+        updatePlaybackState(.stopped)
+        updateNowPlayingMetadata(playbackRate: 0)
+    }
+
+    private func playbackPaused() {
+        updatePlaybackState(.paused)
+        updateNowPlayingMetadata(playbackRate: 0)
+    }
+
+    private func playbackResumed() {
+        updatePlaybackState(.playing)
+        updateNowPlayingMetadata(playbackRate: AudioPreferences.shared.playbackRate)
+    }
+
+    private func playing(ayah: AyahNumber) {
+        currentAyah = ayah
+        if case .downloading = playbackState {
+            updatePlaybackState(.playing)
+            updateNowPlayingMetadata(playbackRate: AudioPreferences.shared.playbackRate)
+        } else {
+            publishSnapshot()
+        }
+    }
+
+    private func setUpRemoteCommandHandler() {
+        let actions = AudioPlaybackRemoteCommandActions(
+            play: { [weak self] in
+                guard let self else { return }
+                Task { @MainActor in
+                    await self.handlePlayCommand()
+                }
+            },
+            pause: { [weak self] in self?.pause() },
+            togglePlayPause: { [weak self] in self?.togglePlayPause() },
+            nextTrack: { [weak self] in self?.stepForward() },
+            previousTrack: { [weak self] in self?.stepBackward() }
+        )
+        remoteCommandsHandler = AudioPlaybackRemoteCommandsHandler(center: .shared(), actions: actions)
+    }
+
+    private func handlePlayCommand() async {
+        switch playbackState {
+        case .paused:
+            resume()
+        case .stopped:
+            guard let currentRequest else {
+                return
+            }
+            do {
+                try await play(
+                    from: currentRequest.start,
+                    to: currentRequest.end,
+                    verseRuns: currentRequest.verseRuns,
+                    listRuns: currentRequest.listRuns
+                )
+            } catch {
+            }
+        case .playing, .downloading:
+            break
+        }
+    }
+
+    private func togglePlayPause() {
+        switch playbackState {
+        case .playing:
+            pause()
+        case .paused:
+            resume()
+        case .stopped, .downloading:
+            Task { @MainActor in
+                await handlePlayCommand()
+            }
+        }
+    }
+
+    private func selectedReciter(from reciters: [Reciter]) -> Reciter? {
+        reciters.first { $0.id == preferences.lastSelectedReciterId }
+    }
+}
+
+@MainActor
+private struct AudioPlaybackRemoteCommandActions {
+    let play: () -> Void
+    let pause: () -> Void
+    let togglePlayPause: () -> Void
+    let nextTrack: () -> Void
+    let previousTrack: () -> Void
+}
+
+@MainActor
+private final class AudioPlaybackRemoteCommandsHandler {
+    init(center: MPRemoteCommandCenter, actions: AudioPlaybackRemoteCommandActions) {
+        self.center = center
+        self.actions = actions
+        setUpRemoteControlEvents()
+    }
+
+    func update(state: AudioPlaybackController.PlaybackState, hasPlaybackRequest: Bool) {
+        switch state {
+        case .playing, .paused:
+            setTransportCommandsEnabled(true)
+        case .downloading:
+            setTransportCommandsEnabled(false)
+            center.playCommand.isEnabled = false
+        case .stopped:
+            setTransportCommandsEnabled(false)
+            center.playCommand.isEnabled = hasPlaybackRequest
+        }
+    }
+
+    private let center: MPRemoteCommandCenter
+    private let actions: AudioPlaybackRemoteCommandActions
+
+    private func setUpRemoteControlEvents() {
+        center.playCommand.addTarget { [weak self] _ in
+            self?.actions.play()
+            return .success
+        }
+        center.pauseCommand.addTarget { [weak self] _ in
+            self?.actions.pause()
+            return .success
+        }
+        center.togglePlayPauseCommand.addTarget { [weak self] _ in
+            self?.actions.togglePlayPause()
+            return .success
+        }
+        center.nextTrackCommand.addTarget { [weak self] _ in
+            self?.actions.nextTrack()
+            return .success
+        }
+        center.previousTrackCommand.addTarget { [weak self] _ in
+            self?.actions.previousTrack()
+            return .success
+        }
+
+        let unusedCommands = [
+            center.seekForwardCommand,
+            center.seekBackwardCommand,
+            center.skipForwardCommand,
+            center.skipBackwardCommand,
+            center.ratingCommand,
+            center.changePlaybackRateCommand,
+            center.likeCommand,
+            center.dislikeCommand,
+            center.bookmarkCommand,
+            center.changePlaybackPositionCommand,
+        ]
+        for command in unusedCommands {
+            command.isEnabled = false
+        }
+    }
+
+    private func setTransportCommandsEnabled(_ enabled: Bool) {
+        let commands = [
+            center.playCommand,
+            center.pauseCommand,
+            center.togglePlayPauseCommand,
+            center.nextTrackCommand,
+            center.previousTrackCommand,
+        ]
+        for command in commands {
+            command.isEnabled = enabled
+        }
+    }
+}
+
+private let audioPlaybackChapterNames = [
+    "Al-Fatihah", "Al-Baqarah", "Ali 'Imran", "An-Nisa", "Al-Ma'idah",
+    "Al-An'am", "Al-A'raf", "Al-Anfal", "At-Taubah", "Yunus",
+    "Hud", "Yusuf", "Ar-Ra'd", "Ibrahim", "Al-Hijr",
+    "An-Nahl", "Al-Isra", "Al-Kahf", "Maryam", "Ta-Ha",
+    "Al-Anbiya", "Al-Hajj", "Al-Mu'minun", "An-Nur", "Al-Furqan",
+    "Ash-Shu'ara", "An-Naml", "Al-Qasas", "Al-'Ankabut", "Ar-Rum",
+    "Luqman", "As-Sajdah", "Al-Ahzab", "Saba", "Fatir",
+    "Ya-Sin", "As-Saffat", "Sad", "Az-Zumar", "Ghafir",
+    "Fussilat", "Ash-Shura", "Az-Zukhruf", "Ad-Dukhan", "Al-Jathiya",
+    "Al-Ahqaf", "Muhammad", "Al-Fath", "Al-Hujurat", "Qaf",
+    "Adh-Dhariyat", "At-Tur", "An-Najm", "Al-Qamar", "Ar-Rahman",
+    "Al-Waqi'ah", "Al-Hadid", "Al-Mujadilah", "Al-Hashr", "Al-Mumtahanah",
+    "As-Saff", "Al-Jumu'ah", "Al-Munafiqun", "At-Taghabun", "At-Talaq",
+    "At-Tahrim", "Al-Mulk", "Al-Qalam", "Al-Haqqah", "Al-Ma'arij",
+    "Nuh", "Al-Jinn", "Al-Muzzammil", "Al-Muddaththir", "Al-Qiyamah",
+    "Ad-Dahr", "Al-Mursalat", "An-Naba", "An-Nazi'at", "Abasa",
+    "At-Takwir", "Al-Infitar", "Al-Mutaffifin", "Al-Inshiqaq", "Al-Buruj",
+    "At-Tariq", "Al-A'la", "Al-Ghashiyah", "Al-Fajr", "Al-Balad",
+    "Ash-Shams", "Al-Lail", "Ad-Duhaa", "Ash-Sharh", "At-Tin",
+    "Al-'Alaq", "Al-Qadr", "Al-Bayyinah", "Az-Zilzal", "Al-Adiyat",
+    "Al-Qari'ah", "At-Takathur", "Al-'Asr", "Al-Humazah", "Al-Fil",
+    "Quraysh", "Al-Ma'un", "Al-Kawthar", "Al-Kafirun", "An-Nasr",
+    "Al-Masad", "Al-Ikhlas", "Al-Falaq", "An-Nas",
+]
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Features/AudioBannerFeature/AudioPlaybackControllerStore.swift
+++ b/Features/AudioBannerFeature/AudioPlaybackControllerStore.swift
@@ -1,0 +1,35 @@
+//
+//  AudioPlaybackControllerStore.swift
+//  QuranEngineApp
+//
+//  Created by aom on 3/9/26.
+//
+
+import AppDependencies
+import Foundation
+import QuranAudioKit
+import ReciterService
+
+@MainActor
+public enum AudioPlaybackControllerStore {
+    public private(set) static var shared: AudioPlaybackController?
+
+    public static func setUpIfNeeded(container: AppDependencies) {
+        guard shared == nil else { return }
+
+        let reciterRetriever = ReciterDataRetriever()
+        let recentRecitersService = RecentRecitersService()
+        let audioPlayer = QuranAudioPlayer()
+        let downloader = QuranAudioDownloader(
+            baseURL: container.filesAppHost,
+            downloader: container.downloadManager
+        )
+
+        shared = AudioPlaybackController(
+            audioPlayer: audioPlayer,
+            downloader: downloader,
+            reciterRetriever: reciterRetriever,
+            recentRecitersService: recentRecitersService
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- add a CarPlay scene with tabs for surahs, reciters, and playback modes
- support playback to page, surah, or juz boundaries, plus custom verse-range playback from CarPlay
- introduce a shared `AudioPlaybackController` so CarPlay and the audio banner stay in sync for reciter selection, download state, remote commands, and Now Playing
- dismiss the CarPlay playback failure alert when the user taps OK so the interface does not get stuck on the alert screen

## Testing
- built the example app locally with `xcrun xcodebuild build -project Example/QuranEngineApp.xcodeproj -scheme QuranEngineApp -sdk iphonesimulator -destination 'generic/platform=iOS' CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO`
- verified the branch is able to merge cleanly into `quran/quran-ios` `main`
