### PR TITLE
Add Mobile Sync notes service

### DIFF
--- a/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
@@ -1,0 +1,158 @@
+#if QURAN_SYNC
+    //
+    //  MobileSyncNoteService.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import Analytics
+    import Foundation
+    @preconcurrency import MobileSync
+    import QuranKit
+    import QuranTextKit
+
+    public struct SyncedNote: Equatable, Identifiable, Sendable {
+        public let localId: String
+        public let body: String
+        public let verses: [AyahNumber]
+        public let modifiedDate: Date
+
+        public var id: String { localId }
+
+        public var firstVerse: AyahNumber { verses[0] }
+    }
+
+    public struct SyncedNotesSequence: AsyncSequence {
+        public typealias Element = [SyncedNote]
+
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
+                var iterator = sequence.makeAsyncIterator()
+                nextValue = {
+                    try await iterator.next()
+                }
+            }
+
+            public mutating func next() async throws -> Element? {
+                try await nextValue()
+            }
+
+            private let nextValue: () async throws -> Element?
+        }
+
+        init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
+            makeIterator = {
+                AsyncIterator(sequence)
+            }
+        }
+
+        public func makeAsyncIterator() -> AsyncIterator {
+            makeIterator()
+        }
+
+        private let makeIterator: () -> AsyncIterator
+    }
+
+    public struct MobileSyncNoteService: @unchecked Sendable {
+        // MARK: Lifecycle
+
+        public init(syncService: SyncService, textService: QuranTextDataService, analytics: AnalyticsLibrary) {
+            self.syncService = syncService
+            self.textService = textService
+            self.analytics = analytics
+        }
+
+        // MARK: Public
+
+        public static let minimumBodyLength = 6
+
+        public func notesSequence(quran: Quran) -> SyncedNotesSequence {
+            let sequence = syncService.notesSequence()
+                .map { notes in
+                    Self.notes(from: notes, quran: quran)
+                }
+            return SyncedNotesSequence(sequence)
+        }
+
+        public func createNote(body: String, verses: [AyahNumber]) async throws {
+            guard let range = versesRange(verses) else {
+                return
+            }
+
+            analytics.updateNote(verses: Set(verses))
+            try await syncService.createNote(
+                body: body,
+                startSura: Int32(range.start.sura.suraNumber),
+                startAyah: Int32(range.start.ayah),
+                endSura: Int32(range.end.sura.suraNumber),
+                endAyah: Int32(range.end.ayah)
+            )
+        }
+
+        public func updateNote(_ note: SyncedNote, body: String) async throws {
+            guard let range = versesRange(note.verses) else {
+                return
+            }
+
+            analytics.updateNote(verses: Set(note.verses))
+            try await syncService.updateNote(
+                localId: note.localId,
+                body: body,
+                startSura: Int32(range.start.sura.suraNumber),
+                startAyah: Int32(range.start.ayah),
+                endSura: Int32(range.end.sura.suraNumber),
+                endAyah: Int32(range.end.ayah)
+            )
+        }
+
+        public func removeNote(_ note: SyncedNote) async throws {
+            try await syncService.removeNote(localId: note.localId)
+        }
+
+        public func textForVerses(_ verses: [AyahNumber]) async throws -> String {
+            let verseTexts = try await textService.textForVerses(verses, translations: [])
+            return verses.sorted()
+                .compactMap { verse in
+                    verseTexts[verse].map { $0.arabicText + " \(NumberFormatter.arabicNumberFormatter.format(verse.ayah))" }
+                }
+                .joined(separator: " ")
+        }
+
+        // MARK: Internal
+
+        static func notes(from notes: [Note_], quran: Quran) -> [SyncedNote] {
+            notes.compactMap { note(from: $0, quran: quran) }
+                .sorted { $0.modifiedDate > $1.modifiedDate }
+        }
+
+        static func note(from note: Note_, quran: Quran) -> SyncedNote? {
+            guard let start = AyahNumber(quran: quran, sura: Int(note.startSura), ayah: Int(note.startAyah)),
+                  let end = AyahNumber(quran: quran, sura: Int(note.endSura), ayah: Int(note.endAyah)),
+                  start <= end
+            else {
+                return nil
+            }
+
+            return SyncedNote(
+                localId: note.localId,
+                body: note.body,
+                verses: start.array(to: end),
+                modifiedDate: note.lastUpdated
+            )
+        }
+
+        // MARK: Private
+
+        private let syncService: SyncService
+        private let textService: QuranTextDataService
+        private let analytics: AnalyticsLibrary
+
+        private func versesRange(_ verses: [AyahNumber]) -> (start: AyahNumber, end: AyahNumber)? {
+            let verses = verses.sorted()
+            guard let start = verses.first, let end = verses.last else {
+                return nil
+            }
+            return (start, end)
+        }
+    }
+#endif

--- a/Domain/AnnotationsService/Tests/MobileSyncNoteServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncNoteServiceTests.swift
@@ -1,0 +1,51 @@
+#if QURAN_SYNC
+    import MobileSync
+    import QuranKit
+    import XCTest
+    @testable import AnnotationsService
+
+    final class MobileSyncNoteServiceTests: XCTestCase {
+        func test_notes_mapsContinuousRange() {
+            let notes = MobileSyncNoteService.notes(from: [
+                Note_(
+                    body: "Remember this",
+                    startSura: 1,
+                    startAyah: 1,
+                    endSura: 1,
+                    endAyah: 2,
+                    lastUpdated: .distantPast,
+                    localId: "note-1"
+                ),
+            ], quran: .hafsMadani1405)
+
+            XCTAssertEqual(notes.count, 1)
+            XCTAssertEqual(notes[0].localId, "note-1")
+            XCTAssertEqual(notes[0].body, "Remember this")
+            XCTAssertEqual(notes[0].verses, [
+                AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!,
+                AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 2)!,
+            ])
+        }
+
+        func test_notes_keepsMultipleNotesForSameAyah() {
+            let notes = MobileSyncNoteService.notes(from: [
+                note(localId: "note-1", body: "First"),
+                note(localId: "note-2", body: "Second"),
+            ], quran: .hafsMadani1405)
+
+            XCTAssertEqual(Set(notes.map(\.localId)), ["note-1", "note-2"])
+        }
+
+        private static func note(localId: String, body: String) -> Note_ {
+            Note_(
+                body: body,
+                startSura: 1,
+                startAyah: 1,
+                endSura: 1,
+                endAyah: 1,
+                lastUpdated: .distantPast,
+                localId: localId
+            )
+        }
+    }
+#endif


### PR DESCRIPTION
## Summary
- Add a small sync-backed note service for Mobile Sync notes.
- Support create/update/delete by concrete sync note id.
- Keep note colors out of the sync note data path.

## Scope
- Data/service layer only.
- No note editor UI changes.
- No notes list UI changes.
- No legacy CoreData note behavior changes.

## Notes
- This is stacked on the synced ayah bookmark menu branch only for current feature context.
- UI behavior is intentionally left to the next PR.

## Validation
- Sync package build was checked locally during implementation.