### PR TITLE
Add synced ayah bookmark menu flow

### DIFF
--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -286,5 +286,7 @@
 "ayah-bookmark.save-verse" = "حفظ الآية";
 "ayah-bookmark.save-to-collection" = "حفظ في مجموعة";
 "ayah-bookmark.save-reading-bookmark" = "حفظ كعلامة قراءة";
+"ayah-bookmark.save-to-highlight" = "حفظ كتمييز";
+"ayah-bookmark.remove-reading-bookmark" = "إزالة علامة القراءة";
 "ayah-bookmark.collection-picker.no-data.title" = "لا توجد مجموعات بعد";
 "ayah-bookmark.collection-picker.no-data.text" = "أضف مجموعة لحفظ هذه الآية.";

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -264,3 +264,10 @@
 "reading-bookmark.education.undo" = "تراجع";
 "reading-bookmark.title" = "علامة القراءة";
 "reading-bookmark.my-title" = "علامة القراءة الخاصة بي";
+
+// MARK: - Ayah Bookmarks
+"ayah-bookmark.save-verse" = "حفظ الآية";
+"ayah-bookmark.save-to-collection" = "حفظ في مجموعة";
+"ayah-bookmark.save-reading-bookmark" = "حفظ كعلامة قراءة";
+"ayah-bookmark.collection-picker.no-data.title" = "لا توجد مجموعات بعد";
+"ayah-bookmark.collection-picker.no-data.text" = "أضف مجموعة لحفظ هذه الآية.";

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -269,5 +269,7 @@
 "ayah-bookmark.save-verse" = "حفظ الآية";
 "ayah-bookmark.save-to-collection" = "حفظ في مجموعة";
 "ayah-bookmark.save-reading-bookmark" = "حفظ كعلامة قراءة";
+"ayah-bookmark.save-to-highlight" = "حفظ كتمييز";
+"ayah-bookmark.remove-reading-bookmark" = "إزالة علامة القراءة";
 "ayah-bookmark.collection-picker.no-data.title" = "لا توجد مجموعات بعد";
 "ayah-bookmark.collection-picker.no-data.text" = "أضف مجموعة لحفظ هذه الآية.";

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -283,6 +283,7 @@
 
 // MARK: - Ayah Bookmarks
 "ayah-bookmark.save-verse" = "حفظ الآية";
+"ayah-bookmark.remove-verse" = "إزالة الإشارة المرجعية";
 "ayah-bookmark.save-to-collection" = "حفظ في مجموعة";
 "ayah-bookmark.save-reading-bookmark" = "حفظ كعلامة قراءة";
 "ayah-bookmark.save-to-highlight" = "حفظ كتمييز";

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -266,6 +266,7 @@
 
 // MARK: - Ayah Bookmarks
 "ayah-bookmark.save-verse" = "حفظ الآية";
+"ayah-bookmark.remove-verse" = "إزالة الإشارة المرجعية";
 "ayah-bookmark.save-to-collection" = "حفظ في مجموعة";
 "ayah-bookmark.save-reading-bookmark" = "حفظ كعلامة قراءة";
 "ayah-bookmark.save-to-highlight" = "حفظ كتمييز";

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -281,3 +281,10 @@
 "reading-bookmark.education.undo" = "تراجع";
 "reading-bookmark.title" = "علامة القراءة";
 "reading-bookmark.my-title" = "علامة القراءة الخاصة بي";
+
+// MARK: - Ayah Bookmarks
+"ayah-bookmark.save-verse" = "حفظ الآية";
+"ayah-bookmark.save-to-collection" = "حفظ في مجموعة";
+"ayah-bookmark.save-reading-bookmark" = "حفظ كعلامة قراءة";
+"ayah-bookmark.collection-picker.no-data.title" = "لا توجد مجموعات بعد";
+"ayah-bookmark.collection-picker.no-data.text" = "أضف مجموعة لحفظ هذه الآية.";

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -279,7 +279,6 @@
 "reading-bookmark.education.title.link" = "علامة قراءة متنقلة";
 "reading-bookmark.education.body" = "حفظ علامة قراءة سيستبدل علامة القراءة القديمة. لحفظ عدة آيات، استخدم ميزة التمييز.";
 "reading-bookmark.education.undo" = "تراجع";
-"reading-bookmark.title" = "علامة القراءة";
 "reading-bookmark.my-title" = "علامة القراءة الخاصة بي";
 
 // MARK: - Ayah Bookmarks

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -262,7 +262,6 @@
 "reading-bookmark.education.title.link" = "علامة قراءة متنقلة";
 "reading-bookmark.education.body" = "حفظ علامة قراءة سيستبدل علامة القراءة القديمة. لحفظ عدة آيات، استخدم ميزة التمييز.";
 "reading-bookmark.education.undo" = "تراجع";
-"reading-bookmark.title" = "علامة القراءة";
 "reading-bookmark.my-title" = "علامة القراءة الخاصة بي";
 
 // MARK: - Ayah Bookmarks

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -287,7 +287,6 @@
 "reading-bookmark.education.title.link" = "reading bookmark";
 "reading-bookmark.education.body" = "Saving a reading bookmark will now replace your old reading bookmark. To save multiple verses, please use the highlight feature.";
 "reading-bookmark.education.undo" = "Undo";
-"reading-bookmark.title" = "Reading Bookmark";
 "reading-bookmark.my-title" = "My Reading Bookmark";
 
 // MARK: - Ayah Bookmarks

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -291,6 +291,7 @@
 
 // MARK: - Ayah Bookmarks
 "ayah-bookmark.save-verse" = "Save Verse";
+"ayah-bookmark.remove-verse" = "Remove Bookmark";
 "ayah-bookmark.save-to-collection" = "Save to Collection";
 "ayah-bookmark.save-reading-bookmark" = "Save as Reading Bookmark";
 "ayah-bookmark.save-to-highlight" = "Save to Highlight";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -289,3 +289,10 @@
 "reading-bookmark.education.undo" = "Undo";
 "reading-bookmark.title" = "Reading Bookmark";
 "reading-bookmark.my-title" = "My Reading Bookmark";
+
+// MARK: - Ayah Bookmarks
+"ayah-bookmark.save-verse" = "Save Verse";
+"ayah-bookmark.save-to-collection" = "Save to Collection";
+"ayah-bookmark.save-reading-bookmark" = "Save as Reading Bookmark";
+"ayah-bookmark.collection-picker.no-data.title" = "No collections yet";
+"ayah-bookmark.collection-picker.no-data.text" = "Add a collection to save this verse.";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -284,3 +284,10 @@
 "reading-bookmark.education.undo" = "Undo";
 "reading-bookmark.title" = "Reading Bookmark";
 "reading-bookmark.my-title" = "My Reading Bookmark";
+
+// MARK: - Ayah Bookmarks
+"ayah-bookmark.save-verse" = "Save Verse";
+"ayah-bookmark.save-to-collection" = "Save to Collection";
+"ayah-bookmark.save-reading-bookmark" = "Save as Reading Bookmark";
+"ayah-bookmark.collection-picker.no-data.title" = "No collections yet";
+"ayah-bookmark.collection-picker.no-data.text" = "Add a collection to save this verse.";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -286,6 +286,7 @@
 
 // MARK: - Ayah Bookmarks
 "ayah-bookmark.save-verse" = "Save Verse";
+"ayah-bookmark.remove-verse" = "Remove Bookmark";
 "ayah-bookmark.save-to-collection" = "Save to Collection";
 "ayah-bookmark.save-reading-bookmark" = "Save as Reading Bookmark";
 "ayah-bookmark.save-to-highlight" = "Save to Highlight";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -294,5 +294,7 @@
 "ayah-bookmark.save-verse" = "Save Verse";
 "ayah-bookmark.save-to-collection" = "Save to Collection";
 "ayah-bookmark.save-reading-bookmark" = "Save as Reading Bookmark";
+"ayah-bookmark.save-to-highlight" = "Save to Highlight";
+"ayah-bookmark.remove-reading-bookmark" = "Remove Reading Bookmark";
 "ayah-bookmark.collection-picker.no-data.title" = "No collections yet";
 "ayah-bookmark.collection-picker.no-data.text" = "Add a collection to save this verse.";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -289,5 +289,7 @@
 "ayah-bookmark.save-verse" = "Save Verse";
 "ayah-bookmark.save-to-collection" = "Save to Collection";
 "ayah-bookmark.save-reading-bookmark" = "Save as Reading Bookmark";
+"ayah-bookmark.save-to-highlight" = "Save to Highlight";
+"ayah-bookmark.remove-reading-bookmark" = "Remove Reading Bookmark";
 "ayah-bookmark.collection-picker.no-data.title" = "No collections yet";
 "ayah-bookmark.collection-picker.no-data.text" = "Add a collection to save this verse.";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -282,7 +282,6 @@
 "reading-bookmark.education.title.link" = "reading bookmark";
 "reading-bookmark.education.body" = "Saving a reading bookmark will now replace your old reading bookmark. To save multiple verses, please use the highlight feature.";
 "reading-bookmark.education.undo" = "Undo";
-"reading-bookmark.title" = "Reading Bookmark";
 "reading-bookmark.my-title" = "My Reading Bookmark";
 
 // MARK: - Ayah Bookmarks

--- a/Features/AyahMenuFeature/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/AyahMenuBuilder.swift
@@ -24,8 +24,7 @@ public struct AyahMenuInput {
         verses: [AyahNumber],
         notes: [QuranAnnotations.Note],
         noteCount: Int = 0,
-        highlightColor: HighlightColor? = nil,
-        isCollectionBookmarked: Bool = false
+        highlightColor: HighlightColor? = nil
     ) {
         self.sourceView = sourceView
         self.pointInView = pointInView
@@ -33,8 +32,30 @@ public struct AyahMenuInput {
         self.notes = notes
         self.noteCount = noteCount
         self.highlightColor = highlightColor
-        self.isCollectionBookmarked = isCollectionBookmarked
+        #if QURAN_SYNC
+            isCollectionBookmarked = false
+        #endif
     }
+
+    #if QURAN_SYNC
+        public init(
+            sourceView: UIView,
+            pointInView: CGPoint,
+            verses: [AyahNumber],
+            notes: [QuranAnnotations.Note],
+            noteCount: Int = 0,
+            highlightColor: HighlightColor? = nil,
+            isCollectionBookmarked: Bool
+        ) {
+            self.sourceView = sourceView
+            self.pointInView = pointInView
+            self.verses = verses
+            self.notes = notes
+            self.noteCount = noteCount
+            self.highlightColor = highlightColor
+            self.isCollectionBookmarked = isCollectionBookmarked
+        }
+    #endif
 
     // MARK: Internal
 
@@ -44,7 +65,9 @@ public struct AyahMenuInput {
     let notes: [QuranAnnotations.Note]
     let noteCount: Int
     let highlightColor: HighlightColor?
-    let isCollectionBookmarked: Bool
+    #if QURAN_SYNC
+        let isCollectionBookmarked: Bool
+    #endif
 }
 
 @MainActor

--- a/Features/AyahMenuFeature/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/AyahMenuBuilder.swift
@@ -24,7 +24,8 @@ public struct AyahMenuInput {
         verses: [AyahNumber],
         notes: [QuranAnnotations.Note],
         noteCount: Int = 0,
-        highlightColor: HighlightColor? = nil
+        highlightColor: HighlightColor? = nil,
+        isCollectionBookmarked: Bool = false
     ) {
         self.sourceView = sourceView
         self.pointInView = pointInView
@@ -32,6 +33,7 @@ public struct AyahMenuInput {
         self.notes = notes
         self.noteCount = noteCount
         self.highlightColor = highlightColor
+        self.isCollectionBookmarked = isCollectionBookmarked
     }
 
     // MARK: Internal
@@ -42,6 +44,7 @@ public struct AyahMenuInput {
     let notes: [QuranAnnotations.Note]
     let noteCount: Int
     let highlightColor: HighlightColor?
+    let isCollectionBookmarked: Bool
 }
 
 @MainActor
@@ -71,6 +74,7 @@ public struct AyahMenuBuilder {
                 highlightColor: input.highlightColor,
                 usesSyncedNotes: usesSyncedNotes,
                 noteCount: input.noteCount,
+                isCollectionBookmarked: input.isCollectionBookmarked,
                 ayahBookmarkCollectionService: container.syncService.map { AyahBookmarkCollectionService(syncService: $0) }
             )
         #else

--- a/Features/AyahMenuFeature/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/AyahMenuBuilder.swift
@@ -23,13 +23,15 @@ public struct AyahMenuInput {
         pointInView: CGPoint,
         verses: [AyahNumber],
         notes: [QuranAnnotations.Note],
-        highlightColor: HighlightColor? = nil
+        highlightColor: HighlightColor? = nil,
+        isCollectionBookmarked: Bool = false
     ) {
         self.sourceView = sourceView
         self.pointInView = pointInView
         self.verses = verses
         self.notes = notes
         self.highlightColor = highlightColor
+        self.isCollectionBookmarked = isCollectionBookmarked
     }
 
     // MARK: Internal
@@ -39,6 +41,7 @@ public struct AyahMenuInput {
     let verses: [AyahNumber]
     let notes: [QuranAnnotations.Note]
     let highlightColor: HighlightColor?
+    let isCollectionBookmarked: Bool
 }
 
 @MainActor
@@ -66,6 +69,7 @@ public struct AyahMenuBuilder {
                 noteService: noteService,
                 textRetriever: textRetriever,
                 highlightColor: input.highlightColor,
+                isCollectionBookmarked: input.isCollectionBookmarked,
                 ayahBookmarkCollectionService: container.syncService.map { AyahBookmarkCollectionService(syncService: $0) }
             )
         #else
@@ -76,7 +80,8 @@ public struct AyahMenuBuilder {
                 notes: input.notes,
                 noteService: noteService,
                 textRetriever: textRetriever,
-                highlightColor: input.highlightColor
+                highlightColor: input.highlightColor,
+                isCollectionBookmarked: input.isCollectionBookmarked
             )
         #endif
         let viewModel = AyahMenuViewModel(deps: deps)

--- a/Features/AyahMenuFeature/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/AyahMenuBuilder.swift
@@ -23,16 +23,35 @@ public struct AyahMenuInput {
         pointInView: CGPoint,
         verses: [AyahNumber],
         notes: [QuranAnnotations.Note],
-        highlightColor: HighlightColor? = nil,
-        isCollectionBookmarked: Bool = false
+        highlightColor: HighlightColor? = nil
     ) {
         self.sourceView = sourceView
         self.pointInView = pointInView
         self.verses = verses
         self.notes = notes
         self.highlightColor = highlightColor
-        self.isCollectionBookmarked = isCollectionBookmarked
+        #if QURAN_SYNC
+            isCollectionBookmarked = false
+        #endif
     }
+
+    #if QURAN_SYNC
+        public init(
+            sourceView: UIView,
+            pointInView: CGPoint,
+            verses: [AyahNumber],
+            notes: [QuranAnnotations.Note],
+            highlightColor: HighlightColor? = nil,
+            isCollectionBookmarked: Bool
+        ) {
+            self.sourceView = sourceView
+            self.pointInView = pointInView
+            self.verses = verses
+            self.notes = notes
+            self.highlightColor = highlightColor
+            self.isCollectionBookmarked = isCollectionBookmarked
+        }
+    #endif
 
     // MARK: Internal
 
@@ -41,7 +60,9 @@ public struct AyahMenuInput {
     let verses: [AyahNumber]
     let notes: [QuranAnnotations.Note]
     let highlightColor: HighlightColor?
-    let isCollectionBookmarked: Bool
+    #if QURAN_SYNC
+        let isCollectionBookmarked: Bool
+    #endif
 }
 
 @MainActor
@@ -80,8 +101,7 @@ public struct AyahMenuBuilder {
                 notes: input.notes,
                 noteService: noteService,
                 textRetriever: textRetriever,
-                highlightColor: input.highlightColor,
-                isCollectionBookmarked: input.isCollectionBookmarked
+                highlightColor: input.highlightColor
             )
         #endif
         let viewModel = AyahMenuViewModel(deps: deps)

--- a/Features/AyahMenuFeature/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewController.swift
@@ -39,7 +39,7 @@ final class AyahMenuViewController: UIViewController {
             play: { [weak self] in self?.viewModel.play() },
             repeatVerses: { [weak self] in self?.viewModel.repeatVerses() },
             highlight: { [weak self] color in await self?.viewModel.updateHighlight(color: color) },
-            saveVerse: { [weak self] in self?.viewModel.saveVerse() },
+            saveVerse: { [weak self] in await self?.viewModel.saveVerse() },
             addNote: { [weak self] in await self?.viewModel.editNote() },
             deleteNote: { [weak self] in await self?.viewModel.deleteNotes() },
             showTranslation: { [weak self] in self?.viewModel.showTranslation() },
@@ -56,7 +56,8 @@ final class AyahMenuViewController: UIViewController {
             isTranslationView: viewModel.isTranslationView,
             usesSyncedNotesIcon: viewModel.usesSyncedNotesIcon,
             noteCount: viewModel.noteCount,
-            usesCollectionBookmarks: viewModel.usesCollectionBookmarks
+            usesCollectionBookmarks: viewModel.usesCollectionBookmarks,
+            isCollectionBookmarked: viewModel.isCollectionBookmarked
         )
         showAyahMenu(dataObject)
     }

--- a/Features/AyahMenuFeature/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewController.swift
@@ -39,7 +39,7 @@ final class AyahMenuViewController: UIViewController {
             play: { [weak self] in self?.viewModel.play() },
             repeatVerses: { [weak self] in self?.viewModel.repeatVerses() },
             highlight: { [weak self] color in await self?.viewModel.updateHighlight(color: color) },
-            saveVerse: { [weak self] in self?.viewModel.saveVerse() },
+            saveVerse: { [weak self] in await self?.viewModel.saveVerse() },
             addNote: { [weak self] in await self?.viewModel.editNote() },
             deleteNote: { [weak self] in await self?.viewModel.deleteNotes() },
             showTranslation: { [weak self] in self?.viewModel.showTranslation() },
@@ -54,7 +54,8 @@ final class AyahMenuViewController: UIViewController {
             repeatSubtitle: viewModel.repeatSubtitle,
             actions: actions,
             isTranslationView: viewModel.isTranslationView,
-            usesCollectionBookmarks: viewModel.usesCollectionBookmarks
+            usesCollectionBookmarks: viewModel.usesCollectionBookmarks,
+            isCollectionBookmarked: viewModel.isCollectionBookmarked
         )
         showAyahMenu(dataObject)
     }

--- a/Features/AyahMenuFeature/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewController.swift
@@ -39,6 +39,7 @@ final class AyahMenuViewController: UIViewController {
             play: { [weak self] in self?.viewModel.play() },
             repeatVerses: { [weak self] in self?.viewModel.repeatVerses() },
             highlight: { [weak self] color in await self?.viewModel.updateHighlight(color: color) },
+            saveVerse: { [weak self] in self?.viewModel.saveVerse() },
             addNote: { [weak self] in await self?.viewModel.editNote() },
             deleteNote: { [weak self] in await self?.viewModel.deleteNotes() },
             showTranslation: { [weak self] in self?.viewModel.showTranslation() },
@@ -54,7 +55,8 @@ final class AyahMenuViewController: UIViewController {
             actions: actions,
             isTranslationView: viewModel.isTranslationView,
             usesSyncedNotesIcon: viewModel.usesSyncedNotesIcon,
-            noteCount: viewModel.noteCount
+            noteCount: viewModel.noteCount,
+            usesCollectionBookmarks: viewModel.usesCollectionBookmarks
         )
         showAyahMenu(dataObject)
     }

--- a/Features/AyahMenuFeature/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewController.swift
@@ -39,6 +39,7 @@ final class AyahMenuViewController: UIViewController {
             play: { [weak self] in self?.viewModel.play() },
             repeatVerses: { [weak self] in self?.viewModel.repeatVerses() },
             highlight: { [weak self] color in await self?.viewModel.updateHighlight(color: color) },
+            saveVerse: { [weak self] in self?.viewModel.saveVerse() },
             addNote: { [weak self] in await self?.viewModel.editNote() },
             deleteNote: { [weak self] in await self?.viewModel.deleteNotes() },
             showTranslation: { [weak self] in self?.viewModel.showTranslation() },
@@ -52,7 +53,8 @@ final class AyahMenuViewController: UIViewController {
             playSubtitle: viewModel.playSubtitle,
             repeatSubtitle: viewModel.repeatSubtitle,
             actions: actions,
-            isTranslationView: viewModel.isTranslationView
+            isTranslationView: viewModel.isTranslationView,
+            usesCollectionBookmarks: viewModel.usesCollectionBookmarks
         )
         showAyahMenu(dataObject)
     }

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -34,6 +34,7 @@ public protocol AyahMenuListener: AnyObject {
     #if QURAN_SYNC
         func addSyncedNote(verses: [AyahNumber])
         func saveVersesAsBookmark(_ verses: [AyahNumber])
+        func removeVersesFromBookmarkCollections(_ verses: [AyahNumber]) async
     #endif
 
     func editNote(_ note: QuranAnnotations.Note)
@@ -54,6 +55,7 @@ final class AyahMenuViewModel {
         #if QURAN_SYNC
             let usesSyncedNotes: Bool
             let noteCount: Int
+            let isCollectionBookmarked: Bool
             let ayahBookmarkCollectionService: AyahBookmarkCollectionService?
         #endif
         let quranContentStatePreferences = QuranContentStatePreferences.shared
@@ -125,6 +127,14 @@ final class AyahMenuViewModel {
             return deps.usesSyncedNotes ? deps.noteCount : 0
         #else
             return 0
+        #endif
+    }
+
+    var isCollectionBookmarked: Bool {
+        #if QURAN_SYNC
+            return usesCollectionBookmarks && deps.isCollectionBookmarked
+        #else
+            return false
         #endif
     }
 
@@ -206,10 +216,15 @@ final class AyahMenuViewModel {
         listener?.showTranslation(deps.verses)
     }
 
-    func saveVerse() {
+    func saveVerse() async {
         #if QURAN_SYNC
-            logger.info("AyahMenu: save verse. Verses: \(deps.verses)")
-            listener?.saveVersesAsBookmark(deps.verses)
+            if isCollectionBookmarked {
+                logger.info("AyahMenu: remove verse bookmark. Verses: \(deps.verses)")
+                await listener?.removeVersesFromBookmarkCollections(deps.verses)
+            } else {
+                logger.info("AyahMenu: save verse. Verses: \(deps.verses)")
+                listener?.saveVersesAsBookmark(deps.verses)
+            }
         #endif
     }
 

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -33,6 +33,7 @@ public protocol AyahMenuListener: AnyObject {
 
     #if QURAN_SYNC
         func saveVersesAsBookmark(_ verses: [AyahNumber])
+        func removeVersesFromBookmarkCollections(_ verses: [AyahNumber]) async
     #endif
 
     func editNote(_ note: QuranAnnotations.Note)
@@ -50,6 +51,7 @@ final class AyahMenuViewModel {
         let noteService: NoteService
         let textRetriever: ShareableVerseTextRetriever
         let highlightColor: HighlightColor?
+        let isCollectionBookmarked: Bool
         #if QURAN_SYNC
             let ayahBookmarkCollectionService: AyahBookmarkCollectionService?
         #endif
@@ -104,6 +106,14 @@ final class AyahMenuViewModel {
     var usesCollectionBookmarks: Bool {
         #if QURAN_SYNC
             return deps.ayahBookmarkCollectionService != nil
+        #else
+            return false
+        #endif
+    }
+
+    var isCollectionBookmarked: Bool {
+        #if QURAN_SYNC
+            return usesCollectionBookmarks && deps.isCollectionBookmarked
         #else
             return false
         #endif
@@ -176,10 +186,15 @@ final class AyahMenuViewModel {
         listener?.showTranslation(deps.verses)
     }
 
-    func saveVerse() {
+    func saveVerse() async {
         #if QURAN_SYNC
-            logger.info("AyahMenu: save verse. Verses: \(deps.verses)")
-            listener?.saveVersesAsBookmark(deps.verses)
+            if isCollectionBookmarked {
+                logger.info("AyahMenu: remove verse bookmark. Verses: \(deps.verses)")
+                await listener?.removeVersesFromBookmarkCollections(deps.verses)
+            } else {
+                logger.info("AyahMenu: save verse. Verses: \(deps.verses)")
+                listener?.saveVersesAsBookmark(deps.verses)
+            }
         #endif
     }
 

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -33,6 +33,7 @@ public protocol AyahMenuListener: AnyObject {
 
     #if QURAN_SYNC
         func addSyncedNote(verses: [AyahNumber])
+        func saveVersesAsBookmark(_ verses: [AyahNumber])
     #endif
 
     func editNote(_ note: QuranAnnotations.Note)
@@ -106,6 +107,14 @@ final class AyahMenuViewModel {
     var usesSyncedNotesIcon: Bool {
         #if QURAN_SYNC
             return deps.usesSyncedNotes
+        #else
+            return false
+        #endif
+    }
+
+    var usesCollectionBookmarks: Bool {
+        #if QURAN_SYNC
+            return deps.ayahBookmarkCollectionService != nil
         #else
             return false
         #endif
@@ -195,6 +204,13 @@ final class AyahMenuViewModel {
     func showTranslation() {
         logger.info("AyahMenu: showTranslation. Verses: \(deps.verses)")
         listener?.showTranslation(deps.verses)
+    }
+
+    func saveVerse() {
+        #if QURAN_SYNC
+            logger.info("AyahMenu: save verse. Verses: \(deps.verses)")
+            listener?.saveVersesAsBookmark(deps.verses)
+        #endif
     }
 
     func copy() {

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -31,6 +31,10 @@ public protocol AyahMenuListener: AnyObject {
     func deleteNotes(_ notes: [QuranAnnotations.Note], verses: [AyahNumber]) async
     func showTranslation(_ verses: [AyahNumber])
 
+    #if QURAN_SYNC
+        func saveVersesAsBookmark(_ verses: [AyahNumber])
+    #endif
+
     func editNote(_ note: QuranAnnotations.Note)
 }
 
@@ -95,6 +99,14 @@ final class AyahMenuViewModel {
             return l("ayah.menu.selected-verse")
         }
         return l("ayah.menu.selected-verses")
+    }
+
+    var usesCollectionBookmarks: Bool {
+        #if QURAN_SYNC
+            return deps.ayahBookmarkCollectionService != nil
+        #else
+            return false
+        #endif
     }
 
     var noteState: AyahMenuUI.NoteState {
@@ -162,6 +174,13 @@ final class AyahMenuViewModel {
     func showTranslation() {
         logger.info("AyahMenu: showTranslation. Verses: \(deps.verses)")
         listener?.showTranslation(deps.verses)
+    }
+
+    func saveVerse() {
+        #if QURAN_SYNC
+            logger.info("AyahMenu: save verse. Verses: \(deps.verses)")
+            listener?.saveVersesAsBookmark(deps.verses)
+        #endif
     }
 
     func copy() {

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -51,8 +51,8 @@ final class AyahMenuViewModel {
         let noteService: NoteService
         let textRetriever: ShareableVerseTextRetriever
         let highlightColor: HighlightColor?
-        let isCollectionBookmarked: Bool
         #if QURAN_SYNC
+            let isCollectionBookmarked: Bool
             let ayahBookmarkCollectionService: AyahBookmarkCollectionService?
         #endif
         let quranContentStatePreferences = QuranContentStatePreferences.shared

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerBuilder.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerBuilder.swift
@@ -5,6 +5,7 @@
     //  Created by Ahmed Nabil on 2026-05-09.
     //
 
+    import AnnotationsService
     import QuranKit
     import UIKit
 

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerBuilder.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerBuilder.swift
@@ -1,0 +1,45 @@
+#if QURAN_SYNC
+    //
+    //  AyahBookmarkCollectionPickerBuilder.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-09.
+    //
+
+    import QuranKit
+    import UIKit
+
+    @MainActor
+    public struct AyahBookmarkCollectionPickerBuilder {
+        // MARK: Lifecycle
+
+        public init(
+            ayahBookmarkCollectionService: AyahBookmarkCollectionService,
+            readingBookmarkService: ReadingBookmarkService
+        ) {
+            self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
+            self.readingBookmarkService = readingBookmarkService
+        }
+
+        // MARK: Public
+
+        public func build(
+            verses: [AyahNumber],
+            didSaveReadingBookmark: @escaping () -> Void,
+            didFinish: @escaping () -> Void
+        ) -> UIViewController {
+            let viewModel = AyahBookmarkCollectionPickerViewModel(
+                ayahBookmarkCollectionService: ayahBookmarkCollectionService,
+                readingBookmarkService: readingBookmarkService,
+                verses: verses,
+                didSaveReadingBookmark: didSaveReadingBookmark,
+                didFinish: didFinish
+            )
+            return AyahBookmarkCollectionPickerViewController(viewModel: viewModel)
+        }
+
+        // MARK: Private
+
+        private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
+        private let readingBookmarkService: ReadingBookmarkService
+    }
+#endif

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerBuilder.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerBuilder.swift
@@ -24,14 +24,14 @@
 
         public func build(
             verses: [AyahNumber],
-            didSaveReadingBookmark: @escaping () -> Void,
+            didUpdateReadingBookmark: @escaping (QuranReadingBookmark?) -> Void,
             didFinish: @escaping () -> Void
         ) -> UIViewController {
             let viewModel = AyahBookmarkCollectionPickerViewModel(
                 ayahBookmarkCollectionService: ayahBookmarkCollectionService,
                 readingBookmarkService: readingBookmarkService,
                 verses: verses,
-                didSaveReadingBookmark: didSaveReadingBookmark,
+                didUpdateReadingBookmark: didUpdateReadingBookmark,
                 didFinish: didFinish
             )
             return AyahBookmarkCollectionPickerViewController(viewModel: viewModel)

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerView.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerView.swift
@@ -1,0 +1,78 @@
+#if QURAN_SYNC
+    //
+    //  AyahBookmarkCollectionPickerView.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-09.
+    //
+
+    import Localization
+    import NoorUI
+    import QuranAnnotations
+    import SwiftUI
+    import UIx
+
+    @MainActor
+    struct AyahBookmarkCollectionPickerView: View {
+        // MARK: Lifecycle
+
+        init(viewModel: AyahBookmarkCollectionPickerViewModel, addCollection: @escaping AsyncAction) {
+            _viewModel = StateObject(wrappedValue: viewModel)
+            self.addCollection = addCollection
+        }
+
+        // MARK: Internal
+
+        @StateObject var viewModel: AyahBookmarkCollectionPickerViewModel
+        let addCollection: AsyncAction
+
+        var body: some View {
+            NoorList {
+                Section {
+                    NoorListItem(
+                        image: .init(.bookmark, color: .red),
+                        title: .text(l("ayah-bookmark.save-reading-bookmark")),
+                        action: { await viewModel.saveReadingBookmark() }
+                    )
+                }
+
+                Section(header: Text(l("ayah-bookmark.save-to-collection"))) {
+                    if viewModel.collections.isEmpty {
+                        emptyCollectionsItem
+                    } else {
+                        ForEach(viewModel.collections) { collection in
+                            collectionItem(collection)
+                        }
+                    }
+
+                    NoorListItem(
+                        image: .init(.folder),
+                        title: .text(l("bookmarks.collections.add")),
+                        action: addCollection
+                    )
+                }
+            }
+            .task { await viewModel.start() }
+            .errorAlert(error: $viewModel.error)
+        }
+
+        // MARK: Private
+
+        private var emptyCollectionsItem: some View {
+            NoorListItem(
+                image: .init(.folder),
+                title: .text(l("ayah-bookmark.collection-picker.no-data.title")),
+                subtitle: .init(text: l("ayah-bookmark.collection-picker.no-data.text"), location: .bottom)
+            )
+        }
+
+        private func collectionItem(_ collection: AyahBookmarkCollection) -> some View {
+            let highlightColor = HighlightColor(collectionName: collection.collection.name)
+            return NoorListItem(
+                image: .init(.folder, color: highlightColor?.color),
+                title: .text(highlightColor?.localizedName ?? collection.collection.name),
+                accessory: .image(viewModel.isSelected(collection) ? .checkmark_checked : .checkmark_unchecked),
+                action: { viewModel.toggleSelection(for: collection) }
+            )
+        }
+    }
+#endif

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerView.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerView.swift
@@ -15,40 +15,36 @@
     struct AyahBookmarkCollectionPickerView: View {
         // MARK: Lifecycle
 
-        init(viewModel: AyahBookmarkCollectionPickerViewModel, addCollection: @escaping AsyncAction) {
+        init(viewModel: AyahBookmarkCollectionPickerViewModel) {
             _viewModel = StateObject(wrappedValue: viewModel)
-            self.addCollection = addCollection
         }
 
         // MARK: Internal
 
         @StateObject var viewModel: AyahBookmarkCollectionPickerViewModel
-        let addCollection: AsyncAction
 
         var body: some View {
             NoorList {
                 Section {
-                    NoorListItem(
-                        image: .init(.bookmark, color: .red),
-                        title: .text(l("ayah-bookmark.save-reading-bookmark")),
-                        action: { await viewModel.saveReadingBookmark() }
-                    )
+                    readingBookmarkItem
                 }
 
-                Section(header: Text(l("ayah-bookmark.save-to-collection"))) {
-                    if viewModel.collections.isEmpty {
-                        emptyCollectionsItem
-                    } else {
-                        ForEach(viewModel.collections) { collection in
+                if !viewModel.highlightCollections.isEmpty {
+                    Section(header: Text(l("ayah-bookmark.save-to-highlight"))) {
+                        ForEach(viewModel.highlightCollections) { collection in
                             collectionItem(collection)
                         }
                     }
+                }
 
-                    NoorListItem(
-                        image: .init(.folder),
-                        title: .text(l("bookmarks.collections.add")),
-                        action: addCollection
-                    )
+                Section(header: Text(l("ayah-bookmark.save-to-collection"))) {
+                    if viewModel.bookmarkCollections.isEmpty {
+                        emptyCollectionsItem
+                    } else {
+                        ForEach(viewModel.bookmarkCollections) { collection in
+                            collectionItem(collection)
+                        }
+                    }
                 }
             }
             .task { await viewModel.start() }
@@ -56,6 +52,21 @@
         }
 
         // MARK: Private
+
+        private var readingBookmarkItem: some View {
+            NoorListItem(
+                image: .init(
+                    viewModel.isSelectedVerseReadingBookmark ? .bookmark : .bookmarkOutline,
+                    color: viewModel.isSelectedVerseReadingBookmark ? .red : nil
+                ),
+                title: .text(
+                    viewModel.isSelectedVerseReadingBookmark
+                        ? l("ayah-bookmark.remove-reading-bookmark")
+                        : l("ayah-bookmark.save-reading-bookmark")
+                ),
+                action: { await viewModel.toggleReadingBookmark() }
+            )
+        }
 
         private var emptyCollectionsItem: some View {
             NoorListItem(
@@ -66,7 +77,7 @@
         }
 
         private func collectionItem(_ collection: AyahBookmarkCollection) -> some View {
-            let highlightColor = HighlightColor(collectionName: collection.collection.name)
+            let highlightColor = AyahBookmarkCollectionPickerViewModel.highlightColor(for: collection)
             return NoorListItem(
                 image: .init(.folder, color: highlightColor?.color),
                 title: .text(highlightColor?.localizedName ?? collection.collection.name),

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewController.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewController.swift
@@ -15,11 +15,15 @@
 
         init(viewModel: AyahBookmarkCollectionPickerViewModel) {
             self.viewModel = viewModel
-            super.init(rootView: AyahBookmarkCollectionPickerView(viewModel: viewModel, addCollection: {}))
-            rootView = AyahBookmarkCollectionPickerView(viewModel: viewModel, addCollection: { [weak self] in
-                self?.addCollection()
-            })
+            super.init(rootView: AyahBookmarkCollectionPickerView(viewModel: viewModel))
             title = l("ayah-bookmark.save-verse")
+            navigationItem.leftBarButtonItem = UIBarButtonItem(
+                image: UIImage(systemName: "plus"),
+                primaryAction: UIAction { [weak self] _ in
+                    self?.addCollection()
+                }
+            )
+            navigationItem.leftBarButtonItem?.accessibilityLabel = l("bookmarks.collections.add")
             navigationItem.rightBarButtonItem = UIBarButtonItem(
                 title: l("button.done"),
                 primaryAction: UIAction { [weak self] _ in

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewController.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewController.swift
@@ -1,0 +1,66 @@
+#if QURAN_SYNC
+    //
+    //  AyahBookmarkCollectionPickerViewController.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-09.
+    //
+
+    import Localization
+    import NoorUI
+    import SwiftUI
+    import UIKit
+
+    final class AyahBookmarkCollectionPickerViewController: UIHostingController<AyahBookmarkCollectionPickerView> {
+        // MARK: Lifecycle
+
+        init(viewModel: AyahBookmarkCollectionPickerViewModel) {
+            self.viewModel = viewModel
+            super.init(rootView: AyahBookmarkCollectionPickerView(viewModel: viewModel, addCollection: {}))
+            rootView = AyahBookmarkCollectionPickerView(viewModel: viewModel, addCollection: { [weak self] in
+                self?.addCollection()
+            })
+            title = l("ayah-bookmark.save-verse")
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                title: l("button.done"),
+                primaryAction: UIAction { [weak self] _ in
+                    Task {
+                        await self?.viewModel.saveSelectedCollections()
+                    }
+                }
+            )
+        }
+
+        @available(*, unavailable)
+        @MainActor
+        dynamic required init?(coder aDecoder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        // MARK: Private
+
+        private let viewModel: AyahBookmarkCollectionPickerViewModel
+
+        private func addCollection() {
+            let alert = UIAlertController(
+                title: l("bookmarks.collections.add"),
+                message: nil,
+                preferredStyle: .alert
+            )
+            alert.addTextField { textField in
+                textField.placeholder = l("bookmarks.collections.new.placeholder")
+            }
+            alert.addAction(UIAlertAction(title: lAndroid("cancel"), style: .cancel))
+            alert.addAction(UIAlertAction(title: l("bookmarks.collections.add"), style: .default) { [weak self, weak alert] _ in
+                guard let name = alert?.textFields?.first?.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !name.isEmpty
+                else {
+                    return
+                }
+                Task {
+                    await self?.viewModel.createCollection(name: name)
+                }
+            })
+            present(alert, animated: true)
+        }
+    }
+#endif

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
@@ -6,6 +6,7 @@
     //
 
     import Foundation
+    import QuranAnnotations
     import QuranKit
     import VLogging
 
@@ -17,13 +18,13 @@
             ayahBookmarkCollectionService: AyahBookmarkCollectionService,
             readingBookmarkService: ReadingBookmarkService,
             verses: [AyahNumber],
-            didSaveReadingBookmark: @escaping () -> Void,
+            didUpdateReadingBookmark: @escaping (QuranReadingBookmark?) -> Void,
             didFinish: @escaping () -> Void
         ) {
             self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
             self.readingBookmarkService = readingBookmarkService
             self.verses = verses
-            self.didSaveReadingBookmark = didSaveReadingBookmark
+            self.didUpdateReadingBookmark = didUpdateReadingBookmark
             self.didFinish = didFinish
         }
 
@@ -31,10 +32,27 @@
 
         @Published var collections: [AyahBookmarkCollection] = []
         @Published var selectedCollectionIDs: Set<String> = []
+        @Published var selectedHighlightCollectionID: String?
+        @Published var readingBookmark: QuranReadingBookmark?
         @Published var error: Error?
 
         var hasSelectedCollections: Bool {
-            !selectedCollectionIDs.isEmpty
+            !selectedCollectionIDs.isEmpty || selectedHighlightCollectionID != nil
+        }
+
+        var bookmarkCollections: [AyahBookmarkCollection] {
+            collections.filter { Self.highlightColor(for: $0) == nil }
+        }
+
+        var highlightCollections: [AyahBookmarkCollection] {
+            collections.filter { Self.highlightColor(for: $0) != nil }
+        }
+
+        var isSelectedVerseReadingBookmark: Bool {
+            guard let firstVerse = verses.first else {
+                return false
+            }
+            return readingBookmark?.isAyahBookmark(for: firstVerse) == true
         }
 
         nonisolated static func sorted(_ collections: [AyahBookmarkCollection]) -> [AyahBookmarkCollection] {
@@ -46,20 +64,21 @@
             return verses.filter { !existingAyahs.contains(AyahKey($0)) }
         }
 
+        nonisolated static func highlightColor(for collection: AyahBookmarkCollection) -> HighlightColor? {
+            HighlightColor(collectionName: collection.collection.name)
+        }
+
         func start() async {
-            do {
-                let sequence = ayahBookmarkCollectionService.collectionsSequence()
-                for try await collections in sequence {
-                    self.collections = Self.sorted(collections)
-                }
-            } catch {
-                self.error = error
-            }
+            async let collections: () = loadCollections()
+            async let readingBookmark: () = loadReadingBookmark()
+            _ = await [collections, readingBookmark]
         }
 
         func toggleSelection(for collection: AyahBookmarkCollection) {
             let id = collection.collection.localId
-            if selectedCollectionIDs.contains(id) {
+            if Self.highlightColor(for: collection) != nil {
+                selectedHighlightCollectionID = selectedHighlightCollectionID == id ? nil : id
+            } else if selectedCollectionIDs.contains(id) {
                 selectedCollectionIDs.remove(id)
             } else {
                 selectedCollectionIDs.insert(id)
@@ -67,7 +86,11 @@
         }
 
         func isSelected(_ collection: AyahBookmarkCollection) -> Bool {
-            selectedCollectionIDs.contains(collection.collection.localId)
+            let id = collection.collection.localId
+            if Self.highlightColor(for: collection) != nil {
+                return selectedHighlightCollectionID == id
+            }
+            return selectedCollectionIDs.contains(id)
         }
 
         func createCollection(name: String) async {
@@ -80,7 +103,8 @@
 
         func saveSelectedCollections() async {
             do {
-                for collection in collections where selectedCollectionIDs.contains(collection.collection.localId) {
+                try await saveSelectedHighlight()
+                for collection in bookmarkCollections where selectedCollectionIDs.contains(collection.collection.localId) {
                     for verse in Self.bookmarksToAdd(to: collection, verses: verses) {
                         try await ayahBookmarkCollectionService.addAyahBookmarkToCollection(
                             collectionLocalId: collection.collection.localId,
@@ -94,14 +118,21 @@
             }
         }
 
-        func saveReadingBookmark() async {
+        func toggleReadingBookmark() async {
             guard let firstVerse = verses.first else {
                 return
             }
 
             do {
-                try await readingBookmarkService.addReadingBookmark(ayah: firstVerse)
-                didSaveReadingBookmark()
+                if isSelectedVerseReadingBookmark {
+                    try await readingBookmarkService.removeReadingBookmark()
+                    readingBookmark = nil
+                    didUpdateReadingBookmark(nil)
+                } else {
+                    let bookmark = try await readingBookmarkService.addReadingBookmark(ayah: firstVerse)
+                    readingBookmark = bookmark
+                    didUpdateReadingBookmark(bookmark)
+                }
                 didFinish()
             } catch {
                 self.error = error
@@ -113,8 +144,57 @@
         private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
         private let readingBookmarkService: ReadingBookmarkService
         private let verses: [AyahNumber]
-        private let didSaveReadingBookmark: () -> Void
+        private let didUpdateReadingBookmark: (QuranReadingBookmark?) -> Void
         private let didFinish: () -> Void
+
+        private func loadCollections() async {
+            do {
+                let sequence = ayahBookmarkCollectionService.collectionsSequence()
+                for try await collections in sequence {
+                    self.collections = Self.sorted(collections)
+                }
+            } catch {
+                self.error = error
+            }
+        }
+
+        private func loadReadingBookmark() async {
+            do {
+                let sequence = readingBookmarkService.readingBookmarkSequence()
+                for try await bookmark in sequence {
+                    readingBookmark = bookmark
+                }
+            } catch {
+                self.error = error
+            }
+        }
+
+        private func saveSelectedHighlight() async throws {
+            guard let selectedHighlightCollectionID else {
+                return
+            }
+
+            let selectedAyahs = Set(verses.map(AyahKey.init))
+            var targetAyahs = Set<AyahKey>()
+
+            for collection in highlightCollections {
+                let isTarget = collection.collection.localId == selectedHighlightCollectionID
+                for bookmark in collection.bookmarks where selectedAyahs.contains(AyahKey(bookmark.ayah)) {
+                    if isTarget {
+                        targetAyahs.insert(AyahKey(bookmark.ayah))
+                    } else {
+                        try await ayahBookmarkCollectionService.removeBookmarkFromCollection(bookmark)
+                    }
+                }
+            }
+
+            for verse in verses where !targetAyahs.contains(AyahKey(verse)) {
+                try await ayahBookmarkCollectionService.addAyahBookmarkToCollection(
+                    collectionLocalId: selectedHighlightCollectionID,
+                    ayah: verse
+                )
+            }
+        }
     }
 
     private struct AyahKey: Hashable {

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
@@ -1,0 +1,129 @@
+#if QURAN_SYNC
+    //
+    //  AyahBookmarkCollectionPickerViewModel.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-09.
+    //
+
+    import Foundation
+    import QuranKit
+    import VLogging
+
+    @MainActor
+    final class AyahBookmarkCollectionPickerViewModel: ObservableObject {
+        // MARK: Lifecycle
+
+        init(
+            ayahBookmarkCollectionService: AyahBookmarkCollectionService,
+            readingBookmarkService: ReadingBookmarkService,
+            verses: [AyahNumber],
+            didSaveReadingBookmark: @escaping () -> Void,
+            didFinish: @escaping () -> Void
+        ) {
+            self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
+            self.readingBookmarkService = readingBookmarkService
+            self.verses = verses
+            self.didSaveReadingBookmark = didSaveReadingBookmark
+            self.didFinish = didFinish
+        }
+
+        // MARK: Internal
+
+        @Published var collections: [AyahBookmarkCollection] = []
+        @Published var selectedCollectionIDs: Set<String> = []
+        @Published var error: Error?
+
+        var hasSelectedCollections: Bool {
+            !selectedCollectionIDs.isEmpty
+        }
+
+        nonisolated static func sorted(_ collections: [AyahBookmarkCollection]) -> [AyahBookmarkCollection] {
+            AyahBookmarkCollectionsViewModel.sorted(collections)
+        }
+
+        nonisolated static func bookmarksToAdd(to collection: AyahBookmarkCollection, verses: [AyahNumber]) -> [AyahNumber] {
+            let existingAyahs = Set(collection.bookmarks.map { AyahKey($0.ayah) })
+            return verses.filter { !existingAyahs.contains(AyahKey($0)) }
+        }
+
+        func start() async {
+            do {
+                let sequence = ayahBookmarkCollectionService.collectionsSequence()
+                for try await collections in sequence {
+                    self.collections = Self.sorted(collections)
+                }
+            } catch {
+                self.error = error
+            }
+        }
+
+        func toggleSelection(for collection: AyahBookmarkCollection) {
+            let id = collection.collection.localId
+            if selectedCollectionIDs.contains(id) {
+                selectedCollectionIDs.remove(id)
+            } else {
+                selectedCollectionIDs.insert(id)
+            }
+        }
+
+        func isSelected(_ collection: AyahBookmarkCollection) -> Bool {
+            selectedCollectionIDs.contains(collection.collection.localId)
+        }
+
+        func createCollection(name: String) async {
+            do {
+                try await ayahBookmarkCollectionService.createCollection(named: name)
+            } catch {
+                self.error = error
+            }
+        }
+
+        func saveSelectedCollections() async {
+            do {
+                for collection in collections where selectedCollectionIDs.contains(collection.collection.localId) {
+                    for verse in Self.bookmarksToAdd(to: collection, verses: verses) {
+                        try await ayahBookmarkCollectionService.addAyahBookmarkToCollection(
+                            collectionLocalId: collection.collection.localId,
+                            ayah: verse
+                        )
+                    }
+                }
+                didFinish()
+            } catch {
+                self.error = error
+            }
+        }
+
+        func saveReadingBookmark() async {
+            guard let firstVerse = verses.first else {
+                return
+            }
+
+            do {
+                try await readingBookmarkService.addReadingBookmark(ayah: firstVerse)
+                didSaveReadingBookmark()
+                didFinish()
+            } catch {
+                self.error = error
+            }
+        }
+
+        // MARK: Private
+
+        private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
+        private let readingBookmarkService: ReadingBookmarkService
+        private let verses: [AyahNumber]
+        private let didSaveReadingBookmark: () -> Void
+        private let didFinish: () -> Void
+    }
+
+    private struct AyahKey: Hashable {
+        init(_ ayahNumber: AyahNumber) {
+            sura = Int32(ayahNumber.sura.suraNumber)
+            ayah = Int32(ayahNumber.ayah)
+        }
+
+        let sura: Int32
+        let ayah: Int32
+    }
+#endif

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
@@ -82,6 +82,7 @@
 
         func toggleSelection(for collection: AyahBookmarkCollection) {
             let id = collection.collection.localId
+            didUpdateSelection = true
             if Self.highlightColor(for: collection) != nil {
                 selectedHighlightCollectionID = selectedHighlightCollectionID == id ? nil : id
             } else if selectedCollectionIDs.contains(id) {
@@ -146,7 +147,7 @@
         private let didUpdateReadingBookmark: (QuranReadingBookmark?) -> Void
         private let didFinish: () -> Void
         private var didEnsureHighlightCollections = false
-        private var didSelectExistingBookmarks = false
+        private var didUpdateSelection = false
 
         private func loadCollections() async {
             do {
@@ -170,10 +171,9 @@
         }
 
         private func selectExistingBookmarksIfNeeded(in collections: [AyahBookmarkCollection]) {
-            guard !didSelectExistingBookmarks else {
+            guard !didUpdateSelection else {
                 return
             }
-            didSelectExistingBookmarks = true
 
             for collection in collections where Self.containsAnyBookmark(in: collection, verses: verses) {
                 if Self.highlightColor(for: collection) != nil {

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
@@ -133,7 +133,6 @@
                     readingBookmark = bookmark
                     didUpdateReadingBookmark(bookmark)
                 }
-                didFinish()
             } catch {
                 self.error = error
             }

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
@@ -5,6 +5,7 @@
     //  Created by Ahmed Nabil on 2026-05-09.
     //
 
+    import AnnotationsService
     import Foundation
     import QuranAnnotations
     import QuranKit
@@ -64,6 +65,15 @@
             return verses.filter { !existingAyahs.contains(AyahKey($0)) }
         }
 
+        nonisolated static func bookmarksToRemove(from collection: AyahBookmarkCollection, verses: [AyahNumber]) -> [AyahCollectionBookmark] {
+            let selectedAyahs = Set(verses.map(AyahKey.init))
+            return collection.bookmarks.filter { selectedAyahs.contains(AyahKey($0.ayah)) }
+        }
+
+        nonisolated static func containsAnyBookmark(in collection: AyahBookmarkCollection, verses: [AyahNumber]) -> Bool {
+            !bookmarksToRemove(from: collection, verses: verses).isEmpty
+        }
+
         nonisolated static func highlightColor(for collection: AyahBookmarkCollection) -> HighlightColor? {
             HighlightColor(collectionName: collection.collection.name)
         }
@@ -104,14 +114,7 @@
         func saveSelectedCollections() async {
             do {
                 try await saveSelectedHighlight()
-                for collection in bookmarkCollections where selectedCollectionIDs.contains(collection.collection.localId) {
-                    for verse in Self.bookmarksToAdd(to: collection, verses: verses) {
-                        try await ayahBookmarkCollectionService.addAyahBookmarkToCollection(
-                            collectionLocalId: collection.collection.localId,
-                            ayah: verse
-                        )
-                    }
-                }
+                try await saveSelectedBookmarkCollections()
                 didFinish()
             } catch {
                 self.error = error
@@ -147,12 +150,14 @@
         private let didUpdateReadingBookmark: (QuranReadingBookmark?) -> Void
         private let didFinish: () -> Void
         private var didEnsureHighlightCollections = false
+        private var didSelectExistingBookmarks = false
 
         private func loadCollections() async {
             do {
                 let sequence = ayahBookmarkCollectionService.collectionsSequence()
                 for try await collections in sequence {
                     self.collections = Self.sorted(collections)
+                    selectExistingBookmarksIfNeeded(in: self.collections)
                     try await ensureHighlightCollections(collections)
                 }
             } catch {
@@ -168,6 +173,21 @@
             try await HighlightBookmarkCollections.ensure(in: collections, using: ayahBookmarkCollectionService)
         }
 
+        private func selectExistingBookmarksIfNeeded(in collections: [AyahBookmarkCollection]) {
+            guard !didSelectExistingBookmarks else {
+                return
+            }
+            didSelectExistingBookmarks = true
+
+            for collection in collections where Self.containsAnyBookmark(in: collection, verses: verses) {
+                if Self.highlightColor(for: collection) != nil {
+                    selectedHighlightCollectionID = collection.collection.localId
+                } else {
+                    selectedCollectionIDs.insert(collection.collection.localId)
+                }
+            }
+        }
+
         private func loadReadingBookmark() async {
             do {
                 let sequence = readingBookmarkService.readingBookmarkSequence()
@@ -180,10 +200,6 @@
         }
 
         private func saveSelectedHighlight() async throws {
-            guard let selectedHighlightCollectionID else {
-                return
-            }
-
             let selectedAyahs = Set(verses.map(AyahKey.init))
             var targetAyahs = Set<AyahKey>()
 
@@ -198,11 +214,32 @@
                 }
             }
 
+            guard let selectedHighlightCollectionID else {
+                return
+            }
+
             for verse in verses where !targetAyahs.contains(AyahKey(verse)) {
                 try await ayahBookmarkCollectionService.addAyahBookmarkToCollection(
                     collectionLocalId: selectedHighlightCollectionID,
                     ayah: verse
                 )
+            }
+        }
+
+        private func saveSelectedBookmarkCollections() async throws {
+            for collection in bookmarkCollections {
+                if selectedCollectionIDs.contains(collection.collection.localId) {
+                    for verse in Self.bookmarksToAdd(to: collection, verses: verses) {
+                        try await ayahBookmarkCollectionService.addAyahBookmarkToCollection(
+                            collectionLocalId: collection.collection.localId,
+                            ayah: verse
+                        )
+                    }
+                } else {
+                    for bookmark in Self.bookmarksToRemove(from: collection, verses: verses) {
+                        try await ayahBookmarkCollectionService.removeBookmarkFromCollection(bookmark)
+                    }
+                }
             }
         }
     }

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
@@ -37,10 +37,6 @@
         @Published var readingBookmark: QuranReadingBookmark?
         @Published var error: Error?
 
-        var hasSelectedCollections: Bool {
-            !selectedCollectionIDs.isEmpty || selectedHighlightCollectionID != nil
-        }
-
         var bookmarkCollections: [AyahBookmarkCollection] {
             collections.filter { Self.highlightColor(for: $0) == nil }
         }
@@ -53,7 +49,7 @@
             guard let firstVerse = verses.first else {
                 return false
             }
-            return readingBookmark?.isReadingBookmark(for: firstVerse) == true
+            return readingBookmark?.isAyahBookmark(for: firstVerse) == true
         }
 
         nonisolated static func sorted(_ collections: [AyahBookmarkCollection]) -> [AyahBookmarkCollection] {

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionPickerViewModel.swift
@@ -52,7 +52,7 @@
             guard let firstVerse = verses.first else {
                 return false
             }
-            return readingBookmark?.isAyahBookmark(for: firstVerse) == true
+            return readingBookmark?.isReadingBookmark(for: firstVerse) == true
         }
 
         nonisolated static func sorted(_ collections: [AyahBookmarkCollection]) -> [AyahBookmarkCollection] {
@@ -146,16 +146,26 @@
         private let verses: [AyahNumber]
         private let didUpdateReadingBookmark: (QuranReadingBookmark?) -> Void
         private let didFinish: () -> Void
+        private var didEnsureHighlightCollections = false
 
         private func loadCollections() async {
             do {
                 let sequence = ayahBookmarkCollectionService.collectionsSequence()
                 for try await collections in sequence {
                     self.collections = Self.sorted(collections)
+                    try await ensureHighlightCollections(collections)
                 }
             } catch {
                 self.error = error
             }
+        }
+
+        private func ensureHighlightCollections(_ collections: [AyahBookmarkCollection]) async throws {
+            guard !didEnsureHighlightCollections else {
+                return
+            }
+            didEnsureHighlightCollections = true
+            try await HighlightBookmarkCollections.ensure(in: collections, using: ayahBookmarkCollectionService)
         }
 
         private func loadReadingBookmark() async {

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionPickerViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionPickerViewModelTests.swift
@@ -32,5 +32,61 @@
                 [newAyah]
             )
         }
+
+        func test_bookmarksToRemove_returnsExistingBookmarks() {
+            let existingAyah = AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
+            let newAyah = AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 2)!
+            let collection = AyahBookmarkCollection(
+                collection: Collection_(name: "Favorites", lastUpdated: .distantPast, localId: "favorites"),
+                bookmarks: [
+                    AyahCollectionBookmark(
+                        bookmark: CollectionAyahBookmark(
+                            collectionLocalId: "favorites",
+                            collectionRemoteId: nil,
+                            bookmarkLocalId: "bookmark-1",
+                            bookmarkRemoteId: nil,
+                            sura: 1,
+                            ayah: 1,
+                            lastUpdated: .distantPast,
+                            localId: "collection-bookmark-1"
+                        ),
+                        ayah: existingAyah
+                    ),
+                ]
+            )
+
+            let bookmarks = AyahBookmarkCollectionPickerViewModel.bookmarksToRemove(
+                from: collection,
+                verses: [existingAyah, newAyah]
+            )
+
+            XCTAssertEqual(bookmarks.map(\.bookmark.localId), ["collection-bookmark-1"])
+        }
+
+        func test_containsAnyBookmark_detectsExistingBookmark() {
+            let existingAyah = AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
+            let newAyah = AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 2)!
+            let collection = AyahBookmarkCollection(
+                collection: Collection_(name: "Favorites", lastUpdated: .distantPast, localId: "favorites"),
+                bookmarks: [
+                    AyahCollectionBookmark(
+                        bookmark: CollectionAyahBookmark(
+                            collectionLocalId: "favorites",
+                            collectionRemoteId: nil,
+                            bookmarkLocalId: "bookmark-1",
+                            bookmarkRemoteId: nil,
+                            sura: 1,
+                            ayah: 1,
+                            lastUpdated: .distantPast,
+                            localId: "collection-bookmark-1"
+                        ),
+                        ayah: existingAyah
+                    ),
+                ]
+            )
+
+            XCTAssertTrue(AyahBookmarkCollectionPickerViewModel.containsAnyBookmark(in: collection, verses: [existingAyah, newAyah]))
+            XCTAssertFalse(AyahBookmarkCollectionPickerViewModel.containsAnyBookmark(in: collection, verses: [newAyah]))
+        }
     }
 #endif

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionPickerViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionPickerViewModelTests.swift
@@ -1,0 +1,36 @@
+#if QURAN_SYNC
+    import MobileSync
+    import QuranKit
+    import XCTest
+    @testable import BookmarksFeature
+
+    final class AyahBookmarkCollectionPickerViewModelTests: XCTestCase {
+        func test_bookmarksToAdd_skipsExistingBookmarks() {
+            let existingAyah = AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
+            let newAyah = AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 2)!
+            let collection = AyahBookmarkCollection(
+                collection: Collection_(name: "Favorites", lastUpdated: .distantPast, localId: "favorites"),
+                bookmarks: [
+                    AyahCollectionBookmark(
+                        bookmark: CollectionAyahBookmark(
+                            collectionLocalId: "favorites",
+                            collectionRemoteId: nil,
+                            bookmarkLocalId: "bookmark-1",
+                            bookmarkRemoteId: nil,
+                            sura: 1,
+                            ayah: 1,
+                            lastUpdated: .distantPast,
+                            localId: "collection-bookmark-1"
+                        ),
+                        ayah: existingAyah
+                    ),
+                ]
+            )
+
+            XCTAssertEqual(
+                AyahBookmarkCollectionPickerViewModel.bookmarksToAdd(to: collection, verses: [existingAyah, newAyah]),
+                [newAyah]
+            )
+        }
+    }
+#endif

--- a/Features/QuranViewFeature/QuranBuilder.swift
+++ b/Features/QuranViewFeature/QuranBuilder.swift
@@ -36,11 +36,22 @@ public struct QuranBuilder {
         let quran = ReadingPreferences.shared.reading.quran
         let pageBookmarkService = PageBookmarkService(persistence: container.pageBookmarkPersistence)
         #if QURAN_SYNC
-            let syncedHighlightsObserver = container.syncService.map {
-                QuranSyncedHighlightsObserver(ayahBookmarkCollectionService: AyahBookmarkCollectionService(syncService: $0), highlightsService: highlightsService)
+            let ayahBookmarkCollectionService = container.syncService.map {
+                AyahBookmarkCollectionService(syncService: $0)
+            }
+            let syncedHighlightsObserver = ayahBookmarkCollectionService.map {
+                QuranSyncedHighlightsObserver(ayahBookmarkCollectionService: $0, highlightsService: highlightsService)
             }
             let readingBookmarkService = container.syncService.map {
                 ReadingBookmarkService(syncService: $0)
+            }
+            let ayahBookmarkCollectionPickerBuilder: AyahBookmarkCollectionPickerBuilder? = if let ayahBookmarkCollectionService, let readingBookmarkService {
+                AyahBookmarkCollectionPickerBuilder(
+                    ayahBookmarkCollectionService: ayahBookmarkCollectionService,
+                    readingBookmarkService: readingBookmarkService
+                )
+            } else {
+                nil
             }
         #endif
         #if QURAN_SYNC
@@ -60,7 +71,8 @@ public struct QuranBuilder {
                 translationVerseBuilder: TranslationVerseBuilder(container: container),
                 resources: container.readingResources,
                 syncedHighlightsObserver: syncedHighlightsObserver,
-                readingBookmarkService: readingBookmarkService
+                readingBookmarkService: readingBookmarkService,
+                ayahBookmarkCollectionPickerBuilder: ayahBookmarkCollectionPickerBuilder
             )
         #else
             let interactorDeps = QuranInteractor.Deps(

--- a/Features/QuranViewFeature/QuranBuilder.swift
+++ b/Features/QuranViewFeature/QuranBuilder.swift
@@ -83,6 +83,7 @@ public struct QuranBuilder {
                 syncedNoteEditorBuilder: syncedNoteEditorBuilder,
                 syncedHighlightsObserver: syncedHighlightsObserver,
                 readingBookmarkService: readingBookmarkService,
+                ayahBookmarkCollectionService: ayahBookmarkCollectionService,
                 ayahBookmarkCollectionPickerBuilder: ayahBookmarkCollectionPickerBuilder
             )
         #else

--- a/Features/QuranViewFeature/QuranBuilder.swift
+++ b/Features/QuranViewFeature/QuranBuilder.swift
@@ -10,6 +10,9 @@ import AnnotationsService
 import AppDependencies
 import AudioBannerFeature
 import AyahMenuFeature
+#if QURAN_SYNC
+    import BookmarksFeature
+#endif
 import MoreMenuFeature
 import NoteEditorFeature
 import QuranContentFeature

--- a/Features/QuranViewFeature/QuranBuilder.swift
+++ b/Features/QuranViewFeature/QuranBuilder.swift
@@ -44,11 +44,22 @@ public struct QuranBuilder {
                     analytics: container.analytics
                 )
             }
-            let syncedHighlightsObserver = container.syncService.map {
-                QuranSyncedHighlightsObserver(ayahBookmarkCollectionService: AyahBookmarkCollectionService(syncService: $0), highlightsService: highlightsService)
+            let ayahBookmarkCollectionService = container.syncService.map {
+                AyahBookmarkCollectionService(syncService: $0)
+            }
+            let syncedHighlightsObserver = ayahBookmarkCollectionService.map {
+                QuranSyncedHighlightsObserver(ayahBookmarkCollectionService: $0, highlightsService: highlightsService)
             }
             let readingBookmarkService = container.syncService.map {
                 ReadingBookmarkService(syncService: $0)
+            }
+            let ayahBookmarkCollectionPickerBuilder: AyahBookmarkCollectionPickerBuilder? = if let ayahBookmarkCollectionService, let readingBookmarkService {
+                AyahBookmarkCollectionPickerBuilder(
+                    ayahBookmarkCollectionService: ayahBookmarkCollectionService,
+                    readingBookmarkService: readingBookmarkService
+                )
+            } else {
+                nil
             }
             let interactorDeps = QuranInteractor.Deps(
                 quran: quran,
@@ -68,7 +79,8 @@ public struct QuranBuilder {
                 syncedNoteService: syncedNoteService,
                 syncedNoteEditorBuilder: syncedNoteEditorBuilder,
                 syncedHighlightsObserver: syncedHighlightsObserver,
-                readingBookmarkService: readingBookmarkService
+                readingBookmarkService: readingBookmarkService,
+                ayahBookmarkCollectionPickerBuilder: ayahBookmarkCollectionPickerBuilder
             )
         #else
             let interactorDeps = QuranInteractor.Deps(

--- a/Features/QuranViewFeature/QuranBuilder.swift
+++ b/Features/QuranViewFeature/QuranBuilder.swift
@@ -75,6 +75,7 @@ public struct QuranBuilder {
                 resources: container.readingResources,
                 syncedHighlightsObserver: syncedHighlightsObserver,
                 readingBookmarkService: readingBookmarkService,
+                ayahBookmarkCollectionService: ayahBookmarkCollectionService,
                 ayahBookmarkCollectionPickerBuilder: ayahBookmarkCollectionPickerBuilder
             )
         #else

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -56,6 +56,7 @@ protocol QuranPresentable: UIViewController {
     #if QURAN_SYNC
         func showReadingBookmarkNudge(expanded: Bool, undo: @escaping () async -> Void)
         func hideReadingBookmarkNudge()
+        func presentAyahBookmarkCollectionPicker(_ viewController: UIViewController)
     #endif
 }
 
@@ -83,6 +84,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             let syncedNoteEditorBuilder: SyncedNoteEditorBuilder?
             let syncedHighlightsObserver: QuranSyncedHighlightsObserver?
             let readingBookmarkService: ReadingBookmarkService?
+            let ayahBookmarkCollectionPickerBuilder: AyahBookmarkCollectionPickerBuilder?
         #endif
     }
 
@@ -255,6 +257,32 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         logger.info("Quran: dismiss note editor")
         presenter?.dismiss(animated: true)
     }
+
+    #if QURAN_SYNC
+        func saveVersesAsBookmark(_ verses: [AyahNumber]) {
+            guard let ayahBookmarkCollectionPickerBuilder = deps.ayahBookmarkCollectionPickerBuilder else {
+                return
+            }
+
+            contentViewModel?.removeAyahMenuHighlight()
+            presenter?.dismissPresentedViewController { [weak self] in
+                guard let self else { return }
+                let viewController = ayahBookmarkCollectionPickerBuilder.build(
+                    verses: verses,
+                    didSaveReadingBookmark: { [weak self] in
+                        guard let self, let readingBookmarkService = deps.readingBookmarkService else {
+                            return
+                        }
+                        showReadingBookmarkNudge(using: readingBookmarkService)
+                    },
+                    didFinish: { [weak self] in
+                        self?.presenter?.dismissPresentedViewController(completion: nil)
+                    }
+                )
+                presenter?.presentAyahBookmarkCollectionPicker(viewController)
+            }
+        }
+    #endif
 
     func showTranslation(_ verses: [AyahNumber]) {
         guard let verse = verses.first else {

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -10,6 +10,9 @@ import Analytics
 import AnnotationsService
 import AudioBannerFeature
 import AyahMenuFeature
+#if QURAN_SYNC
+    import BookmarksFeature
+#endif
 import Combine
 import Crashing
 import FeaturesSupport

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -269,11 +269,16 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
                 guard let self else { return }
                 let viewController = ayahBookmarkCollectionPickerBuilder.build(
                     verses: verses,
-                    didSaveReadingBookmark: { [weak self] in
-                        guard let self, let readingBookmarkService = deps.readingBookmarkService else {
+                    didUpdateReadingBookmark: { [weak self] bookmark in
+                        guard let self else {
                             return
                         }
-                        showReadingBookmarkNudge(using: readingBookmarkService)
+                        readingBookmark = bookmark
+                        if bookmark != nil, let readingBookmarkService = deps.readingBookmarkService {
+                            showReadingBookmarkNudge(using: readingBookmarkService)
+                        } else {
+                            presenter?.hideReadingBookmarkNudge()
+                        }
                     },
                     didFinish: { [weak self] in
                         self?.presenter?.dismissPresentedViewController(completion: nil)

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -251,11 +251,16 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
                 guard let self else { return }
                 let viewController = ayahBookmarkCollectionPickerBuilder.build(
                     verses: verses,
-                    didSaveReadingBookmark: { [weak self] in
-                        guard let self, let readingBookmarkService = deps.readingBookmarkService else {
+                    didUpdateReadingBookmark: { [weak self] bookmark in
+                        guard let self else {
                             return
                         }
-                        showReadingBookmarkNudge(using: readingBookmarkService)
+                        readingBookmark = bookmark
+                        if bookmark != nil, let readingBookmarkService = deps.readingBookmarkService {
+                            showReadingBookmarkNudge(using: readingBookmarkService)
+                        } else {
+                            presenter?.hideReadingBookmarkNudge()
+                        }
                     },
                     didFinish: { [weak self] in
                         self?.presenter?.dismissPresentedViewController(completion: nil)

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -56,6 +56,7 @@ protocol QuranPresentable: UIViewController {
     #if QURAN_SYNC
         func showReadingBookmarkNudge(expanded: Bool, undo: @escaping () async -> Void)
         func hideReadingBookmarkNudge()
+        func presentAyahBookmarkCollectionPicker(_ viewController: UIViewController)
     #endif
 }
 
@@ -81,6 +82,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         #if QURAN_SYNC
             let syncedHighlightsObserver: QuranSyncedHighlightsObserver?
             let readingBookmarkService: ReadingBookmarkService?
+            let ayahBookmarkCollectionPickerBuilder: AyahBookmarkCollectionPickerBuilder?
         #endif
     }
 
@@ -237,6 +239,32 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         logger.info("Quran: dismiss note editor")
         presenter?.dismiss(animated: true)
     }
+
+    #if QURAN_SYNC
+        func saveVersesAsBookmark(_ verses: [AyahNumber]) {
+            guard let ayahBookmarkCollectionPickerBuilder = deps.ayahBookmarkCollectionPickerBuilder else {
+                return
+            }
+
+            contentViewModel?.removeAyahMenuHighlight()
+            presenter?.dismissPresentedViewController { [weak self] in
+                guard let self else { return }
+                let viewController = ayahBookmarkCollectionPickerBuilder.build(
+                    verses: verses,
+                    didSaveReadingBookmark: { [weak self] in
+                        guard let self, let readingBookmarkService = deps.readingBookmarkService else {
+                            return
+                        }
+                        showReadingBookmarkNudge(using: readingBookmarkService)
+                    },
+                    didFinish: { [weak self] in
+                        self?.presenter?.dismissPresentedViewController(completion: nil)
+                    }
+                )
+                presenter?.presentAyahBookmarkCollectionPicker(viewController)
+            }
+        }
+    #endif
 
     func showTranslation(_ verses: [AyahNumber]) {
         guard let verse = verses.first else {

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -338,15 +338,25 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     func presentAyahMenu(in sourceView: UIView, at point: CGPoint, verses: [AyahNumber]) {
         logger.info("Quran: present ayah menu, verses: \(verses)")
         let notes = notesInteractingVerses(verses)
-        let input = AyahMenuInput(
-            sourceView: sourceView,
-            pointInView: point,
-            verses: verses,
-            notes: notes,
-            noteCount: syncedNoteCount(interacting: verses),
-            highlightColor: highlightColor(for: verses),
-            isCollectionBookmarked: collectionBookmarked(verses)
-        )
+        #if QURAN_SYNC
+            let input = AyahMenuInput(
+                sourceView: sourceView,
+                pointInView: point,
+                verses: verses,
+                notes: notes,
+                noteCount: syncedNoteCount(interacting: verses),
+                highlightColor: highlightColor(for: verses),
+                isCollectionBookmarked: collectionBookmarked(verses)
+            )
+        #else
+            let input = AyahMenuInput(
+                sourceView: sourceView,
+                pointInView: point,
+                verses: verses,
+                notes: notes,
+                highlightColor: highlightColor(for: verses)
+            )
+        #endif
         let ayahMenuViewController = deps.ayahMenuBuilder.build(withListener: self, input: input)
         presenter?.presentAyahMenu(ayahMenuViewController, in: sourceView, at: point)
     }

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -85,6 +85,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         #if QURAN_SYNC
             let syncedHighlightsObserver: QuranSyncedHighlightsObserver?
             let readingBookmarkService: ReadingBookmarkService?
+            let ayahBookmarkCollectionService: AyahBookmarkCollectionService?
             let ayahBookmarkCollectionPickerBuilder: AyahBookmarkCollectionPickerBuilder?
         #endif
     }
@@ -100,6 +101,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     deinit {
         #if QURAN_SYNC
             readingBookmarkTask?.cancel()
+            ayahBookmarkCollectionsTask?.cancel()
         #endif
     }
 
@@ -122,6 +124,9 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     func start() {
         #if QURAN_SYNC
             deps.syncedHighlightsObserver?.start()
+            if let ayahBookmarkCollectionService = deps.ayahBookmarkCollectionService {
+                startAyahBookmarkCollectionsObservation(ayahBookmarkCollectionService)
+            }
         #endif
 
         deps.noteService.notes(quran: deps.quran)
@@ -272,6 +277,26 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
                 presenter?.presentAyahBookmarkCollectionPicker(viewController)
             }
         }
+
+        func removeVersesFromBookmarkCollections(_ verses: [AyahNumber]) async {
+            guard let ayahBookmarkCollectionService = deps.ayahBookmarkCollectionService else {
+                return
+            }
+
+            contentViewModel?.removeAyahMenuHighlight()
+            dismissAyahMenu()
+
+            let selectedVerses = Set(verses)
+            do {
+                for collection in ayahBookmarkCollections where HighlightColor(collectionName: collection.collection.name) == nil {
+                    for bookmark in collection.bookmarks where selectedVerses.contains(bookmark.ayah) {
+                        try await ayahBookmarkCollectionService.removeBookmarkFromCollection(bookmark)
+                    }
+                }
+            } catch {
+                crasher.recordError(error, reason: "Failed to remove ayah bookmark from collections")
+            }
+        }
     #endif
 
     func showTranslation(_ verses: [AyahNumber]) {
@@ -300,7 +325,8 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             pointInView: point,
             verses: verses,
             notes: notes,
-            highlightColor: highlightColor(for: verses)
+            highlightColor: highlightColor(for: verses),
+            isCollectionBookmarked: collectionBookmarked(verses)
         )
         let ayahMenuViewController = deps.ayahMenuBuilder.build(withListener: self, input: input)
         presenter?.presentAyahMenu(ayahMenuViewController, in: sourceView, at: point)
@@ -397,6 +423,9 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
     #if QURAN_SYNC
         private var readingBookmarkTask: Task<Void, Never>?
+        private var ayahBookmarkCollectionsTask: Task<Void, Never>?
+        private var ayahBookmarkCollections: [AyahBookmarkCollection] = []
+
         private var readingBookmark: QuranReadingBookmark? {
             didSet {
                 reloadPageBookmark()
@@ -440,6 +469,22 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
                 }
             }
         }
+
+        private func startAyahBookmarkCollectionsObservation(_ service: AyahBookmarkCollectionService) {
+            ayahBookmarkCollectionsTask?.cancel()
+            ayahBookmarkCollectionsTask = Task { [weak self] in
+                do {
+                    let sequence = service.collectionsSequence()
+                    for try await collections in sequence {
+                        await MainActor.run {
+                            self?.ayahBookmarkCollections = collections
+                        }
+                    }
+                } catch {
+                    crasher.recordError(error, reason: "Failed to observe ayah bookmark collections")
+                }
+            }
+        }
     #endif
 
     private func setVisiblePages(_ pages: [Page]) {
@@ -476,6 +521,20 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     private func notesInteractingVerses(_ verses: [AyahNumber]) -> [Note] {
         let selectedVerses = Set(verses)
         return notes.filter { !selectedVerses.isDisjoint(with: $0.verses) }
+    }
+
+    private func collectionBookmarked(_ verses: [AyahNumber]) -> Bool {
+        #if QURAN_SYNC
+            let selectedVerses = Set(verses)
+            return ayahBookmarkCollections.contains { collection in
+                guard HighlightColor(collectionName: collection.collection.name) == nil else {
+                    return false
+                }
+                return collection.bookmarks.contains { selectedVerses.contains($0.ayah) }
+            }
+        #else
+            return false
+        #endif
     }
 
     private func highlightColor(for verses: [AyahNumber]) -> HighlightColor? {

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -87,6 +87,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             let syncedNoteEditorBuilder: SyncedNoteEditorBuilder?
             let syncedHighlightsObserver: QuranSyncedHighlightsObserver?
             let readingBookmarkService: ReadingBookmarkService?
+            let ayahBookmarkCollectionService: AyahBookmarkCollectionService?
             let ayahBookmarkCollectionPickerBuilder: AyahBookmarkCollectionPickerBuilder?
         #endif
     }
@@ -103,6 +104,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         #if QURAN_SYNC
             syncedNotesObservationTask?.cancel()
             readingBookmarkTask?.cancel()
+            ayahBookmarkCollectionsTask?.cancel()
         #endif
     }
 
@@ -125,6 +127,9 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     func start() {
         #if QURAN_SYNC
             deps.syncedHighlightsObserver?.start()
+            if let ayahBookmarkCollectionService = deps.ayahBookmarkCollectionService {
+                startAyahBookmarkCollectionsObservation(ayahBookmarkCollectionService)
+            }
             if let syncedNoteService = deps.syncedNoteService {
                 startSyncedNotesObservation(syncedNoteService)
             } else {
@@ -290,6 +295,26 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
                 presenter?.presentAyahBookmarkCollectionPicker(viewController)
             }
         }
+
+        func removeVersesFromBookmarkCollections(_ verses: [AyahNumber]) async {
+            guard let ayahBookmarkCollectionService = deps.ayahBookmarkCollectionService else {
+                return
+            }
+
+            contentViewModel?.removeAyahMenuHighlight()
+            dismissAyahMenu()
+
+            let selectedVerses = Set(verses)
+            do {
+                for collection in ayahBookmarkCollections where HighlightColor(collectionName: collection.collection.name) == nil {
+                    for bookmark in collection.bookmarks where selectedVerses.contains(bookmark.ayah) {
+                        try await ayahBookmarkCollectionService.removeBookmarkFromCollection(bookmark)
+                    }
+                }
+            } catch {
+                crasher.recordError(error, reason: "Failed to remove ayah bookmark from collections")
+            }
+        }
     #endif
 
     func showTranslation(_ verses: [AyahNumber]) {
@@ -319,7 +344,8 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             verses: verses,
             notes: notes,
             noteCount: syncedNoteCount(interacting: verses),
-            highlightColor: highlightColor(for: verses)
+            highlightColor: highlightColor(for: verses),
+            isCollectionBookmarked: collectionBookmarked(verses)
         )
         let ayahMenuViewController = deps.ayahMenuBuilder.build(withListener: self, input: input)
         presenter?.presentAyahMenu(ayahMenuViewController, in: sourceView, at: point)
@@ -406,6 +432,8 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         private var syncedNotes: [SyncedNote] = []
         private var syncedNotesObservationTask: Task<Void, Never>?
         private var readingBookmarkTask: Task<Void, Never>?
+        private var ayahBookmarkCollectionsTask: Task<Void, Never>?
+        private var ayahBookmarkCollections: [AyahBookmarkCollection] = []
         private var readingBookmark: QuranReadingBookmark? {
             didSet {
                 reloadPageBookmark()
@@ -485,6 +513,22 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
                 }
             }
         }
+
+        private func startAyahBookmarkCollectionsObservation(_ service: AyahBookmarkCollectionService) {
+            ayahBookmarkCollectionsTask?.cancel()
+            ayahBookmarkCollectionsTask = Task { [weak self] in
+                do {
+                    let sequence = service.collectionsSequence()
+                    for try await collections in sequence {
+                        await MainActor.run {
+                            self?.ayahBookmarkCollections = collections
+                        }
+                    }
+                } catch {
+                    crasher.recordError(error, reason: "Failed to observe ayah bookmark collections")
+                }
+            }
+        }
     #endif
 
     private func setVisiblePages(_ pages: [Page]) {
@@ -528,6 +572,20 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             return SyncedNoteCounter.count(syncedNotes, interacting: verses)
         #else
             return 0
+        #endif
+    }
+
+    private func collectionBookmarked(_ verses: [AyahNumber]) -> Bool {
+        #if QURAN_SYNC
+            let selectedVerses = Set(verses)
+            return ayahBookmarkCollections.contains { collection in
+                guard HighlightColor(collectionName: collection.collection.name) == nil else {
+                    return false
+                }
+                return collection.bookmarks.contains { selectedVerses.contains($0.ayah) }
+            }
+        #else
+            return false
         #endif
     }
 

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -320,14 +320,24 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     func presentAyahMenu(in sourceView: UIView, at point: CGPoint, verses: [AyahNumber]) {
         logger.info("Quran: present ayah menu, verses: \(verses)")
         let notes = notesInteractingVerses(verses)
-        let input = AyahMenuInput(
-            sourceView: sourceView,
-            pointInView: point,
-            verses: verses,
-            notes: notes,
-            highlightColor: highlightColor(for: verses),
-            isCollectionBookmarked: collectionBookmarked(verses)
-        )
+        #if QURAN_SYNC
+            let input = AyahMenuInput(
+                sourceView: sourceView,
+                pointInView: point,
+                verses: verses,
+                notes: notes,
+                highlightColor: highlightColor(for: verses),
+                isCollectionBookmarked: collectionBookmarked(verses)
+            )
+        #else
+            let input = AyahMenuInput(
+                sourceView: sourceView,
+                pointInView: point,
+                verses: verses,
+                notes: notes,
+                highlightColor: highlightColor(for: verses)
+            )
+        #endif
         let ayahMenuViewController = deps.ayahMenuBuilder.build(withListener: self, input: input)
         presenter?.presentAyahMenu(ayahMenuViewController, in: sourceView, at: point)
     }

--- a/Features/QuranViewFeature/QuranViewController.swift
+++ b/Features/QuranViewFeature/QuranViewController.swift
@@ -290,6 +290,15 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
             quranView?.hideReadingBookmarkNudgeView()
             readingBookmarkNudgeController = nil
         }
+
+        func presentAyahBookmarkCollectionPicker(_ viewController: UIViewController) {
+            let navigationController = UINavigationController(rootViewController: viewController)
+            if let sheet = navigationController.sheetPresentationController {
+                sheet.detents = [.medium(), .large()]
+                sheet.prefersGrabberVisible = true
+            }
+            present(navigationController, animated: true)
+        }
     #endif
 
     // MARK: Private

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
@@ -16,6 +16,7 @@ public enum AyahMenuUI {
             play: @escaping AsyncAction,
             repeatVerses: @escaping AsyncAction,
             highlight: @Sendable @escaping (HighlightColor) async -> Void,
+            saveVerse: @escaping AsyncAction,
             addNote: @escaping AsyncAction,
             deleteNote: @escaping AsyncAction,
             showTranslation: @escaping AsyncAction,
@@ -25,6 +26,7 @@ public enum AyahMenuUI {
             self.play = play
             self.repeatVerses = repeatVerses
             self.highlight = highlight
+            self.saveVerse = saveVerse
             self.addNote = addNote
             self.deleteNote = deleteNote
             self.showTranslation = showTranslation
@@ -37,6 +39,7 @@ public enum AyahMenuUI {
         let play: AsyncAction
         let repeatVerses: AsyncAction
         let highlight: @Sendable (HighlightColor) async -> Void
+        let saveVerse: AsyncAction
         let addNote: AsyncAction
         let deleteNote: AsyncAction
         let showTranslation: AsyncAction
@@ -55,7 +58,8 @@ public enum AyahMenuUI {
             actions: Actions,
             isTranslationView: Bool,
             usesSyncedNotesIcon: Bool = false,
-            noteCount: Int = 0
+            noteCount: Int = 0,
+            usesCollectionBookmarks: Bool = false
         ) {
             self.highlightingColor = highlightingColor
             self.state = state
@@ -65,6 +69,7 @@ public enum AyahMenuUI {
             self.isTranslationView = isTranslationView
             self.usesSyncedNotesIcon = usesSyncedNotesIcon
             self.noteCount = noteCount
+            self.usesCollectionBookmarks = usesCollectionBookmarks
         }
 
         // MARK: Internal
@@ -77,6 +82,7 @@ public enum AyahMenuUI {
         let isTranslationView: Bool
         let usesSyncedNotesIcon: Bool
         let noteCount: Int
+        let usesCollectionBookmarks: Bool
     }
 
     // MARK: Public

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
@@ -57,7 +57,8 @@ public enum AyahMenuUI {
             repeatSubtitle: String,
             actions: Actions,
             isTranslationView: Bool,
-            usesCollectionBookmarks: Bool = false
+            usesCollectionBookmarks: Bool = false,
+            isCollectionBookmarked: Bool = false
         ) {
             self.highlightingColor = highlightingColor
             self.state = state
@@ -66,6 +67,7 @@ public enum AyahMenuUI {
             self.actions = actions
             self.isTranslationView = isTranslationView
             self.usesCollectionBookmarks = usesCollectionBookmarks
+            self.isCollectionBookmarked = isCollectionBookmarked
         }
 
         // MARK: Internal
@@ -77,6 +79,7 @@ public enum AyahMenuUI {
         let repeatSubtitle: String
         let isTranslationView: Bool
         let usesCollectionBookmarks: Bool
+        let isCollectionBookmarked: Bool
     }
 
     // MARK: Public

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
@@ -16,6 +16,7 @@ public enum AyahMenuUI {
             play: @escaping AsyncAction,
             repeatVerses: @escaping AsyncAction,
             highlight: @Sendable @escaping (HighlightColor) async -> Void,
+            saveVerse: @escaping AsyncAction,
             addNote: @escaping AsyncAction,
             deleteNote: @escaping AsyncAction,
             showTranslation: @escaping AsyncAction,
@@ -25,6 +26,7 @@ public enum AyahMenuUI {
             self.play = play
             self.repeatVerses = repeatVerses
             self.highlight = highlight
+            self.saveVerse = saveVerse
             self.addNote = addNote
             self.deleteNote = deleteNote
             self.showTranslation = showTranslation
@@ -37,6 +39,7 @@ public enum AyahMenuUI {
         let play: AsyncAction
         let repeatVerses: AsyncAction
         let highlight: @Sendable (HighlightColor) async -> Void
+        let saveVerse: AsyncAction
         let addNote: AsyncAction
         let deleteNote: AsyncAction
         let showTranslation: AsyncAction
@@ -53,7 +56,8 @@ public enum AyahMenuUI {
             playSubtitle: String,
             repeatSubtitle: String,
             actions: Actions,
-            isTranslationView: Bool
+            isTranslationView: Bool,
+            usesCollectionBookmarks: Bool = false
         ) {
             self.highlightingColor = highlightingColor
             self.state = state
@@ -61,6 +65,7 @@ public enum AyahMenuUI {
             self.repeatSubtitle = repeatSubtitle
             self.actions = actions
             self.isTranslationView = isTranslationView
+            self.usesCollectionBookmarks = usesCollectionBookmarks
         }
 
         // MARK: Internal
@@ -71,6 +76,7 @@ public enum AyahMenuUI {
         let playSubtitle: String
         let repeatSubtitle: String
         let isTranslationView: Bool
+        let usesCollectionBookmarks: Bool
     }
 
     // MARK: Public

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
@@ -59,7 +59,8 @@ public enum AyahMenuUI {
             isTranslationView: Bool,
             usesSyncedNotesIcon: Bool = false,
             noteCount: Int = 0,
-            usesCollectionBookmarks: Bool = false
+            usesCollectionBookmarks: Bool = false,
+            isCollectionBookmarked: Bool = false
         ) {
             self.highlightingColor = highlightingColor
             self.state = state
@@ -70,6 +71,7 @@ public enum AyahMenuUI {
             self.usesSyncedNotesIcon = usesSyncedNotesIcon
             self.noteCount = noteCount
             self.usesCollectionBookmarks = usesCollectionBookmarks
+            self.isCollectionBookmarked = isCollectionBookmarked
         }
 
         // MARK: Internal
@@ -83,6 +85,7 @@ public enum AyahMenuUI {
         let usesSyncedNotesIcon: Bool
         let noteCount: Int
         let usesCollectionBookmarks: Bool
+        let isCollectionBookmarked: Bool
     }
 
     // MARK: Public

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
@@ -127,29 +127,37 @@ private struct AyahMenuViewList: View {
             MenuGroup {
                 Divider()
 
-                if dataObject.state == .noHighlight {
+                if dataObject.usesCollectionBookmarks {
+                    Row(title: l("ayah-bookmark.save-verse"), action: dataObject.actions.saveVerse) {
+                        NoorSystemImage.bookmark.image
+                    }
+                    Divider()
+                        .padding(.leading)
+                } else {
+                    if dataObject.state == .noHighlight {
+                        Row(
+                            title: l("ayah.menu.highlight"),
+                            action: {
+                                Task {
+                                    await dataObject.actions.highlight(dataObject.highlightingColor)
+                                }
+                            }
+                        ) {
+                            IconCircle(color: dataObject.highlightingColor)
+                        }
+                        Divider()
+                            .padding(.leading)
+                    }
                     Row(
                         title: l("ayah.menu.highlight"),
-                        action: {
-                            Task {
-                                await dataObject.actions.highlight(dataObject.highlightingColor)
-                            }
-                        }
+                        subtitle: l("ayah.menu.highlight-select-color"),
+                        action: showHighlights
                     ) {
-                        IconCircle(color: dataObject.highlightingColor)
+                        IconCircles()
                     }
                     Divider()
                         .padding(.leading)
                 }
-                Row(
-                    title: l("ayah.menu.highlight"),
-                    subtitle: l("ayah.menu.highlight-select-color"),
-                    action: showHighlights
-                ) {
-                    IconCircles()
-                }
-                Divider()
-                    .padding(.leading)
 
                 switch dataObject.state {
                 case .noHighlight, .highlighted:
@@ -304,6 +312,7 @@ struct AyahMenuView_Previews: PreviewProvider {
         play: {},
         repeatVerses: {},
         highlight: { _ in },
+        saveVerse: {},
         addNote: {},
         deleteNote: {},
         showTranslation: {},

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
@@ -131,29 +131,37 @@ private struct AyahMenuViewList: View {
             MenuGroup {
                 Divider()
 
-                if dataObject.state == .noHighlight {
+                if dataObject.usesCollectionBookmarks {
+                    Row(title: l("ayah-bookmark.save-verse"), action: dataObject.actions.saveVerse) {
+                        NoorSystemImage.bookmark.image
+                    }
+                    Divider()
+                        .padding(.leading)
+                } else {
+                    if dataObject.state == .noHighlight {
+                        Row(
+                            title: l("ayah.menu.highlight"),
+                            action: {
+                                Task {
+                                    await dataObject.actions.highlight(dataObject.highlightingColor)
+                                }
+                            }
+                        ) {
+                            IconCircle(color: dataObject.highlightingColor)
+                        }
+                        Divider()
+                            .padding(.leading)
+                    }
                     Row(
                         title: l("ayah.menu.highlight"),
-                        action: {
-                            Task {
-                                await dataObject.actions.highlight(dataObject.highlightingColor)
-                            }
-                        }
+                        subtitle: l("ayah.menu.highlight-select-color"),
+                        action: showHighlights
                     ) {
-                        IconCircle(color: dataObject.highlightingColor)
+                        IconCircles()
                     }
                     Divider()
                         .padding(.leading)
                 }
-                Row(
-                    title: l("ayah.menu.highlight"),
-                    subtitle: l("ayah.menu.highlight-select-color"),
-                    action: showHighlights
-                ) {
-                    IconCircles()
-                }
-                Divider()
-                    .padding(.leading)
 
                 switch dataObject.state {
                 case .noHighlight, .highlighted:
@@ -360,6 +368,7 @@ struct AyahMenuView_Previews: PreviewProvider {
         play: {},
         repeatVerses: {},
         highlight: { _ in },
+        saveVerse: {},
         addNote: {},
         deleteNote: {},
         showTranslation: {},

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
@@ -128,7 +128,10 @@ private struct AyahMenuViewList: View {
                 Divider()
 
                 if dataObject.usesCollectionBookmarks {
-                    Row(title: l("ayah-bookmark.save-verse"), action: dataObject.actions.saveVerse) {
+                    Row(
+                        title: dataObject.isCollectionBookmarked ? l("ayah-bookmark.remove-verse") : l("ayah-bookmark.save-verse"),
+                        action: dataObject.actions.saveVerse
+                    ) {
                         NoorSystemImage.bookmark.image
                     }
                     Divider()

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
@@ -132,7 +132,10 @@ private struct AyahMenuViewList: View {
                 Divider()
 
                 if dataObject.usesCollectionBookmarks {
-                    Row(title: l("ayah-bookmark.save-verse"), action: dataObject.actions.saveVerse) {
+                    Row(
+                        title: dataObject.isCollectionBookmarked ? l("ayah-bookmark.remove-verse") : l("ayah-bookmark.save-verse"),
+                        action: dataObject.actions.saveVerse
+                    ) {
                         NoorSystemImage.bookmark.image
                     }
                     Divider()

--- a/UI/NoorUI/Images/NoorSystemImage.swift
+++ b/UI/NoorUI/Images/NoorSystemImage.swift
@@ -20,6 +20,7 @@ public enum NoorSystemImage: String {
     case checkmark_unchecked = "circle"
     case checkmark
     case bookmark = "bookmark.fill"
+    case bookmarkOutline = "bookmark"
     case folder = "folder.fill"
     case note = "text.badge.star"
     case lastPage = "clock"


### PR DESCRIPTION
## Summary
- Add Save Verse flow under `QURAN_SYNC`.
- Show collection picker for selected ayah/ayat.
- Preselect collections already containing the ayah.
- Support removing existing ayah bookmark.
- Allow saving first selected ayah as reading bookmark.

## Notes
- Built on synced reading bookmark branch.
- Legacy ayah menu behavior remains unchanged without `QURAN_SYNC`.

https://github.com/user-attachments/assets/a36476db-0e5e-4a4e-8f20-13486763bf71

https://github.com/user-attachments/assets/ecdee7aa-f573-4d4a-b691-1caeeebb9246

https://github.com/user-attachments/assets/31bba2aa-a050-4ba6-8c1f-cf3badc01ac4
