### PR TITLE
Add editable collapsible Noor section

### DIFF
--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
@@ -57,6 +57,24 @@
             )
         }
 
+        private var deleteBookmarkAction: AsyncItemAction<AyahCollectionBookmark>? {
+            guard allowsBookmarkDeletion else {
+                return nil
+            }
+            return { bookmark in
+                await viewModel.deleteBookmark(bookmark)
+            }
+        }
+
+        private func deleteCollectionAction(for collection: AyahBookmarkCollection) -> AsyncAction? {
+            guard allowsCollectionManagement else {
+                return nil
+            }
+            return {
+                await viewModel.deleteCollection(collection)
+            }
+        }
+
         @ViewBuilder
         private func section(for collection: AyahBookmarkCollection) -> some View {
             let isExpanded = Binding(
@@ -64,33 +82,16 @@
                 set: { viewModel.setCollection(collection, expanded: $0) }
             )
 
-            NoorBasicSection(title: collection.collection.name, isExpanded: isExpanded) {
-                ForEach(collection.bookmarks) { bookmark in
-                    bookmarkItem(bookmark)
-                        .swipeActions(edge: .trailing, allowsFullSwipe: allowsBookmarkDeletion) {
-                            if allowsBookmarkDeletion {
-                                Button(role: .destructive) {
-                                    Task {
-                                        await viewModel.deleteBookmark(bookmark)
-                                    }
-                                } label: {
-                                    Label(lAndroid("delete"), systemImage: "trash")
-                                }
-                            }
-                        }
-                }
+            NoorEditableCollapsibleSection(
+                title: collection.collection.name,
+                isExpanded: isExpanded,
+                collection.bookmarks,
+                showsHeaderDeleteAction: allowsCollectionManagement && viewModel.editMode.isEditing,
+                headerDeleteAction: deleteCollectionAction(for: collection)
+            ) { bookmark in
+                bookmarkItem(bookmark)
             }
-            .swipeActions(edge: .trailing, allowsFullSwipe: allowsCollectionManagement) {
-                if allowsCollectionManagement {
-                    Button(role: .destructive) {
-                        Task {
-                            await viewModel.deleteCollection(collection)
-                        }
-                    } label: {
-                        Label(lAndroid("delete"), systemImage: "trash")
-                    }
-                }
-            }
+            .onDelete(action: deleteBookmarkAction)
         }
 
         private func bookmarkItem(_ bookmark: AyahCollectionBookmark) -> some View {

--- a/UI/NoorUI/Components/List/NoorEditableCollapsibleSection.swift
+++ b/UI/NoorUI/Components/List/NoorEditableCollapsibleSection.swift
@@ -1,0 +1,113 @@
+//
+//  NoorEditableCollapsibleSection.swift
+//
+//
+//  Created by Ahmed Nabil on 2026-05-13.
+//
+
+import SwiftUI
+import UIx
+
+public struct NoorEditableCollapsibleSection<Item: Identifiable, ListItem: View>: View {
+    // MARK: Lifecycle
+
+    public init(
+        title: String,
+        isExpanded: Binding<Bool>,
+        _ items: [Item],
+        showsHeaderDeleteAction: Bool = false,
+        headerDeleteAction: AsyncAction? = nil,
+        @ViewBuilder listItem: @escaping (Item) -> ListItem,
+        onDelete: AsyncItemAction<Item>? = nil
+    ) {
+        self.title = title
+        _isExpanded = isExpanded
+        self.items = items
+        self.showsHeaderDeleteAction = showsHeaderDeleteAction
+        self.headerDeleteAction = headerDeleteAction
+        self.listItem = listItem
+        self.onDelete = onDelete
+    }
+
+    // MARK: Public
+
+    public var body: some View {
+        Section {
+            if isExpanded {
+                rows
+            }
+        } header: {
+            header
+        }
+    }
+
+    // MARK: Internal
+
+    let title: String
+    @Binding var isExpanded: Bool
+    let items: [Item]
+    let showsHeaderDeleteAction: Bool
+    let headerDeleteAction: AsyncAction?
+    let listItem: (Item) -> ListItem
+    var onDelete: AsyncItemAction<Item>?
+
+    // MARK: Private
+
+    private var header: some View {
+        HStack {
+            Button {
+                withAnimation {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack {
+                    Text(title)
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                        .font(.footnote.weight(.semibold))
+                        .rotationEffect(.degrees(isExpanded ? 0 : -90))
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if showsHeaderDeleteAction, let headerDeleteAction {
+                Button {
+                    Task {
+                        await headerDeleteAction()
+                    }
+                } label: {
+                    Image(systemName: "trash")
+                        .foregroundStyle(Color.red)
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+        .accessibilityLabel(title)
+    }
+
+    @ViewBuilder
+    private var rows: some View {
+        ForEach(items) { item in
+            listItem(item)
+        }
+        .onDelete(perform: onDelete.map { onDelete in
+            { indexSet in
+                Task {
+                    let itemsToDelete = indexSet.map { items[$0] }
+                    for itemToDelete in itemsToDelete {
+                        await onDelete(itemToDelete)
+                    }
+                }
+            }
+        })
+    }
+}
+
+extension NoorEditableCollapsibleSection {
+    public func onDelete(action: AsyncItemAction<Item>?) -> Self {
+        var mutableSelf = self
+        mutableSelf.onDelete = action
+        return mutableSelf
+    }
+}


### PR DESCRIPTION
## Summary
- Add a dedicated NoorUI editable collapsible section component.
- Use it in ayah bookmark collections for header delete/edit mode and bookmark deletion.
- Keep existing NoorBasicSection and NoorSection behavior unchanged.

## Why
- Base branch currently uses swipe actions on both the collection section and bookmark rows, which can produce duplicate/confusing delete affordances.
- Existing NoorSection supports row deletion, but collections need both row deletion and section/header deletion.
- A separate component avoids changing shared NoorBasicSection behavior used by other screens.

## Validation
- QURAN_SYNC=1 xcodebuild -project Example/QuranEngineApp.xcodeproj -scheme QuranEngineApp -destination 'generic/platform=iOS Simulator' build