### PR TITLE
Bump Mobile Sync SPM to 0.1.9

### DIFF
--- a/Example/QuranEngineApp/Classes/Container.swift
+++ b/Example/QuranEngineApp/Classes/Container.swift
@@ -107,46 +107,15 @@ class Container: AppDependencies {
             AuthFlowFactoryProvider.shared.doInitialize()
 
             let driverFactory = DriverFactory()
+            let storage = AppleMobileSyncStorageFactory.shared.create()
             let graph = SharedDependencyGraph.shared.doInit(
                 driverFactory: driverFactory,
+                storage: storage,
                 environment: synchronizationEnvironment,
-                authEnvironment: authConfig.environment
+                authConfig: authConfig
             )
 
-            let json = AuthModule.companion.provideJson()
-            let settings = AuthModule.companion.provideSettings()
-            let httpClient = AuthModule.companion.provideHttpClient(json: json, config: authConfig)
-            let oidcClient = AuthModule.companion.provideOpenIdConnectClient(
-                config: authConfig,
-                httpClient: httpClient
-            )
-            let authStorage = AuthStorage(settings: settings, json: json)
-            let authNetworkDataSource = AuthNetworkDataSource(
-                authConfig: authConfig,
-                httpClient: httpClient
-            )
-            let logger = KermitLogger.companion.withTag(tag: "quran-ios")
-            let authRepository = OidcAuthRepository(
-                authConfig: authConfig,
-                authStorage: authStorage,
-                oidcClient: oidcClient,
-                networkDataSource: authNetworkDataSource,
-                logger: logger
-            )
-            let authService = AuthService(authRepository: authRepository)
-            let database = PersistenceModule.companion.provideQuranDatabase(driverFactory: driverFactory)
-            let persistenceResetRepository: PersistenceResetRepository = PersistenceResetRepositoryImpl(database: database)
-            let persistenceImportRepository: PersistenceImportRepository = PersistenceImportRepositoryImpl(database: database)
-            let syncService = SyncService(
-                authService: authService,
-                pipeline: graph.syncService.pipelineForIos,
-                environment: synchronizationEnvironment,
-                persistenceResetRepository: persistenceResetRepository,
-                persistenceImportRepository: persistenceImportRepository,
-                settings: SyncServiceKt.makeSettings()
-            )
-
-            return (authService, syncService)
+            return (graph.authService, graph.syncService)
         }()
 
         private static func mobileSyncAuthConfiguration() -> AuthConfig? {

--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quran/mobile-sync-spm.git",
       "state" : {
-        "revision" : "77d319ca4840bcf03639921d371459426d603be0",
-        "version" : "0.1.4"
+        "revision" : "3adcda0237488bb20adcaa850ac15962588c2b29",
+        "version" : "0.1.9"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -68,7 +68,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
 
         // Sync
-        .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.4"),
+        .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.9"),
 
     ], targets: validated(targets) + [testTargetLinkingAllPackageTargets(targets)]
 )


### PR DESCRIPTION
## Summary
- Bump `mobile-sync-spm` to `0.1.9`.
- Use the Mobile Sync-provided Apple storage factory when initializing the sync graph.
- Pulls in the Mobile Sync collection bookmark deletion fix.

## Validation
- `QURAN_SYNC=1 xcodebuild -project Example/QuranEngineApp.xcodeproj -scheme QuranEngineApp -destination 'generic/platform=iOS Simulator' build`