### PR TITLE
Update sync reading session in place

### DIFF
--- a/Domain/AnnotationsService/Sources/LastPageService.swift
+++ b/Domain/AnnotationsService/Sources/LastPageService.swift
@@ -15,5 +15,5 @@ public protocol LastPageService {
 
     func add(page: Page) async throws -> LastPage
 
-    func update(page: Page, toPage: Page) async throws -> LastPage
+    func update(lastPage: LastPage, toPage: Page) async throws -> LastPage
 }

--- a/Domain/AnnotationsService/Sources/LastPageUpdater.swift
+++ b/Domain/AnnotationsService/Sources/LastPageUpdater.swift
@@ -19,6 +19,7 @@
 //
 
 import Crashing
+import QuranAnnotations
 import QuranKit
 
 @MainActor
@@ -31,9 +32,9 @@ public final class LastPageUpdater {
 
     // MARK: Public
 
-    public private(set) var lastPage: Page?
+    public private(set) var lastPage: LastPage?
 
-    public func configure(initialPage: Page, lastPage: Page?) {
+    public func configure(initialPage: Page, lastPage: LastPage?) {
         self.lastPage = lastPage
 
         if let lastPage {
@@ -48,7 +49,7 @@ public final class LastPageUpdater {
             return
         }
         // don't update if it's the same page
-        guard let lastPage, page != lastPage else { return }
+        guard let lastPage, page != lastPage.page else { return }
 
         updateTo(page: page, lastPage: lastPage)
     }
@@ -57,11 +58,10 @@ public final class LastPageUpdater {
 
     private let service: any LastPageService
 
-    private func updateTo(page: Page, lastPage: Page) {
-        self.lastPage = page
+    private func updateTo(page: Page, lastPage: LastPage) {
         Task {
             do {
-                _ = try await service.update(page: lastPage, toPage: page)
+                self.lastPage = try await service.update(lastPage: lastPage, toPage: page)
             } catch {
                 crasher.recordError(error, reason: "Failed to update last page")
             }
@@ -69,10 +69,9 @@ public final class LastPageUpdater {
     }
 
     private func create(page: Page) {
-        lastPage = page
         Task {
             do {
-                _ = try await service.add(page: page)
+                lastPage = try await service.add(page: page)
             } catch {
                 crasher.recordError(error, reason: "Failed to create a last page")
             }

--- a/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
@@ -8,6 +8,7 @@
 
 #if QURAN_SYNC
     import Combine
+    import Foundation
     @preconcurrency import MobileSync
     import QuranAnnotations
     import QuranKit
@@ -29,27 +30,8 @@
                         if Task.isCancelled {
                             break
                         }
-                        let mapped = sessions.compactMap { session -> LastPage? in
-                            // Try to build an AyahNumber from the stored session values
-                            guard let sourceAyah = AyahNumber(quran: quran, sura: Int(session.sura), ayah: Int(session.ayah)) else {
-                                return nil
-                            }
-
-                            // If the source ayah already belongs to the target quran, use its page directly.
-                            // Otherwise map it to the target quran.
-                            let page: Page
-                            if sourceAyah.quran === quran {
-                                page = sourceAyah.page
-                            } else {
-                                let mapper = QuranPageMapper(destination: quran)
-                                guard let mappedAyah = mapper.mapAyah(sourceAyah) else {
-                                    return nil
-                                }
-                                page = mappedAyah.page
-                            }
-
-                            let createdOn = session.lastUpdated
-                            return LastPage(page: page, createdOn: createdOn, modifiedOn: createdOn)
+                        let mapped = sessions.compactMap { session in
+                            lastPage(for: session, quran: quran)
                         }
 
                         let sorted = mapped.sorted { $0.createdOn > $1.createdOn }
@@ -68,17 +50,96 @@
             let firstVerse = page.firstVerse
             let session = try await syncService.addReadingSession(
                 sura: Int32(firstVerse.sura.suraNumber),
-                ayah: Int32(firstVerse.ayah)
+                ayah: Int32(firstVerse.ayah),
+                timestamp: Date()
             )
+            updateState.setActive(localId: session.localId, page: page)
             return LastPage(page: page, createdOn: session.lastUpdated, modifiedOn: session.lastUpdated)
         }
 
         public func update(page: Page, toPage: Page) async throws -> LastPage {
-            try await add(page: toPage)
+            let sessions = try await readingSessions()
+            guard let session = readingSessionToUpdate(from: sessions, page: page) else {
+                return try await add(page: toPage)
+            }
+
+            if let targetSession = readingSession(for: toPage, in: sessions), targetSession.localId != session.localId {
+                updateState.setActive(localId: session.localId, page: toPage)
+                return LastPage(page: toPage, createdOn: session.lastUpdated, modifiedOn: session.lastUpdated)
+            }
+
+            let firstVerse = toPage.firstVerse
+            let updatedSession = try await syncService.updateReadingSession(
+                localId: session.localId,
+                sura: Int32(firstVerse.sura.suraNumber),
+                ayah: Int32(firstVerse.ayah),
+                timestamp: Date()
+            )
+            updateState.setActive(localId: updatedSession.localId, page: toPage)
+            return LastPage(page: toPage, createdOn: updatedSession.lastUpdated, modifiedOn: updatedSession.lastUpdated)
         }
 
         // MARK: Private
 
         private let syncService: SyncService
+        private let updateState = ReadingSessionUpdateState()
+
+        private func readingSessions() async throws -> [ReadingSession] {
+            var iterator = syncService.readingSessionsSequence().makeAsyncIterator()
+            return try await iterator.next() ?? []
+        }
+
+        private func readingSessionToUpdate(from sessions: [ReadingSession], page: Page) -> ReadingSession? {
+            if let activeLocalId = updateState.activeLocalId(for: page),
+               let activeSession = sessions.first(where: { $0.localId == activeLocalId })
+            {
+                return activeSession
+            }
+            return readingSession(for: page, in: sessions)
+        }
+
+        private func readingSession(for page: Page, in sessions: [ReadingSession]) -> ReadingSession? {
+            sessions.first { session in
+                lastPage(for: session, quran: page.quran)?.page == page
+            }
+        }
+
+        private func lastPage(for session: ReadingSession, quran: Quran) -> LastPage? {
+            guard let sourceAyah = AyahNumber(quran: quran, sura: Int(session.sura), ayah: Int(session.ayah)) else {
+                return nil
+            }
+
+            let page: Page
+            if sourceAyah.quran === quran {
+                page = sourceAyah.page
+            } else {
+                let mapper = QuranPageMapper(destination: quran)
+                guard let mappedAyah = mapper.mapAyah(sourceAyah) else {
+                    return nil
+                }
+                page = mappedAyah.page
+            }
+
+            return LastPage(page: page, createdOn: session.lastUpdated, modifiedOn: session.lastUpdated)
+        }
+    }
+
+    private final class ReadingSessionUpdateState: @unchecked Sendable {
+        func activeLocalId(for page: Page) -> String? {
+            lock.withLock {
+                activePage == page ? activeLocalId : nil
+            }
+        }
+
+        func setActive(localId: String, page: Page) {
+            lock.withLock {
+                activeLocalId = localId
+                activePage = page
+            }
+        }
+
+        private let lock = NSLock()
+        private var activeLocalId: String?
+        private var activePage: Page?
     }
 #endif

--- a/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
@@ -53,56 +53,27 @@
                 ayah: Int32(firstVerse.ayah),
                 timestamp: Date()
             )
-            updateState.setActive(localId: session.localId, page: page)
-            return LastPage(page: page, createdOn: session.lastUpdated, modifiedOn: session.lastUpdated)
+            return lastPage(page: page, for: session)
         }
 
-        public func update(page: Page, toPage: Page) async throws -> LastPage {
-            let sessions = try await readingSessions()
-            guard let session = readingSessionToUpdate(from: sessions, page: page) else {
+        public func update(lastPage: LastPage, toPage: Page) async throws -> LastPage {
+            guard let localId = lastPage.localId else {
                 return try await add(page: toPage)
-            }
-
-            if let targetSession = readingSession(for: toPage, in: sessions), targetSession.localId != session.localId {
-                updateState.setActive(localId: session.localId, page: toPage)
-                return LastPage(page: toPage, createdOn: session.lastUpdated, modifiedOn: session.lastUpdated)
             }
 
             let firstVerse = toPage.firstVerse
             let updatedSession = try await syncService.updateReadingSession(
-                localId: session.localId,
+                localId: localId,
                 sura: Int32(firstVerse.sura.suraNumber),
                 ayah: Int32(firstVerse.ayah),
                 timestamp: Date()
             )
-            updateState.setActive(localId: updatedSession.localId, page: toPage)
-            return LastPage(page: toPage, createdOn: updatedSession.lastUpdated, modifiedOn: updatedSession.lastUpdated)
+            return self.lastPage(page: toPage, for: updatedSession)
         }
 
         // MARK: Private
 
         private let syncService: SyncService
-        private let updateState = ReadingSessionUpdateState()
-
-        private func readingSessions() async throws -> [ReadingSession] {
-            var iterator = syncService.readingSessionsSequence().makeAsyncIterator()
-            return try await iterator.next() ?? []
-        }
-
-        private func readingSessionToUpdate(from sessions: [ReadingSession], page: Page) -> ReadingSession? {
-            if let activeLocalId = updateState.activeLocalId(for: page),
-               let activeSession = sessions.first(where: { $0.localId == activeLocalId })
-            {
-                return activeSession
-            }
-            return readingSession(for: page, in: sessions)
-        }
-
-        private func readingSession(for page: Page, in sessions: [ReadingSession]) -> ReadingSession? {
-            sessions.first { session in
-                lastPage(for: session, quran: page.quran)?.page == page
-            }
-        }
 
         private func lastPage(for session: ReadingSession, quran: Quran) -> LastPage? {
             guard let sourceAyah = AyahNumber(quran: quran, sura: Int(session.sura), ayah: Int(session.ayah)) else {
@@ -120,26 +91,16 @@
                 page = mappedAyah.page
             }
 
-            return LastPage(page: page, createdOn: session.lastUpdated, modifiedOn: session.lastUpdated)
-        }
-    }
-
-    private final class ReadingSessionUpdateState: @unchecked Sendable {
-        func activeLocalId(for page: Page) -> String? {
-            lock.withLock {
-                activePage == page ? activeLocalId : nil
-            }
+            return lastPage(page: page, for: session)
         }
 
-        func setActive(localId: String, page: Page) {
-            lock.withLock {
-                activeLocalId = localId
-                activePage = page
-            }
+        private func lastPage(page: Page, for session: ReadingSession) -> LastPage {
+            LastPage(
+                page: page,
+                createdOn: session.lastUpdated,
+                modifiedOn: session.lastUpdated,
+                localId: session.localId
+            )
         }
-
-        private let lock = NSLock()
-        private var activeLocalId: String?
-        private var activePage: Page?
     }
 #endif

--- a/Domain/AnnotationsService/Sources/PersistenceLastPageService.swift
+++ b/Domain/AnnotationsService/Sources/PersistenceLastPageService.swift
@@ -42,8 +42,8 @@ public struct PersistenceLastPageService: LastPageService {
         return try lastPage(quran: page.quran, persistenceModel)
     }
 
-    public func update(page: Page, toPage: Page) async throws -> LastPage {
-        let currentStoredPage = try storedPage(for: page)
+    public func update(lastPage currentLastPage: LastPage, toPage: Page) async throws -> LastPage {
+        let currentStoredPage = try storedPage(for: currentLastPage.page)
         let storedToPage = try storedPage(for: toPage)
         let persistenceModel = try await persistence.update(
             page: currentStoredPage.pageNumber,

--- a/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
+++ b/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
@@ -22,7 +22,9 @@ final class LastPageUpdaterTests: XCTestCase {
         let service = LastPageServiceSpy()
         let sut = LastPageUpdater(service: service)
 
-        sut.configure(initialPage: quran.pages[1], lastPage: quran.pages[0])
+        let lastPage = LastPage(page: quran.pages[0], createdOn: Date(), modifiedOn: Date())
+
+        sut.configure(initialPage: quran.pages[1], lastPage: lastPage)
 
         await waitUntil { service.updateCalls.first?.page == self.quran.pages[0] }
         XCTAssertEqual(service.updateCalls.first?.page, quran.pages[0])
@@ -69,9 +71,9 @@ private final class LastPageServiceSpy: LastPageService {
         return LastPage(page: page, createdOn: Date(), modifiedOn: Date())
     }
 
-    func update(page: Page, toPage: Page) async throws -> LastPage {
+    func update(lastPage: LastPage, toPage: Page) async throws -> LastPage {
         updateCallCount += 1
-        updateCalls.append(UpdateCall(page: page, toPage: toPage))
+        updateCalls.append(UpdateCall(page: lastPage.page, toPage: toPage))
         return LastPage(page: toPage, createdOn: Date(), modifiedOn: Date())
     }
 }

--- a/Domain/AnnotationsService/Tests/PageMappingServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/PageMappingServiceTests.swift
@@ -115,7 +115,8 @@ final class PageMappingServiceTests: XCTestCase {
         let service = PersistenceLastPageService(persistence: persistence)
         let quran = skippedPageQuran()
 
-        let lastPage = try await service.update(page: quran.pages[0], toPage: quran.pages[1])
+        let currentLastPage = LastPage(page: quran.pages[0], createdOn: date, modifiedOn: date)
+        let lastPage = try await service.update(lastPage: currentLastPage, toPage: quran.pages[1])
 
         XCTAssertEqual(persistence.updates, [LastPagePersistenceFake.Update(page: 1, toPage: 2)])
         XCTAssertEqual(lastPage.page.pageNumber, 3)

--- a/Features/AppStructureFeature/Common/TabInteractor.swift
+++ b/Features/AppStructureFeature/Common/TabInteractor.swift
@@ -7,6 +7,7 @@
 //
 
 import FeaturesSupport
+import QuranAnnotations
 import QuranContentFeature
 import QuranKit
 import QuranViewFeature
@@ -26,7 +27,7 @@ class TabInteractor: QuranNavigator {
 
     weak var presenter: TabPresenter?
 
-    func navigateTo(page: Page, lastPage: Page?, highlightingSearchAyah: AyahNumber?) {
+    func navigateTo(page: Page, lastPage: LastPage?, highlightingSearchAyah: AyahNumber?) {
         let input = QuranInput(initialPage: page, lastPage: lastPage, highlightingSearchAyah: highlightingSearchAyah)
         let viewController = quranBuilder.build(input: input)
         presenter?.pushViewController(viewController, animated: true)

--- a/Features/FeaturesSupport/QuranNavigator.swift
+++ b/Features/FeaturesSupport/QuranNavigator.swift
@@ -5,9 +5,10 @@
 //  Created by Mohamed Afifi on 2023-06-19.
 //
 
+import QuranAnnotations
 import QuranKit
 
 @MainActor
 public protocol QuranNavigator: AnyObject {
-    func navigateTo(page: Page, lastPage: Page?, highlightingSearchAyah: AyahNumber?)
+    func navigateTo(page: Page, lastPage: LastPage?, highlightingSearchAyah: AyahNumber?)
 }

--- a/Features/HomeFeature/HomeBuilder.swift
+++ b/Features/HomeFeature/HomeBuilder.swift
@@ -32,7 +32,7 @@ public struct HomeBuilder {
             lastPageService: container.lastPageService(),
             textRetriever: textRetriever,
             navigateToPage: { [weak listener] lastPage in
-                listener?.navigateTo(page: lastPage, lastPage: lastPage, highlightingSearchAyah: nil)
+                listener?.navigateTo(page: lastPage.page, lastPage: lastPage, highlightingSearchAyah: nil)
             },
             navigateToSura: { [weak listener] sura in
                 listener?.navigateTo(page: sura.page, lastPage: nil, highlightingSearchAyah: nil)

--- a/Features/HomeFeature/HomeView.swift
+++ b/Features/HomeFeature/HomeView.swift
@@ -40,7 +40,7 @@ private struct HomeViewUI: View {
 
     let start: AsyncAction
 
-    let selectLastPage: ItemAction<Page>
+    let selectLastPage: ItemAction<LastPage>
     let selectSura: ItemAction<Sura>
     let selectQuarter: ItemAction<QuarterItem>
     let surahSortOrder: SurahSortOrder
@@ -75,7 +75,7 @@ private struct HomeViewUI: View {
             subtitle: .init(text: lastPage.createdOn.timeAgo(), location: .bottom),
             accessory: .text(NumberFormatter.shared.format(lastPage.page.pageNumber))
         ) {
-            selectLastPage(lastPage.page)
+            selectLastPage(lastPage)
         }
     }
 

--- a/Features/HomeFeature/HomeViewModel.swift
+++ b/Features/HomeFeature/HomeViewModel.swift
@@ -34,7 +34,7 @@ final class HomeViewModel: ObservableObject {
     init(
         lastPageService: any LastPageService,
         textRetriever: QuranTextDataService,
-        navigateToPage: @escaping (Page) -> Void,
+        navigateToPage: @escaping (LastPage) -> Void,
         navigateToSura: @escaping (Sura) -> Void,
         navigateToQuarter: @escaping (Quarter) -> Void
     ) {
@@ -83,7 +83,7 @@ final class HomeViewModel: ObservableObject {
         _ = await [lastPages, suras, quarters]
     }
 
-    func navigateTo(_ lastPage: Page) {
+    func navigateTo(_ lastPage: LastPage) {
         navigateToPage(lastPage)
     }
 
@@ -103,7 +103,7 @@ final class HomeViewModel: ObservableObject {
 
     private let lastPageService: any LastPageService
     private let textRetriever: QuranTextDataService
-    private let navigateToPage: (Page) -> Void
+    private let navigateToPage: (LastPage) -> Void
     private let navigateToSura: (Sura) -> Void
     private let navigateToQuarter: (Quarter) -> Void
     private let readingPreferences = ReadingPreferences.shared

--- a/Features/QuranContentFeature/QuranInput.swift
+++ b/Features/QuranContentFeature/QuranInput.swift
@@ -6,12 +6,13 @@
 //  Copyright © 2019 Quran.com. All rights reserved.
 //
 
+import QuranAnnotations
 import QuranKit
 
 public struct QuranInput {
     // MARK: Lifecycle
 
-    public init(initialPage: Page, lastPage: Page?, highlightingSearchAyah: AyahNumber?) {
+    public init(initialPage: Page, lastPage: LastPage?, highlightingSearchAyah: AyahNumber?) {
         self.initialPage = initialPage
         self.lastPage = lastPage
         self.highlightingSearchAyah = highlightingSearchAyah
@@ -20,6 +21,6 @@ public struct QuranInput {
     // MARK: Public
 
     public let initialPage: Page
-    public let lastPage: Page?
+    public let lastPage: LastPage?
     public let highlightingSearchAyah: AyahNumber?
 }

--- a/Model/QuranAnnotations/LastPage.swift
+++ b/Model/QuranAnnotations/LastPage.swift
@@ -11,10 +11,11 @@ import QuranKit
 public struct LastPage: Equatable, Identifiable {
     // MARK: Lifecycle
 
-    public init(page: Page, createdOn: Date, modifiedOn: Date) {
+    public init(page: Page, createdOn: Date, modifiedOn: Date, localId: String? = nil) {
         self.page = page
         self.createdOn = createdOn
         self.modifiedOn = modifiedOn
+        self.localId = localId
     }
 
     // MARK: Public
@@ -22,6 +23,7 @@ public struct LastPage: Equatable, Identifiable {
     public var page: Page
     public var createdOn: Date
     public var modifiedOn: Date
+    public var localId: String?
 
     public var id: Page { page }
 }


### PR DESCRIPTION
## Summary
- Update the active Mobile Sync reading session by `localId` when swiping pages.
- Send explicit timestamps through the new Mobile Sync API.
- Avoid adding/reordering unrelated recent reading sessions.

## Validation
- `QURAN_SYNC=1 xcodebuild -project Example/QuranEngineApp.xcodeproj -scheme QuranEngineApp -destination 'generic/platform=iOS Simulator' build`
- Previously validated on simulator with Maestro: selected session changed to latest page while the other sessions stayed unchanged.


https://github.com/user-attachments/assets/2e80d2a0-d76b-4a59-9e3d-7a255a8f988c

