### PR TITLE
Add sync notes UI flow

### DIFF
--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -273,3 +273,5 @@
 "ayah-bookmark.remove-reading-bookmark" = "إزالة علامة القراءة";
 "ayah-bookmark.collection-picker.no-data.title" = "لا توجد مجموعات بعد";
 "ayah-bookmark.collection-picker.no-data.text" = "أضف مجموعة لحفظ هذه الآية.";
+"notes.minimum-length.alert.title" = "الملاحظة قصيرة جدًا";
+"notes.minimum-length.alert.body" = "يجب أن تكون الملاحظة %d أحرف على الأقل.";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -293,3 +293,5 @@
 "ayah-bookmark.remove-reading-bookmark" = "Remove Reading Bookmark";
 "ayah-bookmark.collection-picker.no-data.title" = "No collections yet";
 "ayah-bookmark.collection-picker.no-data.text" = "Add a collection to save this verse.";
+"notes.minimum-length.alert.title" = "Note is too short";
+"notes.minimum-length.alert.body" = "Notes must be at least %d characters.";

--- a/Features/AppDependencies/AppDependencies.swift
+++ b/Features/AppDependencies/AppDependencies.swift
@@ -74,4 +74,16 @@ extension AppDependencies {
             analytics: analytics
         )
     }
+
+    #if QURAN_SYNC
+        public func mobileSyncNoteService() -> MobileSyncNoteService? {
+            syncService.map {
+                MobileSyncNoteService(
+                    syncService: $0,
+                    textService: textDataService(),
+                    analytics: analytics
+                )
+            }
+        }
+    #endif
 }

--- a/Features/AyahMenuFeature/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/AyahMenuBuilder.swift
@@ -91,7 +91,8 @@ public struct AyahMenuBuilder {
                 textRetriever: textRetriever,
                 highlightColor: input.highlightColor,
                 isCollectionBookmarked: input.isCollectionBookmarked,
-                ayahBookmarkCollectionService: container.syncService.map { AyahBookmarkCollectionService(syncService: $0) }
+                ayahBookmarkCollectionService: container.syncService.map { AyahBookmarkCollectionService(syncService: $0) },
+                usesSyncedNotes: container.mobileSyncNoteService() != nil
             )
         #else
             let deps = AyahMenuViewModel.Deps(

--- a/Features/AyahMenuFeature/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewController.swift
@@ -55,7 +55,8 @@ final class AyahMenuViewController: UIViewController {
             actions: actions,
             isTranslationView: viewModel.isTranslationView,
             usesCollectionBookmarks: viewModel.usesCollectionBookmarks,
-            isCollectionBookmarked: viewModel.isCollectionBookmarked
+            isCollectionBookmarked: viewModel.isCollectionBookmarked,
+            usesSyncedNotesIcon: viewModel.usesSyncedNotesIcon
         )
         showAyahMenu(dataObject)
     }

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -121,6 +121,14 @@ final class AyahMenuViewModel {
         #endif
     }
 
+    var usesSyncedNotesIcon: Bool {
+        #if QURAN_SYNC
+            return deps.usesSyncedNotes
+        #else
+            return false
+        #endif
+    }
+
     var noteState: AyahMenuUI.NoteState {
         #if QURAN_SYNC
             if deps.usesSyncedNotes {

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -34,6 +34,7 @@ public protocol AyahMenuListener: AnyObject {
     #if QURAN_SYNC
         func saveVersesAsBookmark(_ verses: [AyahNumber])
         func removeVersesFromBookmarkCollections(_ verses: [AyahNumber]) async
+        func addSyncedNote(verses: [AyahNumber])
     #endif
 
     func editNote(_ note: QuranAnnotations.Note)
@@ -54,6 +55,7 @@ final class AyahMenuViewModel {
         #if QURAN_SYNC
             let isCollectionBookmarked: Bool
             let ayahBookmarkCollectionService: AyahBookmarkCollectionService?
+            let usesSyncedNotes: Bool
         #endif
         let quranContentStatePreferences = QuranContentStatePreferences.shared
     }
@@ -120,6 +122,11 @@ final class AyahMenuViewModel {
     }
 
     var noteState: AyahMenuUI.NoteState {
+        #if QURAN_SYNC
+            if deps.usesSyncedNotes {
+                return .noHighlight
+            }
+        #endif
         if deps.highlightColor != nil {
             return containsText(deps.notes) ? .noted : .highlighted
         }
@@ -168,6 +175,12 @@ final class AyahMenuViewModel {
 
     func editNote() async {
         logger.info("AyahMenu: edit notes. Verses: \(deps.verses)")
+        #if QURAN_SYNC
+            if deps.usesSyncedNotes {
+                listener?.addSyncedNote(verses: deps.verses)
+                return
+            }
+        #endif
         let notes = deps.notes
         let color = highlightColor(for: deps.noteService.color(from: notes))
         if let note = await updateLegacyHighlight(color: color) {

--- a/Features/NoteEditorFeature/NoteEditorBuilder.swift
+++ b/Features/NoteEditorFeature/NoteEditorBuilder.swift
@@ -6,8 +6,10 @@
 //  Copyright © 2020 Quran.com. All rights reserved.
 //
 
+import AnnotationsService
 import AppDependencies
 import QuranAnnotations
+import QuranKit
 import UIKit
 
 @MainActor
@@ -32,3 +34,29 @@ public struct NoteEditorBuilder {
 
     let container: AppDependencies
 }
+
+#if QURAN_SYNC
+    @MainActor
+    public struct SyncedNoteEditorBuilder {
+        public init(noteService: MobileSyncNoteService) {
+            self.noteService = noteService
+        }
+
+        public func build(withListener listener: NoteEditorListener, note: SyncedNote) -> UIViewController {
+            build(withListener: listener, mode: .edit(note))
+        }
+
+        public func build(withListener listener: NoteEditorListener, verses: [AyahNumber]) -> UIViewController {
+            build(withListener: listener, mode: .create(verses: verses))
+        }
+
+        private let noteService: MobileSyncNoteService
+
+        private func build(withListener listener: NoteEditorListener, mode: SyncedNoteEditorInteractor.Mode) -> UIViewController {
+            let viewModel = SyncedNoteEditorInteractor(noteService: noteService, mode: mode)
+            let viewController = SyncedNoteEditorViewController(viewModel: viewModel)
+            viewModel.listener = listener
+            return viewController
+        }
+    }
+#endif

--- a/Features/NoteEditorFeature/SyncedNoteEditorInteractor.swift
+++ b/Features/NoteEditorFeature/SyncedNoteEditorInteractor.swift
@@ -1,0 +1,125 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNoteEditorInteractor.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import AnnotationsService
+    import Crashing
+    import Foundation
+    import NoorUI
+    import QuranAnnotations
+    import QuranKit
+    import VLogging
+
+    @MainActor
+    final class SyncedNoteEditorInteractor {
+        // MARK: Lifecycle
+
+        init(noteService: MobileSyncNoteService, mode: Mode) {
+            self.noteService = noteService
+            self.mode = mode
+        }
+
+        // MARK: Internal
+
+        enum Mode {
+            case create(verses: [AyahNumber])
+            case edit(SyncedNote)
+        }
+
+        weak var listener: NoteEditorListener?
+
+        var minimumNoteBodyLength: Int { MobileSyncNoteService.minimumBodyLength }
+
+        var isEditedNote: Bool {
+            !(editableNote?.note ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        var canSubmitNote: Bool {
+            let text = (editableNote?.note ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            return !text.isEmpty && text.count >= minimumNoteBodyLength
+        }
+
+        func fetchNote() async throws -> EditableNote {
+            do {
+                let versesText = try await noteService.textForVerses(verses)
+                let editableNote = EditableNote(
+                    ayahText: versesText,
+                    modifiedSince: modifiedSince,
+                    selectedColor: .red,
+                    note: body
+                )
+                self.editableNote = editableNote
+                return editableNote
+            } catch {
+                crasher.recordError(error, reason: "Failed to retrieve synced note text")
+                throw error
+            }
+        }
+
+        func commitEditsAndExit() async {
+            logger.info("SyncedNoteEditor: done tapped")
+            do {
+                let body = editableNote?.note ?? body
+                switch mode {
+                case .create:
+                    try await noteService.createNote(body: body, verses: verses)
+                case .edit(let note):
+                    try await noteService.updateNote(note, body: body)
+                }
+                listener?.dismissNoteEditor()
+            } catch {
+                crasher.recordError(error, reason: "Failed to save synced note")
+            }
+        }
+
+        func forceDelete() async {
+            guard case .edit(let note) = mode else {
+                listener?.dismissNoteEditor()
+                return
+            }
+
+            do {
+                try await noteService.removeNote(note)
+                listener?.dismissNoteEditor()
+            } catch {
+                crasher.recordError(error, reason: "Failed to delete synced note")
+            }
+        }
+
+        // MARK: Private
+
+        private let noteService: MobileSyncNoteService
+        private let mode: Mode
+        private var editableNote: EditableNote?
+
+        private var verses: [AyahNumber] {
+            switch mode {
+            case .create(let verses):
+                return verses
+            case .edit(let note):
+                return note.verses
+            }
+        }
+
+        private var body: String {
+            switch mode {
+            case .create:
+                return ""
+            case .edit(let note):
+                return note.body
+            }
+        }
+
+        private var modifiedSince: String {
+            switch mode {
+            case .create:
+                return ""
+            case .edit(let note):
+                return note.modifiedDate.timeAgo()
+            }
+        }
+    }
+#endif

--- a/Features/NoteEditorFeature/SyncedNoteEditorViewController.swift
+++ b/Features/NoteEditorFeature/SyncedNoteEditorViewController.swift
@@ -1,0 +1,118 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNoteEditorViewController.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import Combine
+    import NoorUI
+    import SwiftUI
+    import UIKit
+    import VLogging
+
+    final class SyncedNoteEditorViewController: BaseViewController, UIAdaptivePresentationControllerDelegate {
+        // MARK: Lifecycle
+
+        init(viewModel: SyncedNoteEditorInteractor) {
+            self.viewModel = viewModel
+            super.init(nibName: nil, bundle: nil)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        // MARK: Internal
+
+        override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+            traitCollection.userInterfaceIdiom == .pad ? .all : .portrait
+        }
+
+        override func viewDidLoad() {
+            super.viewDidLoad()
+
+            presentationController?.delegate = self
+
+            Task {
+                do {
+                    let note = try await viewModel.fetchNote()
+                    setNote(note)
+                } catch {
+                    showErrorAlert(error: error)
+                }
+            }
+        }
+
+        func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {}
+
+        // MARK: Private
+
+        private let viewModel: SyncedNoteEditorInteractor
+        private var doneButton: UIBarButtonItem?
+        private var cancellables: Set<AnyCancellable> = []
+
+        private func setNote(_ note: EditableNote) {
+            let noteEditor = NoteEditorView(
+                note: note,
+                showsColors: false,
+                done: { [weak self] in self?.doneTapped() },
+                delete: { [weak self] in await self?.delete() }
+            )
+            let viewController = UIHostingController(rootView: noteEditor)
+            let navigationController = buildNavigationController(rootViewController: viewController, note: note)
+            bindDoneButton(to: note)
+            addFullScreenChild(navigationController)
+        }
+
+        private func buildNavigationController(rootViewController: UIViewController, note: EditableNote) -> UINavigationController {
+            let modifiedText = UIBarButtonItem(title: note.modifiedSince, style: .plain, target: nil, action: nil)
+            modifiedText.isEnabled = false
+            let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneTapped))
+
+            rootViewController.navigationItem.largeTitleDisplayMode = .never
+            rootViewController.navigationItem.leftBarButtonItem = modifiedText
+            rootViewController.navigationItem.rightBarButtonItem = doneButton
+            self.doneButton = doneButton
+
+            return UINavigationController(rootViewController: rootViewController)
+        }
+
+        private func bindDoneButton(to note: EditableNote) {
+            updateDoneButton(text: note.note)
+            note.notePublisher
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] text in self?.updateDoneButton(text: text) }
+                .store(in: &cancellables)
+        }
+
+        private func updateDoneButton(text: String) {
+            doneButton?.isEnabled = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        @objc
+        private func doneTapped() {
+            guard viewModel.canSubmitNote else {
+                showNoteMinimumLengthAlert(minimumLength: viewModel.minimumNoteBodyLength)
+                return
+            }
+
+            Task {
+                await viewModel.commitEditsAndExit()
+            }
+        }
+
+        private func delete() async {
+            logger.info("SyncedNoteEditor: delete note")
+            if viewModel.isEditedNote {
+                confirmNoteDelete(
+                    delete: { await self.viewModel.forceDelete() },
+                    cancel: { }
+                )
+            } else {
+                await viewModel.forceDelete()
+            }
+        }
+    }
+#endif

--- a/Features/NotesFeature/NotesBuilder.swift
+++ b/Features/NotesFeature/NotesBuilder.swift
@@ -8,6 +8,9 @@
 
 import AppDependencies
 import FeaturesSupport
+#if QURAN_SYNC
+    import NoteEditorFeature
+#endif
 import QuranKit
 import QuranTextKit
 import UIKit
@@ -23,6 +26,17 @@ public struct NotesBuilder {
     // MARK: Public
 
     public func build(withListener listener: QuranNavigator) -> UIViewController {
+        #if QURAN_SYNC
+            if let noteService = container.mobileSyncNoteService() {
+                let viewModel = SyncedNotesViewModel(noteService: noteService)
+                let viewController = SyncedNotesViewController(
+                    viewModel: viewModel,
+                    noteEditorBuilder: SyncedNoteEditorBuilder(noteService: noteService)
+                )
+                return viewController
+            }
+        #endif
+
         let textRetriever = ShareableVerseTextRetriever(
             databasesURL: container.databasesURL,
             quranFileURL: container.quranUthmaniV2Database

--- a/Features/NotesFeature/SyncedNoteItem.swift
+++ b/Features/NotesFeature/SyncedNoteItem.swift
@@ -1,0 +1,16 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNoteItem.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import AnnotationsService
+
+    struct SyncedNoteItem: Equatable, Identifiable {
+        let note: SyncedNote
+        let verseText: String
+
+        var id: String { note.id }
+    }
+#endif

--- a/Features/NotesFeature/SyncedNotesView.swift
+++ b/Features/NotesFeature/SyncedNotesView.swift
@@ -1,0 +1,134 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNotesView.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import Localization
+    import NoorUI
+    import QuranKit
+    import SwiftUI
+    import UIx
+
+    struct SyncedNotesView: View {
+        @StateObject var viewModel: SyncedNotesViewModel
+        let selectAction: ItemAction<SyncedNoteItem>
+
+        var body: some View {
+            SyncedNotesViewUI(
+                editMode: $viewModel.editMode,
+                error: $viewModel.error,
+                notes: viewModel.filteredNotes,
+                searchTerm: viewModel.searchTerm,
+                start: { await viewModel.start() },
+                selectAction: selectAction,
+                deleteAction: { await viewModel.deleteItem($0) }
+            )
+        }
+    }
+
+    private struct SyncedNotesViewUI: View {
+        // MARK: Internal
+
+        @Binding var editMode: EditMode
+        @Binding var error: Error?
+
+        let notes: [SyncedNoteItem]
+        let searchTerm: String
+        let start: AsyncAction
+        let selectAction: ItemAction<SyncedNoteItem>
+        let deleteAction: AsyncItemAction<SyncedNoteItem>
+
+        var body: some View {
+            Group {
+                if notes.isEmpty {
+                    if isSearching {
+                        noResults
+                    } else {
+                        noData
+                    }
+                } else {
+                    NoorList {
+                        NoorSection(notes) { note in
+                            listItem(note)
+                        }
+                        .onDelete(action: deleteAction)
+                    }
+                }
+            }
+            .task { await start() }
+            .errorAlert(error: $error)
+            .environment(\.editMode, $editMode)
+        }
+
+        // MARK: Private
+
+        private var isSearching: Bool {
+            !searchTerm.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        private var noData: some View {
+            DataUnavailableView(
+                title: l("notes.no-data.title"),
+                text: l("notes.no-data.text"),
+                image: .note
+            )
+        }
+
+        private var noResults: some View {
+            DataUnavailableView(
+                title: lFormat("notes.search.no-results.title", searchTerm),
+                text: l("notes.search.no-results.text"),
+                image: .search
+            )
+        }
+
+        private func listItem(_ item: SyncedNoteItem) -> some View {
+            let note = item.note
+            let ayah = note.firstVerse
+            let page = ayah.page
+            let ayahCount = note.verses.count
+            let numberOfAyahs = ayahCount > 1 ? lFormat("notes.verses-count", ayahCount - 1) : ""
+            return NoorListItem(
+                subheading: subheadingText(
+                    localizedVerse: ayah.localizedName,
+                    arabicSuraName: ayah.sura.arabicSuraName,
+                    numberOfAyahs: numberOfAyahs
+                ),
+                rightPretitle: "\(verse: item.verseText, color: Color.clear, lineLimit: 2)",
+                title: titleText(for: note.body.trimmingCharacters(in: .whitespacesAndNewlines)),
+                subtitle: .init(text: note.modifiedDate.timeAgo(), location: .bottom),
+                accessory: .text(NumberFormatter.shared.format(page.pageNumber))
+            ) {
+                selectAction(item)
+            }
+        }
+
+        private func highlightRanges(in text: String) -> [HighlightingRange] {
+            let term = searchTerm.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !term.isEmpty,
+                  let range = text.range(of: term, options: .caseInsensitive)
+            else {
+                return []
+            }
+            return [HighlightingRange(range, fontWeight: .heavy)]
+        }
+
+        private func titleText(for noteText: String) -> MultipartText {
+            let ranges = highlightRanges(in: noteText)
+            if ranges.isEmpty {
+                return .text(noteText)
+            }
+            return "\(noteText, highlighting: ranges)"
+        }
+
+        private func subheadingText(localizedVerse: String, arabicSuraName: String, numberOfAyahs: String) -> MultipartText {
+            let ranges = highlightRanges(in: localizedVerse)
+            if ranges.isEmpty {
+                return "\(localizedVerse) \(sura: arabicSuraName) \(numberOfAyahs)"
+            }
+            return "\(localizedVerse, highlighting: ranges) \(sura: arabicSuraName) \(numberOfAyahs)"
+        }
+    }
+#endif

--- a/Features/NotesFeature/SyncedNotesViewController.swift
+++ b/Features/NotesFeature/SyncedNotesViewController.swift
@@ -1,0 +1,131 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNotesViewController.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import AnnotationsService
+    import Combine
+    import Localization
+    import NoteEditorFeature
+    import SwiftUI
+    import UIx
+    import VLogging
+
+    final class SyncedNotesViewController: UIHostingController<SyncedNotesView>, UISearchBarDelegate, NoteEditorListener {
+        // MARK: Lifecycle
+
+        init(viewModel: SyncedNotesViewModel, noteEditorBuilder: SyncedNoteEditorBuilder) {
+            self.viewModel = viewModel
+            self.noteEditorBuilder = noteEditorBuilder
+            super.init(rootView: SyncedNotesView(viewModel: viewModel, selectAction: { _ in }))
+            rootView = SyncedNotesView(viewModel: viewModel, selectAction: { [weak self] item in self?.editNote(item.note) })
+            initialize()
+        }
+
+        @available(*, unavailable)
+        @MainActor
+        dynamic required init?(coder aDecoder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        // MARK: Internal
+
+        override func viewDidLoad() {
+            super.viewDidLoad()
+
+            searchController.obscuresBackgroundDuringPresentation = false
+            searchController.hidesNavigationBarDuringPresentation = false
+            searchController.searchBar.placeholder = l("notes.search.placeholder.text")
+            searchController.searchBar.delegate = self
+            navigationItem.searchController = searchController
+            navigationItem.hidesSearchBarWhenScrolling = true
+            definesPresentationContext = true
+
+            viewModel.$searchTerm
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] term in
+                    guard let bar = self?.searchController.searchBar else { return }
+                    if bar.text != term {
+                        bar.text = term
+                    }
+                }
+                .store(in: &cancellables)
+        }
+
+        func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+            logger.info("[Notes] search textDidChange to \(searchText)")
+            viewModel.searchTerm = searchText
+        }
+
+        func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+            logger.info("[Notes] search cancel")
+            viewModel.searchTerm = ""
+        }
+
+        func dismissNoteEditor() {
+            dismiss(animated: true)
+        }
+
+        // MARK: Private
+
+        private var editController: EditController?
+        private let viewModel: SyncedNotesViewModel
+        private let noteEditorBuilder: SyncedNoteEditorBuilder
+        private let searchController = UISearchController(searchResultsController: nil)
+        private var cancellables: Set<AnyCancellable> = []
+
+        private var currentEditMode: EditMode? {
+            if viewModel.notes.isEmpty {
+                return nil
+            }
+            return viewModel.editMode
+        }
+
+        private func initialize() {
+            title = l("tab.notes")
+
+            editController = EditController(
+                navigationItem: navigationItem,
+                reload: viewModel.objectWillChange.eraseToAnyPublisher(),
+                editMode: Binding(
+                    get: { [weak self] in self?.currentEditMode },
+                    set: { [weak self] value in self?.viewModel.editMode = value ?? .inactive }
+                ),
+                customItems: [
+                    UIBarButtonItem(
+                        image: UIImage(systemName: "square.and.arrow.up"),
+                        style: .plain,
+                        target: self,
+                        action: #selector(shareAllNotes)
+                    ),
+                ]
+            )
+        }
+
+        private func editNote(_ note: SyncedNote) {
+            let viewController = noteEditorBuilder.build(withListener: self, note: note)
+            present(viewController, animated: true)
+        }
+
+        @objc
+        private func shareAllNotes() {
+            Task {
+                do {
+                    let notesText = try await viewModel.prepareNotesForSharing()
+                    let activityViewController = UIActivityViewController(activityItems: [notesText], applicationActivities: nil)
+                    let view = navigationController?.view
+                    let viewBound = view.map { CGRect(x: $0.bounds.midX, y: $0.bounds.midY, width: 0, height: 0) }
+                    activityViewController.modalPresentationStyle = .formSheet
+                    activityViewController.popoverPresentationController?.permittedArrowDirections = []
+                    activityViewController.popoverPresentationController?.sourceView = view
+                    activityViewController.popoverPresentationController?.sourceRect = viewBound ?? .zero
+                    present(activityViewController, animated: true)
+                } catch {
+                    showErrorAlert(error: error)
+                }
+            }
+        }
+    }
+#endif

--- a/Features/NotesFeature/SyncedNotesViewModel.swift
+++ b/Features/NotesFeature/SyncedNotesViewModel.swift
@@ -1,0 +1,105 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNotesViewModel.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import AnnotationsService
+    import Crashing
+    import Foundation
+    import Localization
+    import QuranKit
+    import ReadingService
+    import SwiftUI
+    import Utilities
+    import VLogging
+
+    @MainActor
+    final class SyncedNotesViewModel: ObservableObject {
+        // MARK: Lifecycle
+
+        init(noteService: MobileSyncNoteService) {
+            self.noteService = noteService
+        }
+
+        // MARK: Internal
+
+        @Published var editMode: EditMode = .inactive
+        @Published var error: Error?
+        @Published var notes: [SyncedNoteItem] = []
+        @Published var searchTerm: String = ""
+
+        var filteredNotes: [SyncedNoteItem] {
+            let term = searchTerm.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !term.isEmpty else {
+                return notes
+            }
+            return notes.filter { item in
+                if item.note.body.range(of: term, options: .caseInsensitive) != nil {
+                    return true
+                }
+                let suraName = item.note.firstVerse.sura.localizedName()
+                return suraName.range(of: term, options: .caseInsensitive) != nil
+            }
+        }
+
+        func start() async {
+            do {
+                let sequence = noteService.notesSequence(quran: readingPreferences.reading.quran)
+                for try await notes in sequence {
+                    self.notes = await noteItems(with: notes)
+                }
+            } catch {
+                self.error = error
+            }
+        }
+
+        func deleteItem(_ item: SyncedNoteItem) async {
+            do {
+                try await noteService.removeNote(item.note)
+            } catch {
+                self.error = error
+            }
+        }
+
+        func prepareNotesForSharing() async throws -> String {
+            try await crasher.recordError("Failed to share synced notes") {
+                var notesText = [String]()
+                let notes: [SyncedNoteItem] = await self.notes
+                for (index, note) in notes.enumerated() {
+                    notesText.append(contentsOf: [note.note.body.trimmingCharacters(in: .newlines), ""])
+                    let verses = try await noteService.textForVerses(note.note.verses)
+                    notesText.append(verses)
+                    if index != notes.count - 1 {
+                        notesText.append(contentsOf: ["", "", ""])
+                    }
+                }
+                return notesText.joined(separator: "\n")
+            }
+        }
+
+        // MARK: Private
+
+        private let noteService: MobileSyncNoteService
+        private let readingPreferences = ReadingPreferences.shared
+
+        private nonisolated func noteItems(with notes: [SyncedNote]) async -> [SyncedNoteItem] {
+            await withTaskGroup(of: SyncedNoteItem.self) { group in
+                for note in notes {
+                    group.addTask {
+                        do {
+                            let verseText = try await self.noteService.textForVerses(note.verses)
+                            return SyncedNoteItem(note: note, verseText: verseText)
+                        } catch {
+                            crasher.recordError(error, reason: "MobileSyncNoteService.textForVerses")
+                            return SyncedNoteItem(note: note, verseText: note.firstVerse.localizedName)
+                        }
+                    }
+                }
+
+                return await group.collect()
+            }
+        }
+    }
+#endif

--- a/Features/QuranViewFeature/QuranBuilder.swift
+++ b/Features/QuranViewFeature/QuranBuilder.swift
@@ -56,6 +56,8 @@ public struct QuranBuilder {
             } else {
                 nil
             }
+            let syncedNoteService = container.mobileSyncNoteService()
+            let syncedNoteEditorBuilder = syncedNoteService.map { SyncedNoteEditorBuilder(noteService: $0) }
         #endif
         #if QURAN_SYNC
             let interactorDeps = QuranInteractor.Deps(
@@ -76,7 +78,9 @@ public struct QuranBuilder {
                 syncedHighlightsObserver: syncedHighlightsObserver,
                 readingBookmarkService: readingBookmarkService,
                 ayahBookmarkCollectionService: ayahBookmarkCollectionService,
-                ayahBookmarkCollectionPickerBuilder: ayahBookmarkCollectionPickerBuilder
+                ayahBookmarkCollectionPickerBuilder: ayahBookmarkCollectionPickerBuilder,
+                syncedNoteService: syncedNoteService,
+                syncedNoteEditorBuilder: syncedNoteEditorBuilder
             )
         #else
             let interactorDeps = QuranInteractor.Deps(

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -87,6 +87,8 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             let readingBookmarkService: ReadingBookmarkService?
             let ayahBookmarkCollectionService: AyahBookmarkCollectionService?
             let ayahBookmarkCollectionPickerBuilder: AyahBookmarkCollectionPickerBuilder?
+            let syncedNoteService: MobileSyncNoteService?
+            let syncedNoteEditorBuilder: SyncedNoteEditorBuilder?
         #endif
     }
 
@@ -129,10 +131,13 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             }
         #endif
 
-        deps.noteService.notes(quran: deps.quran)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in self?.notes = $0 }
-            .store(in: &cancellables)
+        #if QURAN_SYNC
+            if deps.syncedNoteService == nil {
+                startLegacyNotesObservation()
+            }
+        #else
+            startLegacyNotesObservation()
+        #endif
 
         #if QURAN_SYNC
             if let readingBookmarkService = deps.readingBookmarkService {
@@ -242,6 +247,19 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let viewController = deps.noteEditorBuilder.build(withListener: self, note: note)
         presenter?.present(viewController, animated: true)
     }
+
+    #if QURAN_SYNC
+        func addSyncedNote(verses: [AyahNumber]) {
+            guard let syncedNoteEditorBuilder = deps.syncedNoteEditorBuilder else {
+                return
+            }
+
+            dismissAyahMenu()
+            presenter?.rotateToPortraitIfPhone()
+            let viewController = syncedNoteEditorBuilder.build(withListener: self, verses: verses)
+            presenter?.present(viewController, animated: true)
+        }
+    #endif
 
     func dismissNoteEditor() {
         logger.info("Quran: dismiss note editor")
@@ -454,6 +472,13 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         didSet {
             reloadPageBookmark()
         }
+    }
+
+    private func startLegacyNotesObservation() {
+        deps.noteService.notes(quran: deps.quran)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.notes = $0 }
+            .store(in: &cancellables)
     }
 
     private func startPageBookmarkObservation() {

--- a/Package.swift
+++ b/Package.swift
@@ -688,6 +688,7 @@ private func featuresTargets() -> [[Target]] {
             "FeaturesSupport",
             "ReadingService",
             "NoorUI",
+            "NoteEditorFeature",
         ]),
 
         target(type, name: "TranslationVerseFeature", hasTests: false, dependencies: [

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
@@ -58,7 +58,8 @@ public enum AyahMenuUI {
             actions: Actions,
             isTranslationView: Bool,
             usesCollectionBookmarks: Bool = false,
-            isCollectionBookmarked: Bool = false
+            isCollectionBookmarked: Bool = false,
+            usesSyncedNotesIcon: Bool = false
         ) {
             self.highlightingColor = highlightingColor
             self.state = state
@@ -68,6 +69,7 @@ public enum AyahMenuUI {
             self.isTranslationView = isTranslationView
             self.usesCollectionBookmarks = usesCollectionBookmarks
             self.isCollectionBookmarked = isCollectionBookmarked
+            self.usesSyncedNotesIcon = usesSyncedNotesIcon
         }
 
         // MARK: Internal
@@ -80,6 +82,7 @@ public enum AyahMenuUI {
         let isTranslationView: Bool
         let usesCollectionBookmarks: Bool
         let isCollectionBookmarked: Bool
+        let usesSyncedNotesIcon: Bool
     }
 
     // MARK: Public

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
@@ -65,6 +65,8 @@ public struct AyahMenuView: View {
 }
 
 private struct AyahMenuViewList: View {
+    // MARK: Internal
+
     let dataObject: AyahMenuUI.DataObject
     let showHighlights: AsyncAction
 
@@ -81,15 +83,13 @@ private struct AyahMenuViewList: View {
 
     var editNote: some View {
         Row(title: l("ayah.menu.edit-note"), action: dataObject.actions.addNote) {
-            Image(systemName: "text.bubble.fill")
-                .foregroundColor(dataObject.highlightingColor.color)
+            noteIcon(legacySystemName: "text.bubble.fill")
         }
     }
 
     var addNote: some View {
         Row(title: l("ayah.menu.add-note"), action: dataObject.actions.addNote) {
-            Image(systemName: "plus.bubble.fill")
-                .foregroundColor(dataObject.highlightingColor.color)
+            noteIcon(legacySystemName: "plus.bubble.fill")
         }
     }
 
@@ -200,6 +200,19 @@ private struct AyahMenuViewList: View {
             }
         }
         .fixedSize(horizontal: true, vertical: false)
+    }
+
+    // MARK: Private
+
+    private func noteIcon(legacySystemName: String) -> some View {
+        Group {
+            if dataObject.usesSyncedNotesIcon {
+                NoorSystemImage.note.image
+            } else {
+                Image(systemName: legacySystemName)
+                    .foregroundColor(dataObject.highlightingColor.color)
+            }
+        }
     }
 }
 

--- a/UI/NoorUI/Features/Note/EditableNote.swift
+++ b/UI/NoorUI/Features/Note/EditableNote.swift
@@ -26,6 +26,10 @@ public class EditableNote: ObservableObject {
     @Published public internal(set) var selectedColor: Note.Color
     @Published public internal(set) var note: String
 
+    public var notePublisher: AnyPublisher<String, Never> {
+        $note.eraseToAnyPublisher()
+    }
+
     // MARK: Internal
 
     @Published var editing: Bool

--- a/UI/NoorUI/Features/Note/NoteEditorView.swift
+++ b/UI/NoorUI/Features/Note/NoteEditorView.swift
@@ -13,8 +13,14 @@ import UIx
 public struct NoteEditorView: View {
     // MARK: Lifecycle
 
-    public init(note: EditableNote, done: @escaping () -> Void, delete: @Sendable @escaping () async -> Void) {
+    public init(
+        note: EditableNote,
+        showsColors: Bool = true,
+        done: @escaping () -> Void,
+        delete: @Sendable @escaping () async -> Void
+    ) {
         _note = ObservedObject(initialValue: note)
+        self.showsColors = showsColors
         self.done = done
         self.delete = delete
     }
@@ -26,11 +32,13 @@ public struct NoteEditorView: View {
             ZStack(alignment: .leading) {
                 HStack {
                     Spacer()
-                    ForEach(Note.Color.sortedColors, id: \.self) { color in
-                        Button(
-                            action: { note.selectedColor = color },
-                            label: { NoteCircle(color: color.color, selected: color == note.selectedColor) }
-                        )
+                    if showsColors {
+                        ForEach(Note.Color.sortedColors, id: \.self) { color in
+                            Button(
+                                action: { note.selectedColor = color },
+                                label: { NoteCircle(color: color.color, selected: color == note.selectedColor) }
+                            )
+                        }
                     }
                     Spacer()
                 }
@@ -57,8 +65,10 @@ public struct NoteEditorView: View {
                     .font(.quran(ofSize: .small))
                     .padding(.leading)
                     .overlay(HStack {
-                        Rectangle().fill(note.selectedColor.color)
-                            .frame(width: 4)
+                        if showsColors {
+                            Rectangle().fill(note.selectedColor.color)
+                                .frame(width: 4)
+                        }
                         Spacer()
                     })
                     .environment(\.layoutDirection, .rightToLeft)
@@ -84,6 +94,7 @@ public struct NoteEditorView: View {
 
     @ObservedObject var note: EditableNote
 
+    let showsColors: Bool
     let done: () -> Void
     let delete: @Sendable () async -> Void
 }

--- a/UI/NoorUI/Features/Note/UIViewController+Note.swift
+++ b/UI/NoorUI/Features/Note/UIViewController+Note.swift
@@ -26,6 +26,16 @@ extension UIViewController {
         present(alert, animated: true)
     }
 
+    public func showNoteMinimumLengthAlert(minimumLength: Int) {
+        let alert = UIAlertController(
+            title: l("notes.minimum-length.alert.title"),
+            message: lFormat("notes.minimum-length.alert.body", minimumLength),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: lAndroid("dialog_ok"), style: .default, handler: nil))
+        present(alert, animated: true)
+    }
+
     public func addCloudSyncInfo() {
         navigationItem.leftBarButtonItem = UIBarButtonItem(
             image: .symbol("link.icloud.fill"),


### PR DESCRIPTION
## Summary
- Add sync-gated notes list and editor flows.
- Hide note colors under sync so notes and highlights stay separate.
- Enforce minimum note length at submit time.
- Support multiple notes per ayah, edit, and delete.
- Use the Notes tab icon in the sync ayah menu note action.

## Scope
- `QURAN_SYNC`-gated UI/domain wiring only.
- Uses the sync notes service from the base PR.
- Non-sync notes behavior remains unchanged.

## Validation
- `QURAN_SYNC=1` package build passed.
- Non-sync package build passed.
- Local smoke tests were run before publishing.