### PR TITLE
Add Mobile Sync notes service

### DIFF
--- a/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
@@ -17,12 +17,6 @@
         public let modifiedDate: Date
 
         public var id: String { localId }
-
-        public var firstVerse: AyahNumber { startAyah }
-
-        public var verses: [AyahNumber] {
-            startAyah.array(to: endAyah)
-        }
     }
 
     public struct SyncedNotesSequence: AsyncSequence {
@@ -56,7 +50,7 @@
         private let makeIterator: () -> AsyncIterator
     }
 
-    public struct MobileSyncNoteService: @unchecked Sendable {
+    public struct MobileSyncNoteService {
         // MARK: Lifecycle
 
         public init(syncService: SyncService) {

--- a/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
@@ -1,0 +1,133 @@
+#if QURAN_SYNC
+    //
+    //  MobileSyncNoteService.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import Foundation
+    @preconcurrency import MobileSync
+    import QuranKit
+
+    public struct SyncedNote: Equatable, Identifiable, Sendable {
+        public let localId: String
+        public let body: String
+        public let startAyah: AyahNumber
+        public let endAyah: AyahNumber
+        public let modifiedDate: Date
+
+        public var id: String { localId }
+
+        public var firstVerse: AyahNumber { startAyah }
+
+        public var verses: [AyahNumber] {
+            startAyah.array(to: endAyah)
+        }
+    }
+
+    public struct SyncedNotesSequence: AsyncSequence {
+        public typealias Element = [SyncedNote]
+
+        public struct AsyncIterator: AsyncIteratorProtocol {
+            init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
+                var iterator = sequence.makeAsyncIterator()
+                nextValue = {
+                    try await iterator.next()
+                }
+            }
+
+            public mutating func next() async throws -> Element? {
+                try await nextValue()
+            }
+
+            private let nextValue: () async throws -> Element?
+        }
+
+        init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
+            makeIterator = {
+                AsyncIterator(sequence)
+            }
+        }
+
+        public func makeAsyncIterator() -> AsyncIterator {
+            makeIterator()
+        }
+
+        private let makeIterator: () -> AsyncIterator
+    }
+
+    public struct MobileSyncNoteService: @unchecked Sendable {
+        // MARK: Lifecycle
+
+        public init(syncService: SyncService) {
+            self.syncService = syncService
+        }
+
+        // MARK: Public
+
+        public func notesSequence(quran: Quran) -> SyncedNotesSequence {
+            let sequence = syncService.notesSequence()
+                .map { notes in
+                    Self.notes(from: notes, quran: quran)
+                }
+            return SyncedNotesSequence(sequence)
+        }
+
+        public func createNote(body: String, startAyah: AyahNumber, endAyah: AyahNumber) async throws {
+            try await syncService.createNote(
+                body: body,
+                startSura: Int32(startAyah.sura.suraNumber),
+                startAyah: Int32(startAyah.ayah),
+                endSura: Int32(endAyah.sura.suraNumber),
+                endAyah: Int32(endAyah.ayah)
+            )
+        }
+
+        public func updateNote(_ note: SyncedNote, body: String) async throws {
+            try await updateNote(note, body: body, startAyah: note.startAyah, endAyah: note.endAyah)
+        }
+
+        public func updateNote(_ note: SyncedNote, body: String, startAyah: AyahNumber, endAyah: AyahNumber) async throws {
+            try await syncService.updateNote(
+                localId: note.localId,
+                body: body,
+                startSura: Int32(startAyah.sura.suraNumber),
+                startAyah: Int32(startAyah.ayah),
+                endSura: Int32(endAyah.sura.suraNumber),
+                endAyah: Int32(endAyah.ayah)
+            )
+        }
+
+        public func removeNote(_ note: SyncedNote) async throws {
+            try await syncService.removeNote(localId: note.localId)
+        }
+
+        // MARK: Internal
+
+        static func notes(from notes: [Note_], quran: Quran) -> [SyncedNote] {
+            notes.compactMap { note(from: $0, quran: quran) }
+                .sorted { $0.modifiedDate > $1.modifiedDate }
+        }
+
+        static func note(from note: Note_, quran: Quran) -> SyncedNote? {
+            guard let start = AyahNumber(quran: quran, sura: Int(note.startSura), ayah: Int(note.startAyah)),
+                  let end = AyahNumber(quran: quran, sura: Int(note.endSura), ayah: Int(note.endAyah)),
+                  start <= end
+            else {
+                return nil
+            }
+
+            return SyncedNote(
+                localId: note.localId,
+                body: note.body,
+                startAyah: start,
+                endAyah: end,
+                modifiedDate: note.lastUpdated
+            )
+        }
+
+        // MARK: Private
+
+        private let syncService: SyncService
+    }
+#endif

--- a/Domain/AnnotationsService/Tests/MobileSyncNoteServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncNoteServiceTests.swift
@@ -1,0 +1,53 @@
+#if QURAN_SYNC
+    import MobileSync
+    import QuranKit
+    import XCTest
+    @testable import AnnotationsService
+
+    final class MobileSyncNoteServiceTests: XCTestCase {
+        func test_notes_mapsContinuousRange() {
+            let notes = MobileSyncNoteService.notes(from: [
+                Note_(
+                    body: "Remember this",
+                    startSura: 1,
+                    startAyah: 1,
+                    endSura: 1,
+                    endAyah: 2,
+                    lastUpdated: .distantPast,
+                    localId: "note-1"
+                ),
+            ], quran: .hafsMadani1405)
+
+            XCTAssertEqual(notes.count, 1)
+            XCTAssertEqual(notes[0].localId, "note-1")
+            XCTAssertEqual(notes[0].body, "Remember this")
+            XCTAssertEqual(notes[0].startAyah, AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1))
+            XCTAssertEqual(notes[0].endAyah, AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 2))
+            XCTAssertEqual(notes[0].verses, [
+                AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!,
+                AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 2)!,
+            ])
+        }
+
+        func test_notes_keepsMultipleNotesForSameAyah() {
+            let notes = MobileSyncNoteService.notes(from: [
+                Self.note(localId: "note-1", body: "First"),
+                Self.note(localId: "note-2", body: "Second"),
+            ], quran: .hafsMadani1405)
+
+            XCTAssertEqual(Set(notes.map { note in note.localId }), ["note-1", "note-2"])
+        }
+
+        private static func note(localId: String, body: String) -> Note_ {
+            Note_(
+                body: body,
+                startSura: 1,
+                startAyah: 1,
+                endSura: 1,
+                endAyah: 1,
+                lastUpdated: .distantPast,
+                localId: localId
+            )
+        }
+    }
+#endif

--- a/Domain/AnnotationsService/Tests/MobileSyncNoteServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncNoteServiceTests.swift
@@ -23,10 +23,6 @@
             XCTAssertEqual(notes[0].body, "Remember this")
             XCTAssertEqual(notes[0].startAyah, AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1))
             XCTAssertEqual(notes[0].endAyah, AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 2))
-            XCTAssertEqual(notes[0].verses, [
-                AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!,
-                AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 2)!,
-            ])
         }
 
         func test_notes_keepsMultipleNotesForSameAyah() {
@@ -38,14 +34,23 @@
             XCTAssertEqual(Set(notes.map { note in note.localId }), ["note-1", "note-2"])
         }
 
-        private static func note(localId: String, body: String) -> Note_ {
+        func test_notes_sortsByLatestUpdatedDate() {
+            let notes = MobileSyncNoteService.notes(from: [
+                Self.note(localId: "older", body: "Older", lastUpdated: Date(timeIntervalSince1970: 1)),
+                Self.note(localId: "newer", body: "Newer", lastUpdated: Date(timeIntervalSince1970: 2)),
+            ], quran: .hafsMadani1405)
+
+            XCTAssertEqual(notes.map(\.localId), ["newer", "older"])
+        }
+
+        private static func note(localId: String, body: String, lastUpdated: Date = .distantPast) -> Note_ {
             Note_(
                 body: body,
                 startSura: 1,
                 startAyah: 1,
                 endSura: 1,
                 endAyah: 1,
-                lastUpdated: .distantPast,
+                lastUpdated: lastUpdated,
                 localId: localId
             )
         }

--- a/Package.swift
+++ b/Package.swift
@@ -503,6 +503,7 @@ private func domainTargets() -> [[Target]] {
         ]),
 
         target(type, name: "AnnotationsService", dependencies: [
+            .product(name: "MobileSync", package: "mobile-sync-spm"),
             "QuranAnnotations",
             "LastPagePersistence",
             "NotePersistence",


### PR DESCRIPTION
## Summary
- Adds a thin Mobile Sync-backed notes service in `AnnotationsService`.
- Maps Mobile Sync notes to typed `SyncedNote` values with continuous ayah ranges.
- Supports create/update/delete by concrete sync note id.

## Scope
- Data/service only.
- No notes UI wiring.
- No legacy note persistence changes.
- No migration logic.

## Validation
- `QURAN_SYNC=1 xcodebuild build` via stacked UI branch.
- Non-sync `xcodebuild build` via stacked UI branch.
- Targeted `MobileSyncNoteServiceTests` passed.