### PR TITLE
Add sync notes UI flow

### DIFF
--- a/AllTargetsTests/SyncedNoteCounterTests.swift
+++ b/AllTargetsTests/SyncedNoteCounterTests.swift
@@ -1,0 +1,51 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNoteCounterTests.swift
+    //  Quran
+    //
+    //  Created by Ahmed Nabil on 2026-05-20.
+    //
+
+    import QuranKit
+    import XCTest
+    @testable import AnnotationsService
+    @testable import QuranViewFeature
+
+    final class SyncedNoteCounterTests: XCTestCase {
+        func test_count_returnsZero_whenNoNotes() {
+            XCTAssertEqual(SyncedNoteCounter.count([], interacting: [ayah(1)]), 0)
+        }
+
+        func test_count_countsMultipleNotesForSameAyah() {
+            let notes = [note(id: "1", start: ayah(1)), note(id: "2", start: ayah(1))]
+
+            XCTAssertEqual(SyncedNoteCounter.count(notes, interacting: [ayah(1)]), 2)
+        }
+
+        func test_count_countsMultiAyahNoteOverlappingSelection() {
+            let notes = [note(start: ayah(1), end: ayah(3))]
+
+            XCTAssertEqual(SyncedNoteCounter.count(notes, interacting: [ayah(2)]), 1)
+        }
+
+        func test_count_skipsNonOverlappingNotes() {
+            let notes = [note(start: ayah(1), end: ayah(2))]
+
+            XCTAssertEqual(SyncedNoteCounter.count(notes, interacting: [ayah(3)]), 0)
+        }
+
+        private func note(id: String = "note", start: AyahNumber, end: AyahNumber? = nil) -> SyncedNote {
+            SyncedNote(
+                localId: id,
+                body: "Note body",
+                startAyah: start,
+                endAyah: end ?? start,
+                modifiedDate: Date()
+            )
+        }
+
+        private func ayah(_ ayah: Int) -> AyahNumber {
+            AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: ayah)!
+        }
+    }
+#endif

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -244,3 +244,6 @@
 "bookmarks.collections.new.placeholder" = "اسم المجموعة";
 "bookmarks.collections.no-data.title" = "لا توجد مجموعات حتى الآن";
 "bookmarks.collections.no-data.text" = "أنشئ مجموعة لتنظيم إشاراتك المرجعية للآيات.";
+
+"notes.minimum-length.alert.title" = "الملاحظة قصيرة جدًا";
+"notes.minimum-length.alert.body" = "يجب أن تكون الملاحظة %d أحرف على الأقل.";

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -130,6 +130,8 @@
 "notes.verses-count" = "(+%d آيات)";
 "notes.delete.alert.title" = "حذف الإشارة المرجعية";
 "notes.delete.alert.body" = "سيتم حذف الملاحظة أيضًا.";
+"notes.delete-note.alert.title" = "حذف الملاحظة";
+"notes.delete-note.alert.body" = "سيتم حذف هذه الملاحظة.";
 "notes.icloud.alert.title" = "مزامنة iCloud";
 "notes.icloud.alert.body" = "يستخدم التطبيق iCloud لمزامنة الإشارات المرجعية والملاحظات عبر أجهزتك. يمكنك تعطيله من جهازك من خلال إعدادات iCloud.";
 "notes.search.placeholder.text" = "ابحث في ملاحظاتك";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -134,6 +134,8 @@
 "notes.verses-count" = "(+%d ayat)";
 "notes.delete.alert.title" = "Delete Highlight";
 "notes.delete.alert.body" = "The associated note will also be deleted.";
+"notes.delete-note.alert.title" = "Delete Note";
+"notes.delete-note.alert.body" = "This note will be deleted.";
 "notes.icloud.alert.title" = "iCloud Sync";
 "notes.icloud.alert.body" = "The app uses iCloud to sync bookmarks & notes across your devices. You can disable it from your device's iCloud settings.";
 "notes.search.placeholder.text" = "Search your notes";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -252,3 +252,6 @@
 "bookmarks.collections.no-data.text" = "Create a collection to organize your ayah bookmarks.";
 
 "bookmarks.old-page-bookmarks" = "Old Page Bookmarks";
+
+"notes.minimum-length.alert.title" = "Note is too short";
+"notes.minimum-length.alert.body" = "Notes must be at least %d characters.";

--- a/Features/AppDependencies/AppDependencies.swift
+++ b/Features/AppDependencies/AppDependencies.swift
@@ -74,4 +74,12 @@ extension AppDependencies {
             analytics: analytics
         )
     }
+
+    #if QURAN_SYNC
+        public func mobileSyncNoteService() -> MobileSyncNoteService? {
+            syncService.map {
+                MobileSyncNoteService(syncService: $0)
+            }
+        }
+    #endif
 }

--- a/Features/AyahMenuFeature/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/AyahMenuBuilder.swift
@@ -52,7 +52,8 @@ public struct AyahMenuBuilder {
             verses: input.verses,
             notes: input.notes,
             noteService: noteService,
-            textRetriever: textRetriever
+            textRetriever: textRetriever,
+            usesSyncedNotes: usesSyncedNotes
         ))
         viewModel.listener = listener
         return AyahMenuViewController(viewModel: viewModel)
@@ -61,4 +62,12 @@ public struct AyahMenuBuilder {
     // MARK: Private
 
     private let container: AppDependencies
+
+    private var usesSyncedNotes: Bool {
+        #if QURAN_SYNC
+            return container.mobileSyncNoteService() != nil
+        #else
+            return false
+        #endif
+    }
 }

--- a/Features/AyahMenuFeature/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/AyahMenuBuilder.swift
@@ -15,11 +15,12 @@ import UIKit
 public struct AyahMenuInput {
     // MARK: Lifecycle
 
-    public init(sourceView: UIView, pointInView: CGPoint, verses: [AyahNumber], notes: [Note]) {
+    public init(sourceView: UIView, pointInView: CGPoint, verses: [AyahNumber], notes: [Note], noteCount: Int = 0) {
         self.sourceView = sourceView
         self.pointInView = pointInView
         self.verses = verses
         self.notes = notes
+        self.noteCount = noteCount
     }
 
     // MARK: Internal
@@ -28,6 +29,7 @@ public struct AyahMenuInput {
     let pointInView: CGPoint
     let verses: [AyahNumber]
     let notes: [Note]
+    let noteCount: Int
 }
 
 @MainActor
@@ -53,7 +55,8 @@ public struct AyahMenuBuilder {
             notes: input.notes,
             noteService: noteService,
             textRetriever: textRetriever,
-            usesSyncedNotes: usesSyncedNotes
+            usesSyncedNotes: usesSyncedNotes,
+            noteCount: input.noteCount
         ))
         viewModel.listener = listener
         return AyahMenuViewController(viewModel: viewModel)

--- a/Features/AyahMenuFeature/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewController.swift
@@ -52,7 +52,8 @@ final class AyahMenuViewController: UIViewController {
             playSubtitle: viewModel.playSubtitle,
             repeatSubtitle: viewModel.repeatSubtitle,
             actions: actions,
-            isTranslationView: viewModel.isTranslationView
+            isTranslationView: viewModel.isTranslationView,
+            usesSyncedNotesIcon: viewModel.usesSyncedNotesIcon
         )
         showAyahMenu(dataObject)
     }

--- a/Features/AyahMenuFeature/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewController.swift
@@ -53,7 +53,8 @@ final class AyahMenuViewController: UIViewController {
             repeatSubtitle: viewModel.repeatSubtitle,
             actions: actions,
             isTranslationView: viewModel.isTranslationView,
-            usesSyncedNotesIcon: viewModel.usesSyncedNotesIcon
+            usesSyncedNotesIcon: viewModel.usesSyncedNotesIcon,
+            noteCount: viewModel.noteCount
         )
         showAyahMenu(dataObject)
     }

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -47,6 +47,7 @@ final class AyahMenuViewModel {
         let noteService: NoteService
         let textRetriever: ShareableVerseTextRetriever
         let usesSyncedNotes: Bool
+        let noteCount: Int
         let quranContentStatePreferences = QuranContentStatePreferences.shared
     }
 
@@ -90,6 +91,14 @@ final class AyahMenuViewModel {
             return deps.usesSyncedNotes
         #else
             return false
+        #endif
+    }
+
+    var noteCount: Int {
+        #if QURAN_SYNC
+            return deps.usesSyncedNotes ? deps.noteCount : 0
+        #else
+            return 0
         #endif
     }
 

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -28,6 +28,10 @@ public protocol AyahMenuListener: AnyObject {
     func deleteNotes(_ notes: [Note], verses: [AyahNumber]) async
     func showTranslation(_ verses: [AyahNumber])
 
+    #if QURAN_SYNC
+        func addSyncedNote(verses: [AyahNumber])
+    #endif
+
     func editNote(_ note: Note)
 }
 
@@ -42,6 +46,7 @@ final class AyahMenuViewModel {
         let notes: [Note]
         let noteService: NoteService
         let textRetriever: ShareableVerseTextRetriever
+        let usesSyncedNotes: Bool
         let quranContentStatePreferences = QuranContentStatePreferences.shared
     }
 
@@ -81,6 +86,11 @@ final class AyahMenuViewModel {
     }
 
     var noteState: AyahMenuUI.NoteState {
+        #if QURAN_SYNC
+            if deps.usesSyncedNotes {
+                return .noHighlight
+            }
+        #endif
         if deps.notes.isEmpty {
             return .noHighlight
         } else if containsText(deps.notes) {
@@ -116,6 +126,12 @@ final class AyahMenuViewModel {
 
     func editNote() async {
         logger.info("AyahMenu: edit notes. Verses: \(deps.verses)")
+        #if QURAN_SYNC
+            if deps.usesSyncedNotes {
+                listener?.addSyncedNote(verses: deps.verses)
+                return
+            }
+        #endif
         let notes = deps.notes
         let color = deps.noteService.color(from: notes)
         if let note = await _updateHighlight(color: color) {

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -85,6 +85,14 @@ final class AyahMenuViewModel {
         return l("ayah.menu.selected-verses")
     }
 
+    var usesSyncedNotesIcon: Bool {
+        #if QURAN_SYNC
+            return deps.usesSyncedNotes
+        #else
+            return false
+        #endif
+    }
+
     var noteState: AyahMenuUI.NoteState {
         #if QURAN_SYNC
             if deps.usesSyncedNotes {

--- a/Features/NoteEditorFeature/NoteEditorBuilder.swift
+++ b/Features/NoteEditorFeature/NoteEditorBuilder.swift
@@ -6,8 +6,12 @@
 //  Copyright © 2020 Quran.com. All rights reserved.
 //
 
+import Analytics
+import AnnotationsService
 import AppDependencies
 import QuranAnnotations
+import QuranKit
+import QuranTextKit
 import UIKit
 
 @MainActor
@@ -32,3 +36,33 @@ public struct NoteEditorBuilder {
 
     let container: AppDependencies
 }
+
+#if QURAN_SYNC
+    @MainActor
+    public struct SyncedNoteEditorBuilder {
+        public init(noteService: MobileSyncNoteService, textService: QuranTextDataService, analytics: AnalyticsLibrary) {
+            self.noteService = noteService
+            self.textService = textService
+            self.analytics = analytics
+        }
+
+        public func build(withListener listener: NoteEditorListener, note: SyncedNote) -> UIViewController {
+            build(withListener: listener, mode: .edit(note))
+        }
+
+        public func build(withListener listener: NoteEditorListener, verses: [AyahNumber]) -> UIViewController {
+            build(withListener: listener, mode: .create(verses: verses))
+        }
+
+        private let noteService: MobileSyncNoteService
+        private let textService: QuranTextDataService
+        private let analytics: AnalyticsLibrary
+
+        private func build(withListener listener: NoteEditorListener, mode: SyncedNoteEditorInteractor.Mode) -> UIViewController {
+            let viewModel = SyncedNoteEditorInteractor(noteService: noteService, textService: textService, analytics: analytics, mode: mode)
+            let viewController = SyncedNoteEditorViewController(viewModel: viewModel)
+            viewModel.listener = listener
+            return viewController
+        }
+    }
+#endif

--- a/Features/NoteEditorFeature/SyncedNoteEditorInteractor.swift
+++ b/Features/NoteEditorFeature/SyncedNoteEditorInteractor.swift
@@ -112,7 +112,7 @@
             case .create(let verses):
                 return verses
             case .edit(let note):
-                return note.verses
+                return note.startAyah.array(to: note.endAyah)
             }
         }
 

--- a/Features/NoteEditorFeature/SyncedNoteEditorInteractor.swift
+++ b/Features/NoteEditorFeature/SyncedNoteEditorInteractor.swift
@@ -1,0 +1,154 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNoteEditorInteractor.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import Analytics
+    import AnnotationsService
+    import Crashing
+    import Foundation
+    import NoorUI
+    import QuranAnnotations
+    import QuranKit
+    import QuranTextKit
+    import VLogging
+
+    @MainActor
+    final class SyncedNoteEditorInteractor {
+        // MARK: Lifecycle
+
+        init(noteService: MobileSyncNoteService, textService: QuranTextDataService, analytics: AnalyticsLibrary, mode: Mode) {
+            self.noteService = noteService
+            self.textService = textService
+            self.analytics = analytics
+            self.mode = mode
+        }
+
+        // MARK: Internal
+
+        enum Mode {
+            case create(verses: [AyahNumber])
+            case edit(SyncedNote)
+        }
+
+        static let minimumNoteBodyLength = 6
+
+        weak var listener: NoteEditorListener?
+
+        var minimumNoteBodyLength: Int { Self.minimumNoteBodyLength }
+
+        var isEditedNote: Bool {
+            !(editableNote?.note ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        var canSubmitNote: Bool {
+            let text = (editableNote?.note ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            return !text.isEmpty && text.count >= minimumNoteBodyLength
+        }
+
+        func fetchNote() async throws -> EditableNote {
+            do {
+                let versesText = try await textForVerses(verses)
+                let editableNote = EditableNote(
+                    ayahText: versesText,
+                    modifiedSince: modifiedSince,
+                    selectedColor: .red,
+                    note: body
+                )
+                self.editableNote = editableNote
+                return editableNote
+            } catch {
+                crasher.recordError(error, reason: "Failed to retrieve synced note text")
+                throw error
+            }
+        }
+
+        func commitEditsAndExit() async {
+            logger.info("SyncedNoteEditor: done tapped")
+            do {
+                let body = editableNote?.note ?? body
+                guard let range = versesRange else {
+                    return
+                }
+                analytics.logEvent("UpdateNoteVersesNum", value: Set(verses).count.description)
+                switch mode {
+                case .create:
+                    try await noteService.createNote(body: body, startAyah: range.start, endAyah: range.end)
+                case .edit(let note):
+                    try await noteService.updateNote(note, body: body, startAyah: range.start, endAyah: range.end)
+                }
+                listener?.dismissNoteEditor()
+            } catch {
+                crasher.recordError(error, reason: "Failed to save synced note")
+            }
+        }
+
+        func forceDelete() async {
+            guard case .edit(let note) = mode else {
+                listener?.dismissNoteEditor()
+                return
+            }
+
+            do {
+                try await noteService.removeNote(note)
+                listener?.dismissNoteEditor()
+            } catch {
+                crasher.recordError(error, reason: "Failed to delete synced note")
+            }
+        }
+
+        // MARK: Private
+
+        private let noteService: MobileSyncNoteService
+        private let textService: QuranTextDataService
+        private let analytics: AnalyticsLibrary
+        private let mode: Mode
+        private var editableNote: EditableNote?
+
+        private var verses: [AyahNumber] {
+            switch mode {
+            case .create(let verses):
+                return verses
+            case .edit(let note):
+                return note.verses
+            }
+        }
+
+        private var versesRange: (start: AyahNumber, end: AyahNumber)? {
+            let verses = verses.sorted()
+            guard let start = verses.first, let end = verses.last else {
+                return nil
+            }
+            return (start, end)
+        }
+
+        private var body: String {
+            switch mode {
+            case .create:
+                return ""
+            case .edit(let note):
+                return note.body
+            }
+        }
+
+        private var modifiedSince: String {
+            switch mode {
+            case .create:
+                return ""
+            case .edit(let note):
+                return note.modifiedDate.timeAgo()
+            }
+        }
+
+        private func textForVerses(_ verses: [AyahNumber]) async throws -> String {
+            let verseTexts = try await textService.textForVerses(verses, translations: [])
+            return verses.sorted()
+                .compactMap { verse in
+                    verseTexts[verse].map { $0.arabicText + " \(NumberFormatter.arabicNumberFormatter.format(verse.ayah))" }
+                }
+                .joined(separator: " ")
+        }
+    }
+#endif

--- a/Features/NoteEditorFeature/SyncedNoteEditorViewController.swift
+++ b/Features/NoteEditorFeature/SyncedNoteEditorViewController.swift
@@ -106,7 +106,7 @@
         private func delete() async {
             logger.info("SyncedNoteEditor: delete note")
             if viewModel.isEditedNote {
-                confirmNoteDelete(
+                confirmSyncedNoteDelete(
                     delete: { await self.viewModel.forceDelete() },
                     cancel: { }
                 )

--- a/Features/NoteEditorFeature/SyncedNoteEditorViewController.swift
+++ b/Features/NoteEditorFeature/SyncedNoteEditorViewController.swift
@@ -1,0 +1,118 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNoteEditorViewController.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import Combine
+    import NoorUI
+    import SwiftUI
+    import UIKit
+    import VLogging
+
+    final class SyncedNoteEditorViewController: BaseViewController, UIAdaptivePresentationControllerDelegate {
+        // MARK: Lifecycle
+
+        init(viewModel: SyncedNoteEditorInteractor) {
+            self.viewModel = viewModel
+            super.init(nibName: nil, bundle: nil)
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        // MARK: Internal
+
+        override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+            traitCollection.userInterfaceIdiom == .pad ? .all : .portrait
+        }
+
+        override func viewDidLoad() {
+            super.viewDidLoad()
+
+            presentationController?.delegate = self
+
+            Task {
+                do {
+                    let note = try await viewModel.fetchNote()
+                    setNote(note)
+                } catch {
+                    showErrorAlert(error: error)
+                }
+            }
+        }
+
+        func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {}
+
+        // MARK: Private
+
+        private let viewModel: SyncedNoteEditorInteractor
+        private var doneButton: UIBarButtonItem?
+        private var cancellables: Set<AnyCancellable> = []
+
+        private func setNote(_ note: EditableNote) {
+            let noteEditor = NoteEditorView(
+                note: note,
+                showsColors: false,
+                done: { [weak self] in self?.doneTapped() },
+                delete: { [weak self] in await self?.delete() }
+            )
+            let viewController = UIHostingController(rootView: noteEditor)
+            let navigationController = buildNavigationController(rootViewController: viewController, note: note)
+            bindDoneButton(to: note)
+            addFullScreenChild(navigationController)
+        }
+
+        private func buildNavigationController(rootViewController: UIViewController, note: EditableNote) -> UINavigationController {
+            let modifiedText = UIBarButtonItem(title: note.modifiedSince, style: .plain, target: nil, action: nil)
+            modifiedText.isEnabled = false
+            let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneTapped))
+
+            rootViewController.navigationItem.largeTitleDisplayMode = .never
+            rootViewController.navigationItem.leftBarButtonItem = modifiedText
+            rootViewController.navigationItem.rightBarButtonItem = doneButton
+            self.doneButton = doneButton
+
+            return UINavigationController(rootViewController: rootViewController)
+        }
+
+        private func bindDoneButton(to note: EditableNote) {
+            updateDoneButton(text: note.note)
+            note.notePublisher
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] text in self?.updateDoneButton(text: text) }
+                .store(in: &cancellables)
+        }
+
+        private func updateDoneButton(text: String) {
+            doneButton?.isEnabled = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        @objc
+        private func doneTapped() {
+            guard viewModel.canSubmitNote else {
+                showNoteMinimumLengthAlert(minimumLength: viewModel.minimumNoteBodyLength)
+                return
+            }
+
+            Task {
+                await viewModel.commitEditsAndExit()
+            }
+        }
+
+        private func delete() async {
+            logger.info("SyncedNoteEditor: delete note")
+            if viewModel.isEditedNote {
+                confirmNoteDelete(
+                    delete: { await self.viewModel.forceDelete() },
+                    cancel: { }
+                )
+            } else {
+                await viewModel.forceDelete()
+            }
+        }
+    }
+#endif

--- a/Features/NotesFeature/NotesBuilder.swift
+++ b/Features/NotesFeature/NotesBuilder.swift
@@ -8,6 +8,9 @@
 
 import AppDependencies
 import FeaturesSupport
+#if QURAN_SYNC
+    import NoteEditorFeature
+#endif
 import QuranKit
 import QuranTextKit
 import UIKit
@@ -23,6 +26,22 @@ public struct NotesBuilder {
     // MARK: Public
 
     public func build(withListener listener: QuranNavigator) -> UIViewController {
+        #if QURAN_SYNC
+            if let noteService = container.mobileSyncNoteService() {
+                let textService = container.textDataService()
+                let viewModel = SyncedNotesViewModel(noteService: noteService, textService: textService)
+                let viewController = SyncedNotesViewController(
+                    viewModel: viewModel,
+                    noteEditorBuilder: SyncedNoteEditorBuilder(
+                        noteService: noteService,
+                        textService: textService,
+                        analytics: container.analytics
+                    )
+                )
+                return viewController
+            }
+        #endif
+
         let textRetriever = ShareableVerseTextRetriever(
             databasesURL: container.databasesURL,
             quranFileURL: container.quranUthmaniV2Database

--- a/Features/NotesFeature/SyncedNoteItem.swift
+++ b/Features/NotesFeature/SyncedNoteItem.swift
@@ -1,0 +1,16 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNoteItem.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import AnnotationsService
+
+    struct SyncedNoteItem: Equatable, Identifiable {
+        let note: SyncedNote
+        let verseText: String
+
+        var id: String { note.id }
+    }
+#endif

--- a/Features/NotesFeature/SyncedNotesView.swift
+++ b/Features/NotesFeature/SyncedNotesView.swift
@@ -1,0 +1,134 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNotesView.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import Localization
+    import NoorUI
+    import QuranKit
+    import SwiftUI
+    import UIx
+
+    struct SyncedNotesView: View {
+        @StateObject var viewModel: SyncedNotesViewModel
+        let selectAction: ItemAction<SyncedNoteItem>
+
+        var body: some View {
+            SyncedNotesViewUI(
+                editMode: $viewModel.editMode,
+                error: $viewModel.error,
+                notes: viewModel.filteredNotes,
+                searchTerm: viewModel.searchTerm,
+                start: { await viewModel.start() },
+                selectAction: selectAction,
+                deleteAction: { await viewModel.deleteItem($0) }
+            )
+        }
+    }
+
+    private struct SyncedNotesViewUI: View {
+        // MARK: Internal
+
+        @Binding var editMode: EditMode
+        @Binding var error: Error?
+
+        let notes: [SyncedNoteItem]
+        let searchTerm: String
+        let start: AsyncAction
+        let selectAction: ItemAction<SyncedNoteItem>
+        let deleteAction: AsyncItemAction<SyncedNoteItem>
+
+        var body: some View {
+            Group {
+                if notes.isEmpty {
+                    if isSearching {
+                        noResults
+                    } else {
+                        noData
+                    }
+                } else {
+                    NoorList {
+                        NoorSection(notes) { note in
+                            listItem(note)
+                        }
+                        .onDelete(action: deleteAction)
+                    }
+                }
+            }
+            .task { await start() }
+            .errorAlert(error: $error)
+            .environment(\.editMode, $editMode)
+        }
+
+        // MARK: Private
+
+        private var isSearching: Bool {
+            !searchTerm.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
+        private var noData: some View {
+            DataUnavailableView(
+                title: l("notes.no-data.title"),
+                text: l("notes.no-data.text"),
+                image: .note
+            )
+        }
+
+        private var noResults: some View {
+            DataUnavailableView(
+                title: lFormat("notes.search.no-results.title", searchTerm),
+                text: l("notes.search.no-results.text"),
+                image: .search
+            )
+        }
+
+        private func listItem(_ item: SyncedNoteItem) -> some View {
+            let note = item.note
+            let ayah = note.firstVerse
+            let page = ayah.page
+            let ayahCount = note.verses.count
+            let numberOfAyahs = ayahCount > 1 ? lFormat("notes.verses-count", ayahCount - 1) : ""
+            return NoorListItem(
+                subheading: subheadingText(
+                    localizedVerse: ayah.localizedName,
+                    arabicSuraName: ayah.sura.arabicSuraName,
+                    numberOfAyahs: numberOfAyahs
+                ),
+                rightPretitle: "\(verse: item.verseText, color: Color.clear, lineLimit: 2)",
+                title: titleText(for: note.body.trimmingCharacters(in: .whitespacesAndNewlines)),
+                subtitle: .init(text: note.modifiedDate.timeAgo(), location: .bottom),
+                accessory: .text(NumberFormatter.shared.format(page.pageNumber))
+            ) {
+                selectAction(item)
+            }
+        }
+
+        private func highlightRanges(in text: String) -> [HighlightingRange] {
+            let term = searchTerm.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !term.isEmpty,
+                  let range = text.range(of: term, options: .caseInsensitive)
+            else {
+                return []
+            }
+            return [HighlightingRange(range, fontWeight: .heavy)]
+        }
+
+        private func titleText(for noteText: String) -> MultipartText {
+            let ranges = highlightRanges(in: noteText)
+            if ranges.isEmpty {
+                return .text(noteText)
+            }
+            return "\(noteText, highlighting: ranges)"
+        }
+
+        private func subheadingText(localizedVerse: String, arabicSuraName: String, numberOfAyahs: String) -> MultipartText {
+            let ranges = highlightRanges(in: localizedVerse)
+            if ranges.isEmpty {
+                return "\(localizedVerse) \(sura: arabicSuraName) \(numberOfAyahs)"
+            }
+            return "\(localizedVerse, highlighting: ranges) \(sura: arabicSuraName) \(numberOfAyahs)"
+        }
+    }
+#endif

--- a/Features/NotesFeature/SyncedNotesView.swift
+++ b/Features/NotesFeature/SyncedNotesView.swift
@@ -86,9 +86,9 @@
 
         private func listItem(_ item: SyncedNoteItem) -> some View {
             let note = item.note
-            let ayah = note.firstVerse
+            let ayah = note.startAyah
             let page = ayah.page
-            let ayahCount = note.verses.count
+            let ayahCount = note.startAyah.array(to: note.endAyah).count
             let numberOfAyahs = ayahCount > 1 ? lFormat("notes.verses-count", ayahCount - 1) : ""
             return NoorListItem(
                 subheading: subheadingText(

--- a/Features/NotesFeature/SyncedNotesViewController.swift
+++ b/Features/NotesFeature/SyncedNotesViewController.swift
@@ -1,0 +1,131 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNotesViewController.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import AnnotationsService
+    import Combine
+    import Localization
+    import NoteEditorFeature
+    import SwiftUI
+    import UIx
+    import VLogging
+
+    final class SyncedNotesViewController: UIHostingController<SyncedNotesView>, UISearchBarDelegate, NoteEditorListener {
+        // MARK: Lifecycle
+
+        init(viewModel: SyncedNotesViewModel, noteEditorBuilder: SyncedNoteEditorBuilder) {
+            self.viewModel = viewModel
+            self.noteEditorBuilder = noteEditorBuilder
+            super.init(rootView: SyncedNotesView(viewModel: viewModel, selectAction: { _ in }))
+            rootView = SyncedNotesView(viewModel: viewModel, selectAction: { [weak self] item in self?.editNote(item.note) })
+            initialize()
+        }
+
+        @available(*, unavailable)
+        @MainActor
+        dynamic required init?(coder aDecoder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        // MARK: Internal
+
+        override func viewDidLoad() {
+            super.viewDidLoad()
+
+            searchController.obscuresBackgroundDuringPresentation = false
+            searchController.hidesNavigationBarDuringPresentation = false
+            searchController.searchBar.placeholder = l("notes.search.placeholder.text")
+            searchController.searchBar.delegate = self
+            navigationItem.searchController = searchController
+            navigationItem.hidesSearchBarWhenScrolling = true
+            definesPresentationContext = true
+
+            viewModel.$searchTerm
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] term in
+                    guard let bar = self?.searchController.searchBar else { return }
+                    if bar.text != term {
+                        bar.text = term
+                    }
+                }
+                .store(in: &cancellables)
+        }
+
+        func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+            logger.info("[Notes] search textDidChange to \(searchText)")
+            viewModel.searchTerm = searchText
+        }
+
+        func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+            logger.info("[Notes] search cancel")
+            viewModel.searchTerm = ""
+        }
+
+        func dismissNoteEditor() {
+            dismiss(animated: true)
+        }
+
+        // MARK: Private
+
+        private var editController: EditController?
+        private let viewModel: SyncedNotesViewModel
+        private let noteEditorBuilder: SyncedNoteEditorBuilder
+        private let searchController = UISearchController(searchResultsController: nil)
+        private var cancellables: Set<AnyCancellable> = []
+
+        private var currentEditMode: EditMode? {
+            if viewModel.notes.isEmpty {
+                return nil
+            }
+            return viewModel.editMode
+        }
+
+        private func initialize() {
+            title = l("tab.notes")
+
+            editController = EditController(
+                navigationItem: navigationItem,
+                reload: viewModel.objectWillChange.eraseToAnyPublisher(),
+                editMode: Binding(
+                    get: { [weak self] in self?.currentEditMode },
+                    set: { [weak self] value in self?.viewModel.editMode = value ?? .inactive }
+                ),
+                customItems: [
+                    UIBarButtonItem(
+                        image: UIImage(systemName: "square.and.arrow.up"),
+                        style: .plain,
+                        target: self,
+                        action: #selector(shareAllNotes)
+                    ),
+                ]
+            )
+        }
+
+        private func editNote(_ note: SyncedNote) {
+            let viewController = noteEditorBuilder.build(withListener: self, note: note)
+            present(viewController, animated: true)
+        }
+
+        @objc
+        private func shareAllNotes() {
+            Task {
+                do {
+                    let notesText = try await viewModel.prepareNotesForSharing()
+                    let activityViewController = UIActivityViewController(activityItems: [notesText], applicationActivities: nil)
+                    let view = navigationController?.view
+                    let viewBound = view.map { CGRect(x: $0.bounds.midX, y: $0.bounds.midY, width: 0, height: 0) }
+                    activityViewController.modalPresentationStyle = .formSheet
+                    activityViewController.popoverPresentationController?.permittedArrowDirections = []
+                    activityViewController.popoverPresentationController?.sourceView = view
+                    activityViewController.popoverPresentationController?.sourceRect = viewBound ?? .zero
+                    present(activityViewController, animated: true)
+                } catch {
+                    showErrorAlert(error: error)
+                }
+            }
+        }
+    }
+#endif

--- a/Features/NotesFeature/SyncedNotesViewModel.swift
+++ b/Features/NotesFeature/SyncedNotesViewModel.swift
@@ -1,0 +1,117 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNotesViewModel.swift
+    //
+    //  Created by Ahmed Nabil on 2026-05-16.
+    //
+
+    import AnnotationsService
+    import Crashing
+    import Foundation
+    import Localization
+    import QuranKit
+    import QuranTextKit
+    import ReadingService
+    import SwiftUI
+    import Utilities
+    import VLogging
+
+    @MainActor
+    final class SyncedNotesViewModel: ObservableObject {
+        // MARK: Lifecycle
+
+        init(noteService: MobileSyncNoteService, textService: QuranTextDataService) {
+            self.noteService = noteService
+            self.textService = textService
+        }
+
+        // MARK: Internal
+
+        @Published var editMode: EditMode = .inactive
+        @Published var error: Error?
+        @Published var notes: [SyncedNoteItem] = []
+        @Published var searchTerm: String = ""
+
+        var filteredNotes: [SyncedNoteItem] {
+            let term = searchTerm.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !term.isEmpty else {
+                return notes
+            }
+            return notes.filter { item in
+                if item.note.body.range(of: term, options: .caseInsensitive) != nil {
+                    return true
+                }
+                let suraName = item.note.firstVerse.sura.localizedName()
+                return suraName.range(of: term, options: .caseInsensitive) != nil
+            }
+        }
+
+        func start() async {
+            do {
+                let sequence = noteService.notesSequence(quran: readingPreferences.reading.quran)
+                for try await notes in sequence {
+                    self.notes = await noteItems(with: notes)
+                }
+            } catch {
+                self.error = error
+            }
+        }
+
+        func deleteItem(_ item: SyncedNoteItem) async {
+            do {
+                try await noteService.removeNote(item.note)
+            } catch {
+                self.error = error
+            }
+        }
+
+        func prepareNotesForSharing() async throws -> String {
+            try await crasher.recordError("Failed to share synced notes") {
+                var notesText = [String]()
+                let notes: [SyncedNoteItem] = await self.notes
+                for (index, note) in notes.enumerated() {
+                    notesText.append(contentsOf: [note.note.body.trimmingCharacters(in: .newlines), ""])
+                    let verses = try await textForVerses(note.note.verses)
+                    notesText.append(verses)
+                    if index != notes.count - 1 {
+                        notesText.append(contentsOf: ["", "", ""])
+                    }
+                }
+                return notesText.joined(separator: "\n")
+            }
+        }
+
+        // MARK: Private
+
+        private let noteService: MobileSyncNoteService
+        private let textService: QuranTextDataService
+        private let readingPreferences = ReadingPreferences.shared
+
+        private nonisolated func noteItems(with notes: [SyncedNote]) async -> [SyncedNoteItem] {
+            await withTaskGroup(of: SyncedNoteItem.self) { group in
+                for note in notes {
+                    group.addTask {
+                        do {
+                            let verseText = try await self.textForVerses(note.verses)
+                            return SyncedNoteItem(note: note, verseText: verseText)
+                        } catch {
+                            crasher.recordError(error, reason: "SyncedNotesViewModel.textForVerses")
+                            return SyncedNoteItem(note: note, verseText: note.firstVerse.localizedName)
+                        }
+                    }
+                }
+
+                return await group.collect()
+            }
+        }
+
+        private nonisolated func textForVerses(_ verses: [AyahNumber]) async throws -> String {
+            let verseTexts = try await textService.textForVerses(verses, translations: [])
+            return verses.sorted()
+                .compactMap { verse in
+                    verseTexts[verse].map { $0.arabicText + " \(NumberFormatter.arabicNumberFormatter.format(verse.ayah))" }
+                }
+                .joined(separator: " ")
+        }
+    }
+#endif

--- a/Features/NotesFeature/SyncedNotesViewModel.swift
+++ b/Features/NotesFeature/SyncedNotesViewModel.swift
@@ -41,7 +41,7 @@
                 if item.note.body.range(of: term, options: .caseInsensitive) != nil {
                     return true
                 }
-                let suraName = item.note.firstVerse.sura.localizedName()
+                let suraName = item.note.startAyah.sura.localizedName()
                 return suraName.range(of: term, options: .caseInsensitive) != nil
             }
         }
@@ -71,7 +71,7 @@
                 let notes: [SyncedNoteItem] = await self.notes
                 for (index, note) in notes.enumerated() {
                     notesText.append(contentsOf: [note.note.body.trimmingCharacters(in: .newlines), ""])
-                    let verses = try await textForVerses(note.note.verses)
+                    let verses = try await textForVerses(note.note.startAyah.array(to: note.note.endAyah))
                     notesText.append(verses)
                     if index != notes.count - 1 {
                         notesText.append(contentsOf: ["", "", ""])
@@ -88,20 +88,22 @@
         private let readingPreferences = ReadingPreferences.shared
 
         private nonisolated func noteItems(with notes: [SyncedNote]) async -> [SyncedNoteItem] {
-            await withTaskGroup(of: SyncedNoteItem.self) { group in
-                for note in notes {
+            await withTaskGroup(of: (Int, SyncedNoteItem).self) { group in
+                for (index, note) in notes.enumerated() {
                     group.addTask {
                         do {
-                            let verseText = try await self.textForVerses(note.verses)
-                            return SyncedNoteItem(note: note, verseText: verseText)
+                            let verseText = try await self.textForVerses(note.startAyah.array(to: note.endAyah))
+                            return (index, SyncedNoteItem(note: note, verseText: verseText))
                         } catch {
                             crasher.recordError(error, reason: "SyncedNotesViewModel.textForVerses")
-                            return SyncedNoteItem(note: note, verseText: note.firstVerse.localizedName)
+                            return (index, SyncedNoteItem(note: note, verseText: note.startAyah.localizedName))
                         }
                     }
                 }
 
                 return await group.collect()
+                    .sorted { $0.0 < $1.0 }
+                    .map(\.1)
             }
         }
 

--- a/Features/QuranViewFeature/QuranBuilder.swift
+++ b/Features/QuranViewFeature/QuranBuilder.swift
@@ -35,21 +35,49 @@ public struct QuranBuilder {
 
         let quran = ReadingPreferences.shared.reading.quran
         let pageBookmarkService = PageBookmarkService(persistence: container.pageBookmarkPersistence)
-        let interactorDeps = QuranInteractor.Deps(
-            quran: quran,
-            analytics: container.analytics,
-            pageBookmarkService: pageBookmarkService,
-            noteService: container.noteService(),
-            ayahMenuBuilder: AyahMenuBuilder(container: container),
-            moreMenuBuilder: MoreMenuBuilder(),
-            audioBannerBuilder: AudioBannerBuilder(container: container),
-            wordPointerBuilder: WordPointerBuilder(container: container),
-            noteEditorBuilder: NoteEditorBuilder(container: container),
-            contentBuilder: ContentBuilder(container: container, highlightsService: highlightsService),
-            translationsSelectionBuilder: TranslationsListBuilder(container: container),
-            translationVerseBuilder: TranslationVerseBuilder(container: container),
-            resources: container.readingResources
-        )
+        #if QURAN_SYNC
+            let syncedNoteService = container.mobileSyncNoteService()
+            let syncedNoteEditorBuilder = syncedNoteService.map {
+                SyncedNoteEditorBuilder(
+                    noteService: $0,
+                    textService: container.textDataService(),
+                    analytics: container.analytics
+                )
+            }
+            let interactorDeps = QuranInteractor.Deps(
+                quran: quran,
+                analytics: container.analytics,
+                pageBookmarkService: pageBookmarkService,
+                noteService: container.noteService(),
+                ayahMenuBuilder: AyahMenuBuilder(container: container),
+                moreMenuBuilder: MoreMenuBuilder(),
+                audioBannerBuilder: AudioBannerBuilder(container: container),
+                wordPointerBuilder: WordPointerBuilder(container: container),
+                noteEditorBuilder: NoteEditorBuilder(container: container),
+                contentBuilder: ContentBuilder(container: container, highlightsService: highlightsService),
+                translationsSelectionBuilder: TranslationsListBuilder(container: container),
+                translationVerseBuilder: TranslationVerseBuilder(container: container),
+                resources: container.readingResources,
+                syncedNoteService: syncedNoteService,
+                syncedNoteEditorBuilder: syncedNoteEditorBuilder
+            )
+        #else
+            let interactorDeps = QuranInteractor.Deps(
+                quran: quran,
+                analytics: container.analytics,
+                pageBookmarkService: pageBookmarkService,
+                noteService: container.noteService(),
+                ayahMenuBuilder: AyahMenuBuilder(container: container),
+                moreMenuBuilder: MoreMenuBuilder(),
+                audioBannerBuilder: AudioBannerBuilder(container: container),
+                wordPointerBuilder: WordPointerBuilder(container: container),
+                noteEditorBuilder: NoteEditorBuilder(container: container),
+                contentBuilder: ContentBuilder(container: container, highlightsService: highlightsService),
+                translationsSelectionBuilder: TranslationsListBuilder(container: container),
+                translationVerseBuilder: TranslationVerseBuilder(container: container),
+                resources: container.readingResources
+            )
+        #endif
         let interactor = QuranInteractor(deps: interactorDeps, input: input)
         let viewController = QuranViewController(interactor: interactor)
         return viewController

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -72,6 +72,10 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let translationsSelectionBuilder: TranslationsListBuilder
         let translationVerseBuilder: TranslationVerseBuilder
         let resources: ReadingResourcesService
+        #if QURAN_SYNC
+            let syncedNoteService: MobileSyncNoteService?
+            let syncedNoteEditorBuilder: SyncedNoteEditorBuilder?
+        #endif
     }
 
     // MARK: Lifecycle
@@ -99,10 +103,13 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     var visiblePages: [Page] { contentViewModel?.visiblePages ?? [] }
 
     func start() {
-        deps.noteService.notes(quran: deps.quran)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in self?.notes = $0 }
-            .store(in: &cancellables)
+        #if QURAN_SYNC
+            if deps.syncedNoteService == nil {
+                startLegacyNotesObservation()
+            }
+        #else
+            startLegacyNotesObservation()
+        #endif
 
         deps.pageBookmarkService.pageBookmarks(quran: deps.quran)
             .receive(on: DispatchQueue.main)
@@ -207,6 +214,19 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let viewController = deps.noteEditorBuilder.build(withListener: self, note: note)
         presenter?.present(viewController, animated: true)
     }
+
+    #if QURAN_SYNC
+        func addSyncedNote(verses: [AyahNumber]) {
+            guard let syncedNoteEditorBuilder = deps.syncedNoteEditorBuilder else {
+                return
+            }
+
+            dismissAyahMenu()
+            presenter?.rotateToPortraitIfPhone()
+            let viewController = syncedNoteEditorBuilder.build(withListener: self, verses: verses)
+            presenter?.present(viewController, animated: true)
+        }
+    #endif
 
     func dismissNoteEditor() {
         logger.info("Quran: dismiss note editor")
@@ -337,6 +357,13 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         didSet {
             reloadPageBookmark()
         }
+    }
+
+    private func startLegacyNotesObservation() {
+        deps.noteService.notes(quran: deps.quran)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.notes = $0 }
+            .store(in: &cancellables)
     }
 
     private func setVisiblePages(_ pages: [Page]) {

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -86,6 +86,12 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         logger.info("Quran: opening quran \(input)")
     }
 
+    deinit {
+        #if QURAN_SYNC
+            syncedNotesObservationTask?.cancel()
+        #endif
+    }
+
     // MARK: Internal
 
     @Published var contentStatus: ContentStatusView.State?
@@ -104,7 +110,9 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
     func start() {
         #if QURAN_SYNC
-            if deps.syncedNoteService == nil {
+            if let syncedNoteService = deps.syncedNoteService {
+                startSyncedNotesObservation(syncedNoteService)
+            } else {
                 startLegacyNotesObservation()
             }
         #else
@@ -258,7 +266,8 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             sourceView: sourceView,
             pointInView: point,
             verses: verses,
-            notes: notes
+            notes: notes,
+            noteCount: syncedNoteCount(interacting: verses)
         )
         let ayahMenuViewController = deps.ayahMenuBuilder.build(withListener: self, input: input)
         presenter?.presentAyahMenu(ayahMenuViewController, in: sourceView, at: point)
@@ -334,6 +343,10 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     private let selectedTranslationsPreferences = SelectedTranslationsPreferences.shared
 
     private var notes: [Note] = []
+    #if QURAN_SYNC
+        private var syncedNotes: [SyncedNote] = []
+        private var syncedNotesObservationTask: Task<Void, Never>?
+    #endif
 
     private var deps: Deps
     private let input: QuranInput
@@ -365,6 +378,26 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             .sink { [weak self] in self?.notes = $0 }
             .store(in: &cancellables)
     }
+
+    #if QURAN_SYNC
+        private func startSyncedNotesObservation(_ noteService: MobileSyncNoteService) {
+            let quran = deps.quran
+            syncedNotesObservationTask?.cancel()
+            syncedNotesObservationTask = Task {
+                do {
+                    let sequence = noteService.notesSequence(quran: quran)
+                    for try await notes in sequence {
+                        await MainActor.run { [weak self] in
+                            self?.syncedNotes = notes
+                        }
+                    }
+                } catch is CancellationError {
+                } catch {
+                    crasher.recordError(error, reason: "Failed to observe synced notes")
+                }
+            }
+        }
+    #endif
 
     private func setVisiblePages(_ pages: [Page]) {
         logger.info("Quran: set visible pages \(pages)")
@@ -400,6 +433,14 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     private func notesInteractingVerses(_ verses: [AyahNumber]) -> [Note] {
         let selectedVerses = Set(verses)
         return notes.filter { !selectedVerses.isDisjoint(with: $0.verses) }
+    }
+
+    private func syncedNoteCount(interacting verses: [AyahNumber]) -> Int {
+        #if QURAN_SYNC
+            return SyncedNoteCounter.count(syncedNotes, interacting: verses)
+        #else
+            return 0
+        #endif
     }
 
     private func dismissWordPointer() {

--- a/Features/QuranViewFeature/SyncedNoteCounter.swift
+++ b/Features/QuranViewFeature/SyncedNoteCounter.swift
@@ -1,0 +1,23 @@
+#if QURAN_SYNC
+    //
+    //  SyncedNoteCounter.swift
+    //  Quran
+    //
+    //  Created by Ahmed Nabil on 2026-05-20.
+    //
+
+    import AnnotationsService
+    import QuranKit
+
+    enum SyncedNoteCounter {
+        static func count(_ notes: [SyncedNote], interacting verses: [AyahNumber]) -> Int {
+            let selectedVerses = Set(verses)
+            return notes.filter { note in
+                guard note.endAyah >= note.startAyah else {
+                    return false
+                }
+                return !selectedVerses.isDisjoint(with: note.startAyah.array(to: note.endAyah))
+            }.count
+        }
+    }
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -613,9 +613,11 @@ private func featuresTargets() -> [[Target]] {
         ]),
 
         target(type, name: "NoteEditorFeature", hasTests: false, dependencies: [
+            "Analytics",
             "AppDependencies",
             "AnnotationsService",
             "NoorUI",
+            "QuranTextKit",
         ]),
 
         target(type, name: "BookmarksFeature", dependencies: [
@@ -685,6 +687,7 @@ private func featuresTargets() -> [[Target]] {
             "FeaturesSupport",
             "ReadingService",
             "NoorUI",
+            "NoteEditorFeature",
         ]),
 
         target(type, name: "TranslationVerseFeature", hasTests: false, dependencies: [

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
@@ -54,7 +54,8 @@ public enum AyahMenuUI {
             repeatSubtitle: String,
             actions: Actions,
             isTranslationView: Bool,
-            usesSyncedNotesIcon: Bool = false
+            usesSyncedNotesIcon: Bool = false,
+            noteCount: Int = 0
         ) {
             self.highlightingColor = highlightingColor
             self.state = state
@@ -63,6 +64,7 @@ public enum AyahMenuUI {
             self.actions = actions
             self.isTranslationView = isTranslationView
             self.usesSyncedNotesIcon = usesSyncedNotesIcon
+            self.noteCount = noteCount
         }
 
         // MARK: Internal
@@ -74,6 +76,7 @@ public enum AyahMenuUI {
         let repeatSubtitle: String
         let isTranslationView: Bool
         let usesSyncedNotesIcon: Bool
+        let noteCount: Int
     }
 
     // MARK: Public

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
@@ -53,7 +53,8 @@ public enum AyahMenuUI {
             playSubtitle: String,
             repeatSubtitle: String,
             actions: Actions,
-            isTranslationView: Bool
+            isTranslationView: Bool,
+            usesSyncedNotesIcon: Bool = false
         ) {
             self.highlightingColor = highlightingColor
             self.state = state
@@ -61,6 +62,7 @@ public enum AyahMenuUI {
             self.repeatSubtitle = repeatSubtitle
             self.actions = actions
             self.isTranslationView = isTranslationView
+            self.usesSyncedNotesIcon = usesSyncedNotesIcon
         }
 
         // MARK: Internal
@@ -71,6 +73,7 @@ public enum AyahMenuUI {
         let playSubtitle: String
         let repeatSubtitle: String
         let isTranslationView: Bool
+        let usesSyncedNotesIcon: Bool
     }
 
     // MARK: Public

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
@@ -90,6 +90,10 @@ private struct AyahMenuViewList: View {
     var addNote: some View {
         Row(title: l("ayah.menu.add-note"), action: dataObject.actions.addNote) {
             noteIcon(legacySystemName: "plus.bubble.fill")
+        } accessory: {
+            if dataObject.noteCount > 0 {
+                NoteCountBadge(count: dataObject.noteCount)
+            }
         }
     }
 
@@ -205,7 +209,23 @@ private struct AyahMenuViewList: View {
     }
 }
 
-private struct Row<Symbol: View>: View {
+private struct NoteCountBadge: View {
+    let count: Int
+
+    @ScaledMetric private var horizontalPadding = ContentDimension.interPageSpacing
+    @ScaledMetric private var verticalPadding = ContentDimension.interSpacing
+
+    var body: some View {
+        Text(NumberFormatter.shared.format(count))
+            .font(.footnote)
+            .foregroundColor(Color.label)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .background(Capsule().fill(Color(.secondarySystemFill)))
+    }
+}
+
+private struct Row<Symbol: View, Accessory: View>: View {
     // MARK: Lifecycle
 
     init(
@@ -213,19 +233,38 @@ private struct Row<Symbol: View>: View {
         subtitle: String? = nil,
         action: @Sendable @escaping () async -> Void,
         @ViewBuilder symbol: () -> Symbol
-    ) {
+    ) where Accessory == EmptyView {
         self.symbol = symbol()
+        accessory = EmptyView()
         self.title = title
         self.subtitle = subtitle
         self.action = action
+        hasAccessory = false
+    }
+
+    init(
+        title: String,
+        subtitle: String? = nil,
+        action: @Sendable @escaping () async -> Void,
+        @ViewBuilder symbol: () -> Symbol,
+        @ViewBuilder accessory: () -> Accessory
+    ) {
+        self.symbol = symbol()
+        self.accessory = accessory()
+        self.title = title
+        self.subtitle = subtitle
+        self.action = action
+        hasAccessory = true
     }
 
     // MARK: Internal
 
     let symbol: Symbol
+    let accessory: Accessory
     let title: String
     let subtitle: String?
     let action: @Sendable () async -> Void
+    let hasAccessory: Bool
     @ScaledMetric var verticalPadding = 12
 
     var body: some View {
@@ -248,6 +287,10 @@ private struct Row<Symbol: View>: View {
                         .font(.footnote)
                         .foregroundColor(.secondaryLabel)
                     }
+                }
+                if hasAccessory {
+                    Spacer(minLength: 12)
+                    accessory
                 }
             }
             .padding(.horizontal)

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
@@ -65,6 +65,8 @@ public struct AyahMenuView: View {
 }
 
 private struct AyahMenuViewList: View {
+    // MARK: Internal
+
     let dataObject: AyahMenuUI.DataObject
     let showHighlights: AsyncAction
 
@@ -81,15 +83,13 @@ private struct AyahMenuViewList: View {
 
     var editNote: some View {
         Row(title: l("ayah.menu.edit-note"), action: dataObject.actions.addNote) {
-            Image(systemName: "text.bubble.fill")
-                .foregroundColor(dataObject.highlightingColor.color)
+            noteIcon(legacySystemName: "text.bubble.fill")
         }
     }
 
     var addNote: some View {
         Row(title: l("ayah.menu.add-note"), action: dataObject.actions.addNote) {
-            Image(systemName: "plus.bubble.fill")
-                .foregroundColor(dataObject.highlightingColor.color)
+            noteIcon(legacySystemName: "plus.bubble.fill")
         }
     }
 
@@ -189,6 +189,19 @@ private struct AyahMenuViewList: View {
             }
         }
         .fixedSize(horizontal: true, vertical: false)
+    }
+
+    // MARK: Private
+
+    private func noteIcon(legacySystemName: String) -> some View {
+        Group {
+            if dataObject.usesSyncedNotesIcon {
+                NoorSystemImage.note.image
+            } else {
+                Image(systemName: legacySystemName)
+                    .foregroundColor(dataObject.highlightingColor.color)
+            }
+        }
     }
 }
 

--- a/UI/NoorUI/Features/Note/EditableNote.swift
+++ b/UI/NoorUI/Features/Note/EditableNote.swift
@@ -26,6 +26,10 @@ public class EditableNote: ObservableObject {
     @Published public internal(set) var selectedColor: Note.Color
     @Published public internal(set) var note: String
 
+    public var notePublisher: AnyPublisher<String, Never> {
+        $note.eraseToAnyPublisher()
+    }
+
     // MARK: Internal
 
     @Published var editing: Bool

--- a/UI/NoorUI/Features/Note/NoteEditorView.swift
+++ b/UI/NoorUI/Features/Note/NoteEditorView.swift
@@ -13,8 +13,14 @@ import UIx
 public struct NoteEditorView: View {
     // MARK: Lifecycle
 
-    public init(note: EditableNote, done: @escaping () -> Void, delete: @Sendable @escaping () async -> Void) {
+    public init(
+        note: EditableNote,
+        showsColors: Bool = true,
+        done: @escaping () -> Void,
+        delete: @Sendable @escaping () async -> Void
+    ) {
         _note = ObservedObject(initialValue: note)
+        self.showsColors = showsColors
         self.done = done
         self.delete = delete
     }
@@ -26,11 +32,13 @@ public struct NoteEditorView: View {
             ZStack(alignment: .leading) {
                 HStack {
                     Spacer()
-                    ForEach(Note.Color.sortedColors, id: \.self) { color in
-                        Button(
-                            action: { note.selectedColor = color },
-                            label: { NoteCircle(color: color.color, selected: color == note.selectedColor) }
-                        )
+                    if showsColors {
+                        ForEach(Note.Color.sortedColors, id: \.self) { color in
+                            Button(
+                                action: { note.selectedColor = color },
+                                label: { NoteCircle(color: color.color, selected: color == note.selectedColor) }
+                            )
+                        }
                     }
                     Spacer()
                 }
@@ -57,8 +65,10 @@ public struct NoteEditorView: View {
                     .font(.quran(ofSize: .small))
                     .padding(.leading)
                     .overlay(HStack {
-                        Rectangle().fill(note.selectedColor.color)
-                            .frame(width: 4)
+                        if showsColors {
+                            Rectangle().fill(note.selectedColor.color)
+                                .frame(width: 4)
+                        }
                         Spacer()
                     })
                     .environment(\.layoutDirection, .rightToLeft)
@@ -84,6 +94,7 @@ public struct NoteEditorView: View {
 
     @ObservedObject var note: EditableNote
 
+    let showsColors: Bool
     let done: () -> Void
     let delete: @Sendable () async -> Void
 }

--- a/UI/NoorUI/Features/Note/UIViewController+Note.swift
+++ b/UI/NoorUI/Features/Note/UIViewController+Note.swift
@@ -26,6 +26,16 @@ extension UIViewController {
         present(alert, animated: true)
     }
 
+    public func showNoteMinimumLengthAlert(minimumLength: Int) {
+        let alert = UIAlertController(
+            title: l("notes.minimum-length.alert.title"),
+            message: lFormat("notes.minimum-length.alert.body", minimumLength),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: lAndroid("dialog_ok"), style: .default, handler: nil))
+        present(alert, animated: true)
+    }
+
     public func addCloudSyncInfo() {
         navigationItem.leftBarButtonItem = UIBarButtonItem(
             image: .symbol("link.icloud.fill"),

--- a/UI/NoorUI/Features/Note/UIViewController+Note.swift
+++ b/UI/NoorUI/Features/Note/UIViewController+Note.swift
@@ -26,6 +26,21 @@ extension UIViewController {
         present(alert, animated: true)
     }
 
+    public func confirmSyncedNoteDelete(delete: @escaping AsyncAction, cancel: @escaping () -> Void) {
+        let alert = UIAlertController(
+            title: l("notes.delete-note.alert.title"),
+            message: l("notes.delete-note.alert.body"),
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: lAndroid("cancel"), style: .cancel) { _ in cancel() })
+        alert.addAction(UIAlertAction(title: l("button.delete"), style: .destructive) { _ in
+            Task {
+                await delete()
+            }
+        })
+        present(alert, animated: true)
+    }
+
     public func showNoteMinimumLengthAlert(minimumLength: Int) {
         let alert = UIAlertController(
             title: l("notes.minimum-length.alert.title"),


### PR DESCRIPTION
## Summary
- Uses Mobile Sync notes when `QURAN_SYNC` is enabled.
- Keeps legacy notes behavior unchanged when sync is disabled.
- Sync note editor hides color controls and enforces the 6-character minimum with localized alerts.
- Sync notes list supports multiple notes for the same ayah, edit, and delete.
- Uses the Notes tab icon in the ayah menu for the sync notes action.

## Scope
- UI/wiring only on top of the Mobile Sync notes service PR.
- No legacy note persistence changes.
- No note/highlight migration logic.

## Validation
- `QURAN_SYNC=1 xcodebuild build` passed.
- Non-sync `xcodebuild build` passed.
- `swiftformat --lint .` passed.
- Targeted `MobileSyncNoteServiceTests` passed through the stack.

https://github.com/user-attachments/assets/73c55c9d-d025-4188-9b2c-b4b6735f1dc1


