### PR TITLE
Prepare synced highlight collection entry points

### DIFF
--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
@@ -14,6 +14,7 @@
         init(
             ayahBookmarkCollectionService: AyahBookmarkCollectionService,
             includedCollectionNames: Set<String>? = nil,
+            prepareCollections: @escaping ([AyahBookmarkCollection]) async throws -> Void = { _ in },
             navigateToPage: @escaping (Page) -> Void,
             title: String = l("bookmarks.collections"),
             allowsCollectionManagement: Bool = true,
@@ -21,6 +22,7 @@
         ) {
             self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
             self.includedCollectionNames = includedCollectionNames
+            self.prepareCollections = prepareCollections
             self.navigateToPage = navigateToPage
             self.title = title
             self.allowsCollectionManagement = allowsCollectionManagement
@@ -32,6 +34,7 @@
                 ayahBookmarkCollectionService: ayahBookmarkCollectionService,
                 includedCollectionNames: includedCollectionNames,
                 excludedCollectionNames: includedCollectionNames == nil ? [Self.oldPageBookmarksCollectionName] : [],
+                prepareCollections: prepareCollections,
                 navigateToPage: navigateToPage
             )
             return AyahBookmarkCollectionsViewController(
@@ -60,6 +63,7 @@
 
         private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
         private let includedCollectionNames: Set<String>?
+        private let prepareCollections: ([AyahBookmarkCollection]) async throws -> Void
         private let navigateToPage: (Page) -> Void
         private let title: String
         private let allowsCollectionManagement: Bool

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
@@ -19,11 +19,13 @@
             ayahBookmarkCollectionService: AyahBookmarkCollectionService,
             includedCollectionNames: Set<String>? = nil,
             excludedCollectionNames: Set<String> = [],
+            prepareCollections: @escaping ([AyahBookmarkCollection]) async throws -> Void = { _ in },
             navigateToPage: @escaping (Page) -> Void
         ) {
             self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
             self.includedCollectionNames = includedCollectionNames
             self.excludedCollectionNames = excludedCollectionNames
+            self.prepareCollections = prepareCollections
             self.navigateToPage = navigateToPage
         }
 
@@ -54,7 +56,7 @@
                 let sequence = ayahBookmarkCollectionService.collectionsSequence()
                 for try await collections in sequence {
                     self.collections = Self.sorted(filtered(collections))
-                    try await ensureHighlightCollections(collections)
+                    try await prepareCollectionsIfNeeded(collections)
                 }
             } catch {
                 self.error = error
@@ -108,12 +110,9 @@
         private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
         private let includedCollectionNames: Set<String>?
         private let excludedCollectionNames: Set<String>
+        private let prepareCollections: ([AyahBookmarkCollection]) async throws -> Void
         private let navigateToPage: (Page) -> Void
-        private var didEnsureHighlightCollections = false
-
-        private var shouldEnsureHighlightCollections: Bool {
-            includedCollectionNames == nil || includedCollectionNames == Set(HighlightBookmarkCollections.names)
-        }
+        private var didPrepareCollections = false
 
         private static func highlightSortIndex(_ collection: AyahBookmarkCollection) -> Int? {
             guard let color = HighlightColor(collectionName: collection.collection.name) else {
@@ -132,12 +131,12 @@
             }
         }
 
-        private func ensureHighlightCollections(_ collections: [AyahBookmarkCollection]) async throws {
-            guard !didEnsureHighlightCollections, shouldEnsureHighlightCollections else {
+        private func prepareCollectionsIfNeeded(_ collections: [AyahBookmarkCollection]) async throws {
+            guard !didPrepareCollections else {
                 return
             }
-            didEnsureHighlightCollections = true
-            try await HighlightBookmarkCollections.ensure(in: collections, using: ayahBookmarkCollectionService)
+            didPrepareCollections = true
+            try await prepareCollections(collections)
         }
     }
 #endif

--- a/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
@@ -26,7 +26,6 @@ public struct BookmarksBuilder {
     public func build(withListener listener: QuranNavigator) -> UIViewController {
         let service = PageBookmarkService(persistence: container.pageBookmarkPersistence)
         #if QURAN_SYNC
-            let showHighlightsAction: (@MainActor (UIViewController) async -> Void)?
             let showCollectionsAction: (@MainActor (UIViewController) async -> Void)?
             let showOldPageBookmarksAction: (@MainActor (UIViewController) async -> Void)?
             if let syncService = container.syncService {
@@ -37,26 +36,11 @@ public struct BookmarksBuilder {
                 let navigateToPage: (Page) -> Void = { [weak listener] page in
                     listener?.navigateTo(page: page, lastPage: nil, highlightingSearchAyah: nil)
                 }
-                let highlightsBuilder = AyahBookmarkCollectionsBuilder(
-                    ayahBookmarkCollectionService: ayahBookmarkCollectionService,
-                    includedCollectionNames: Set(HighlightBookmarkCollections.names),
-                    prepareCollections: prepareHighlightCollections,
-                    navigateToPage: navigateToPage,
-                    title: l("bookmarks.highlights"),
-                    allowsCollectionManagement: false
-                )
                 let collectionsBuilder = AyahBookmarkCollectionsBuilder(
                     ayahBookmarkCollectionService: ayahBookmarkCollectionService,
                     prepareCollections: prepareHighlightCollections,
                     navigateToPage: navigateToPage
                 )
-                showHighlightsAction = { presenter in
-                    guard let navigationController = presenter.navigationController else {
-                        return
-                    }
-                    let highlightsViewController = highlightsBuilder.build()
-                    navigationController.pushViewController(highlightsViewController, animated: true)
-                }
                 showCollectionsAction = { presenter in
                     guard let navigationController = presenter.navigationController else {
                         return
@@ -72,7 +56,6 @@ public struct BookmarksBuilder {
                     navigationController.pushViewController(oldPageBookmarksViewController, animated: true)
                 }
             } else {
-                showHighlightsAction = nil
                 showCollectionsAction = nil
                 showOldPageBookmarksAction = nil
             }
@@ -83,7 +66,6 @@ public struct BookmarksBuilder {
                 navigateTo: { [weak listener] page in
                     listener?.navigateTo(page: page, lastPage: nil, highlightingSearchAyah: nil)
                 },
-                showHighlightsAction: showHighlightsAction,
                 showCollectionsAction: showCollectionsAction,
                 showOldPageBookmarksAction: showOldPageBookmarksAction
             )

--- a/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
@@ -31,18 +31,23 @@ public struct BookmarksBuilder {
             let showOldPageBookmarksAction: (@MainActor (UIViewController) async -> Void)?
             if let syncService = container.syncService {
                 let ayahBookmarkCollectionService = AyahBookmarkCollectionService(syncService: syncService)
+                let prepareHighlightCollections: ([AyahBookmarkCollection]) async throws -> Void = { collections in
+                    try await HighlightBookmarkCollections.ensure(in: collections, using: ayahBookmarkCollectionService)
+                }
                 let navigateToPage: (Page) -> Void = { [weak listener] page in
                     listener?.navigateTo(page: page, lastPage: nil, highlightingSearchAyah: nil)
                 }
                 let highlightsBuilder = AyahBookmarkCollectionsBuilder(
                     ayahBookmarkCollectionService: ayahBookmarkCollectionService,
                     includedCollectionNames: Set(HighlightBookmarkCollections.names),
+                    prepareCollections: prepareHighlightCollections,
                     navigateToPage: navigateToPage,
                     title: l("bookmarks.highlights"),
                     allowsCollectionManagement: false
                 )
                 let collectionsBuilder = AyahBookmarkCollectionsBuilder(
                     ayahBookmarkCollectionService: ayahBookmarkCollectionService,
+                    prepareCollections: prepareHighlightCollections,
                     navigateToPage: navigateToPage
                 )
                 showHighlightsAction = { presenter in

--- a/Features/BookmarksFeature/Sources/BookmarksView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksView.swift
@@ -31,7 +31,6 @@ struct BookmarksView: View {
             deleteAction: { await viewModel.deleteItem($0) },
             dismissSyncBanner: { viewModel.dismissSyncBanner() },
             signInAction: { await viewModel.loginToQuranCom() },
-            showHighlightsAction: viewModel.showHighlightsAction,
             showCollectionsAction: viewModel.showCollectionsAction,
             showOldPageBookmarksAction: viewModel.showOldPageBookmarksAction
         )
@@ -53,7 +52,6 @@ private struct BookmarksViewUI: View {
     let deleteAction: AsyncItemAction<PageBookmark>
     let dismissSyncBanner: () -> Void
     let signInAction: @MainActor () async -> Void
-    let showHighlightsAction: AsyncAction?
     let showCollectionsAction: AsyncAction?
     let showOldPageBookmarksAction: AsyncAction?
 
@@ -113,15 +111,6 @@ private struct BookmarksViewUI: View {
             )
         }
 
-        private var highlightsRow: some View {
-            NoorListItem(
-                image: .init { HighlightPaletteIcon() },
-                title: .text(l("bookmarks.highlights")),
-                accessory: .disclosureIndicator,
-                action: showHighlightsAction
-            )
-        }
-
         private var collectionsRow: some View {
             NoorListItem(
                 image: .init(.folder, color: .accentColor),
@@ -147,14 +136,9 @@ private struct BookmarksViewUI: View {
                 }
             }
 
-            if showHighlightsAction != nil || showCollectionsAction != nil {
+            if showCollectionsAction != nil {
                 NoorBasicSection {
-                    if showHighlightsAction != nil {
-                        highlightsRow
-                    }
-                    if showCollectionsAction != nil {
-                        collectionsRow
-                    }
+                    collectionsRow
                 }
             }
         #endif
@@ -263,7 +247,6 @@ struct BookmarksView_Previews: PreviewProvider {
                     deleteAction: { item in items = items.filter { $0 != item } },
                     dismissSyncBanner: {},
                     signInAction: {},
-                    showHighlightsAction: {},
                     showCollectionsAction: showCollectionsAction,
                     showOldPageBookmarksAction: {}
                 )

--- a/Features/BookmarksFeature/Sources/BookmarksViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksViewModel.swift
@@ -26,7 +26,6 @@ final class BookmarksViewModel: ObservableObject {
         service: PageBookmarkService,
         authenticationClient: (any AuthenticationClient)?,
         navigateTo: @escaping (Page) -> Void,
-        showHighlightsAction: (@MainActor (UIViewController) async -> Void)? = nil,
         showCollectionsAction: (@MainActor (UIViewController) async -> Void)? = nil,
         showOldPageBookmarksAction: (@MainActor (UIViewController) async -> Void)? = nil
     ) {
@@ -34,7 +33,6 @@ final class BookmarksViewModel: ObservableObject {
         self.service = service
         self.authenticationClient = authenticationClient
         self.navigateTo = navigateTo
-        presentHighlightsAction = showHighlightsAction
         presentCollectionsAction = showCollectionsAction
         presentOldPageBookmarksAction = showOldPageBookmarksAction
         isSyncBannerDismissed = preferences.isSyncBannerDismissed
@@ -52,15 +50,6 @@ final class BookmarksViewModel: ObservableObject {
 
     var shouldShowSyncBanner: Bool {
         !isAuthenticated && !isSyncBannerDismissed
-    }
-
-    var showHighlightsAction: (@MainActor @Sendable () async -> Void)? {
-        guard presentHighlightsAction != nil else {
-            return nil
-        }
-        return { [weak self] in
-            await self?.showHighlights()
-        }
     }
 
     var showCollectionsAction: (@MainActor @Sendable () async -> Void)? {
@@ -147,13 +136,6 @@ final class BookmarksViewModel: ObservableObject {
         }
     }
 
-    func showHighlights() async {
-        guard let presenter else {
-            return
-        }
-        await presentHighlightsAction?(presenter)
-    }
-
     func showCollections() async {
         guard let presenter else {
             return
@@ -174,7 +156,6 @@ final class BookmarksViewModel: ObservableObject {
     private let analytics: AnalyticsLibrary
     private let service: PageBookmarkService
     private let authenticationClient: (any AuthenticationClient)?
-    private let presentHighlightsAction: (@MainActor (UIViewController) async -> Void)?
     private let presentCollectionsAction: (@MainActor (UIViewController) async -> Void)?
     private let presentOldPageBookmarksAction: (@MainActor (UIViewController) async -> Void)?
     private let readingPreferences = ReadingPreferences.shared


### PR DESCRIPTION
## Summary
- Hide standalone Highlights row from Bookmarks.
- Keep highlights surfaced through synced collections.
- Prepare sync-only entry points without changing legacy behavior.

## Notes
- Base: `feat/highlights-collections`
- `QURAN_SYNC` behavior only.
