### PR TITLE
Feature/streaming audio

### DIFF
--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -102,6 +102,8 @@
 "audio.select-end-verse" = "حدد نهاية التشغيل الصوتي";
 
 "audio.download-play-amount" = "تحميل وتشغيل الصوت لنهاية";
+"audio.streaming.title" = "تشغيل الصوت عبر الإنترنت";
+"audio.streaming.description" = "يوفر مساحة التخزين ببث الصوت، لكنه يتطلب اتصالًا بالإنترنت.";
 "audio.download-play-amount.description" = "عند بدء تشغيل الصوت، سيتوقف مع نهاية";
 
 // MARK: - Bookmarks

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -115,6 +115,7 @@
 
 "audio.download-play-amount" = "Download/Play up to";
 "audio.streaming.title" = "Stream Audio";
+"audio.streaming.description" = "Play without downloading";
 "audio.download-play-amount.description" = "When playing audio, it will play to the end of the";
 
 // MARK: - Bookmarks

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 
 "audio.download-play-amount" = "Download/Play up to";
 "audio.streaming.title" = "Stream Audio";
-"audio.streaming.description" = "Play without downloading";
+"audio.streaming.description" = "Saves disk space by streaming audio, but requires an internet connection.";
 "audio.download-play-amount.description" = "When playing audio, it will play to the end of the";
 
 // MARK: - Bookmarks

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -114,6 +114,7 @@
 "audio.end-at.custom" = "Custom";
 
 "audio.download-play-amount" = "Download/Play up to";
+"audio.streaming.title" = "Stream Audio";
 "audio.download-play-amount.description" = "When playing audio, it will play to the end of the";
 
 // MARK: - Bookmarks

--- a/Domain/QuranAudioKit/Sources/AudioPlayer/GaplessAudioRequestBuilder.swift
+++ b/Domain/QuranAudioKit/Sources/AudioPlayer/GaplessAudioRequestBuilder.swift
@@ -7,6 +7,7 @@
 //
 
 import AudioTimingService
+import Foundation
 import QueuePlayer
 import QuranAudio
 import QuranKit
@@ -45,15 +46,16 @@ struct GaplessAudioRequestBuilder: QuranAudioRequestBuilder {
         from start: AyahNumber,
         to end: AyahNumber,
         frameRuns: Runs,
-        requestRuns: Runs
+        requestRuns: Runs,
+        streaming: Bool
     ) async throws -> QuranAudioRequest {
         let range = try await timingRetriever.timing(for: reciter, from: start, to: end)
-        let surasPaths = urlsToPlay(reciter: reciter, suras: range.timings.keys)
+        let suraURLs = urlsToPlay(reciter: reciter, suras: range.timings.keys, streaming: streaming)
 
         var files: [AudioFile] = []
         var ayahs: [[AyahNumber]] = []
 
-        for (path, sura) in surasPaths {
+        for (url, sura) in suraURLs {
             let suraTimings = range.timings[sura]!
 
             var frames: [AudioFrame] = []
@@ -74,7 +76,7 @@ struct GaplessAudioRequestBuilder: QuranAudioRequestBuilder {
                 frames.append(frame)
                 fileAyahs.append(verse.ayah)
             }
-            files.append(AudioFile(url: path.url, frames: frames))
+            files.append(AudioFile(url: url, frames: frames))
             ayahs.append(fileAyahs)
         }
         let request = AudioRequest(files: files, endTime: range.endTime?.seconds, frameRuns: frameRuns, requestRuns: requestRuns)
@@ -84,16 +86,15 @@ struct GaplessAudioRequestBuilder: QuranAudioRequestBuilder {
 
     // MARK: Private
 
-    private func urlsToPlay(reciter: Reciter, suras: some Collection<Sura>) -> [(path: RelativeFilePath, sura: Sura)] {
+    private func urlsToPlay(reciter: Reciter, suras: some Collection<Sura>, streaming: Bool) -> [(url: URL, sura: Sura)] {
         guard case AudioType.gapless = reciter.audioType else {
             fatalError("Unsupported reciter type gapped. Only gapless reciters can be played here.")
         }
 
-        // loop over the files
-        var files: [(RelativeFilePath, Sura)] = []
+        var files: [(URL, Sura)] = []
         for sura in suras.sorted() {
-            let localURL = reciter.localURL(sura: sura)
-            files.append((localURL, sura))
+            let url = streaming ? reciter.remoteURL(sura: sura) : reciter.localURL(sura: sura).url
+            files.append((url, sura))
         }
         return files
     }

--- a/Domain/QuranAudioKit/Sources/AudioPlayer/GappedAudioRequestBuilder.swift
+++ b/Domain/QuranAudioKit/Sources/AudioPlayer/GappedAudioRequestBuilder.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Quran.com. All rights reserved.
 //
 
+import Foundation
 import QueuePlayer
 import QuranAudio
 import QuranKit
@@ -42,11 +43,12 @@ final class GappedAudioRequestBuilder: QuranAudioRequestBuilder {
         from start: AyahNumber,
         to end: AyahNumber,
         frameRuns: Runs,
-        requestRuns: Runs
+        requestRuns: Runs,
+        streaming: Bool
     ) async throws -> QuranAudioRequest {
-        let (urls, ayahs) = urlsToPlay(reciter: reciter, from: start, to: end, requestRuns: requestRuns)
+        let (urls, ayahs) = urlsToPlay(reciter: reciter, from: start, to: end, requestRuns: requestRuns, streaming: streaming)
         let files = urls.map {
-            AudioFile(url: $0.url, frames: [AudioFrame(startTime: 0, endTime: nil)])
+            AudioFile(url: $0, frames: [AudioFrame(startTime: 0, endTime: nil)])
         }
         let request = AudioRequest(files: files, endTime: nil, frameRuns: frameRuns, requestRuns: requestRuns)
         let quranRequest = GappedAudioRequest(request: request, ayahs: ayahs, reciter: reciter)
@@ -55,12 +57,12 @@ final class GappedAudioRequestBuilder: QuranAudioRequestBuilder {
 
     // MARK: Private
 
-    private func urlsToPlay(reciter: Reciter, from start: AyahNumber, to end: AyahNumber, requestRuns: Runs) -> (urls: [RelativeFilePath], ayahs: [AyahNumber]) {
+    private func urlsToPlay(reciter: Reciter, from start: AyahNumber, to end: AyahNumber, requestRuns: Runs, streaming: Bool) -> (urls: [URL], ayahs: [AyahNumber]) {
         guard case AudioType.gapped = reciter.audioType else {
             fatalError("Unsupported reciter type gapless. Only gapless reciters can be downloaded here.")
         }
 
-        var urls: [RelativeFilePath] = []
+        var urls: [URL] = []
         var ayahs: [AyahNumber] = []
         let verses = start.array(to: end)
         let surasDictionary = Dictionary(grouping: verses, by: { $0.sura })
@@ -70,11 +72,13 @@ final class GappedAudioRequestBuilder: QuranAudioRequestBuilder {
 
             // add besm Allah for all except Al-Fatihah and At-Tawbah
             if (requestRuns == .one || !ayahs.isEmpty) && sura.startsWithBesmAllah && verses[0] == sura.firstVerse {
-                urls.append(reciter.localURL(ayah: start.quran.firstVerse))
+                let url = streaming ? reciter.remoteURL(ayah: start.quran.firstVerse) : reciter.localURL(ayah: start.quran.firstVerse).url
+                urls.append(url)
                 ayahs.append(verses[0])
             }
             for verse in verses {
-                urls.append(reciter.localURL(ayah: verse))
+                let url = streaming ? reciter.remoteURL(ayah: verse) : reciter.localURL(ayah: verse).url
+                urls.append(url)
                 ayahs.append(verse)
             }
         }

--- a/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioPlayer.swift
+++ b/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioPlayer.swift
@@ -106,7 +106,7 @@ public class QuranAudioPlayer {
         try await unzipper.unzip(reciter: reciter)
 
         let builder = getAudioRequestBuilder(for: reciter)
-        let audioRequest = try await builder.buildRequest(with: reciter, from: start, to: end, frameRuns: verseRuns, requestRuns: listRuns)
+        let audioRequest = try await builder.buildRequest(with: reciter, from: start, to: end, frameRuns: verseRuns, requestRuns: listRuns, streaming: streaming)
         let request = audioRequest.getRequest()
         willPlay(request)
         self.audioRequest = audioRequest

--- a/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioPlayer.swift
+++ b/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioPlayer.swift
@@ -91,7 +91,8 @@ public class QuranAudioPlayer {
         from start: AyahNumber,
         to end: AyahNumber,
         verseRuns: Runs,
-        listRuns: Runs
+        listRuns: Runs,
+        streaming: Bool = false
     ) async throws {
         let details: [String: Any] = [
             "startAyah": start,

--- a/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioPlayer.swift
+++ b/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioPlayer.swift
@@ -100,6 +100,7 @@ public class QuranAudioPlayer {
             "reciter": reciter,
             "verseRuns": verseRuns,
             "listRuns": listRuns,
+            "streaming": streaming,
         ]
         logger.notice("Playing \(details.map { "\($0): \($1)" }.joined(separator: ", "))")
         try await unzipper.unzip(reciter: reciter)

--- a/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioRequestBuilder.swift
+++ b/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioRequestBuilder.swift
@@ -23,6 +23,7 @@ protocol QuranAudioRequestBuilder {
         from start: AyahNumber,
         to end: AyahNumber,
         frameRuns: Runs,
-        requestRuns: Runs
+        requestRuns: Runs,
+        streaming: Bool
     ) async throws -> QuranAudioRequest
 }

--- a/Domain/QuranAudioKit/Sources/Downloads/QuranAudioDownloader.swift
+++ b/Domain/QuranAudioKit/Sources/Downloads/QuranAudioDownloader.swift
@@ -66,6 +66,16 @@ public struct QuranAudioDownloader: Sendable {
         return fileSystem.fileExists(at: dbPath)
     }
 
+    public func downloadDatabase(reciter: Reciter) async throws -> DownloadBatchResponse {
+        guard let remoteURL = reciter.databaseRemoteURL(baseURL: baseURL),
+              let localPath = reciter.localZipPath
+        else {
+            fatalError("downloadDatabase called on a non-gapless reciter")
+        }
+        let request = DownloadBatchRequest(requests: [DownloadRequest(url: remoteURL, destination: localPath)])
+        return try await downloader.download(request)
+    }
+
     public func runningAudioDownloads() async -> [DownloadBatchResponse] {
         let batches = await downloader.getOnGoingDownloads()
         let responses = batches.filter(\.isAudio)

--- a/Domain/QuranAudioKit/Sources/Downloads/QuranAudioDownloader.swift
+++ b/Domain/QuranAudioKit/Sources/Downloads/QuranAudioDownloader.swift
@@ -57,6 +57,15 @@ public struct QuranAudioDownloader: Sendable {
         await downloader.cancel(downloads: downloads)
     }
 
+    public func databaseDownloaded(reciter: Reciter) -> Bool {
+        guard let dbPath = reciter.localDatabasePath else {
+            return true
+        }
+        // Only the extracted .db counts as ready; a partial/corrupt .zip is not sufficient
+        // and would cause unzip to fail. AudioUnzipper handles .zip → .db extraction.
+        return fileSystem.fileExists(at: dbPath)
+    }
+
     public func runningAudioDownloads() async -> [DownloadBatchResponse] {
         let batches = await downloader.getOnGoingDownloads()
         let responses = batches.filter(\.isAudio)

--- a/Domain/QuranAudioKit/Sources/Preferences/AudioPreferences.swift
+++ b/Domain/QuranAudioKit/Sources/Preferences/AudioPreferences.swift
@@ -23,8 +23,12 @@ public class AudioPreferences {
     @Preference(audioPlaybackRateKey)
     public var playbackRate: Float
 
+    @Preference(audioStreamingEnabledKey)
+    public var streamingEnabled: Bool
+
     // MARK: Private
 
     private static let audioEndKey = PreferenceKey<Int>(key: "audioEndKey", defaultValue: AudioEnd.juz.rawValue)
     private static let audioPlaybackRateKey = PreferenceKey<Float>(key: "audioPlaybackRate", defaultValue: 1.0)
+    private static let audioStreamingEnabledKey = PreferenceKey<Bool>(key: "audioStreamingEnabled", defaultValue: false)
 }

--- a/Domain/QuranAudioKit/Tests/GaplessAudioRequestBuilderTests.swift
+++ b/Domain/QuranAudioKit/Tests/GaplessAudioRequestBuilderTests.swift
@@ -33,10 +33,11 @@ class GaplessAudioRequestBuilderTests: XCTestCase {
             from: from,
             to: to,
             frameRuns: .one,
-            requestRuns: .one
+            requestRuns: .one,
+            streaming: false
         )
         let firstFrame = try XCTUnwrap(audioRequest.getRequest().files.first?.frames.first)
-        XCTAssertEqual(firstFrame.startTime, .zero)
+        XCTAssertEqual(firstFrame.startTime, 0)
     }
 
     func testAudioFrameIsNotStartingFromZeroSecondsWhenThePlaybackIsRepeated() async throws {
@@ -48,10 +49,11 @@ class GaplessAudioRequestBuilderTests: XCTestCase {
             from: from,
             to: to,
             frameRuns: .one,
-            requestRuns: .indefinite
+            requestRuns: .indefinite,
+            streaming: false
         )
         let firstFrame = try XCTUnwrap(audioRequest.getRequest().files.first?.frames.first)
-        XCTAssertNotEqual(firstFrame.startTime, .zero)
+        XCTAssertNotEqual(firstFrame.startTime, 0)
     }
 
     // MARK: Private

--- a/Domain/QuranAudioKit/Tests/GappedAudioRequestBuilderTests.swift
+++ b/Domain/QuranAudioKit/Tests/GappedAudioRequestBuilderTests.swift
@@ -33,7 +33,8 @@ class GappedAudioRequestBuilderTests: XCTestCase {
             from: from,
             to: to,
             frameRuns: .one,
-            requestRuns: .one
+            requestRuns: .one,
+            streaming: false
         )
         let audioRequest = try XCTUnwrap(request as? GappedAudioRequest).request
         let bismillahFile = audioRequest.files.first { audioFile in
@@ -51,7 +52,8 @@ class GappedAudioRequestBuilderTests: XCTestCase {
             from: from,
             to: to,
             frameRuns: .one,
-            requestRuns: .indefinite
+            requestRuns: .indefinite,
+            streaming: false
         )
         let audioRequest = try XCTUnwrap(request as? GappedAudioRequest).request
         let bismillahFile = audioRequest.files.first { audioFile in
@@ -69,7 +71,8 @@ class GappedAudioRequestBuilderTests: XCTestCase {
             from: from,
             to: to,
             frameRuns: .one,
-            requestRuns: .indefinite
+            requestRuns: .indefinite,
+            streaming: false
         )
         let audioRequest = try XCTUnwrap(request as? GappedAudioRequest).request
         let bismillahFile = audioRequest.files.first { audioFile in

--- a/Features/AudioBannerFeature/AudioBannerViewModel.swift
+++ b/Features/AudioBannerFeature/AudioBannerViewModel.swift
@@ -270,6 +270,8 @@ public final class AudioBannerViewModel: ObservableObject {
                     streaming: streaming
                 )
                 playingStarted()
+            } catch is CancellationError {
+                // User cancelled the download; cancelDownload() already reset state.
             } catch {
                 self?.playbackFailed(error)
             }

--- a/Features/AudioBannerFeature/AudioBannerViewModel.swift
+++ b/Features/AudioBannerFeature/AudioBannerViewModel.swift
@@ -222,7 +222,21 @@ public final class AudioBannerViewModel: ObservableObject {
                 let streaming = AudioPreferences.shared.streamingEnabled
 
                 if streaming {
-                    // gapped reciters stream directly with no download needed
+                    // For gapless streaming, the timing database must still be available locally.
+                    if case .gapless = selectedReciter.audioType {
+                        let dbReady = self?.downloader.databaseDownloaded(reciter: selectedReciter) ?? true
+                        logger.info("AudioBanner: streaming gapless – database ready? \(dbReady)")
+                        if !dbReady {
+                            self?.playingState = .downloading(progress: 0)
+                            let download = try await self?.downloader.downloadDatabase(reciter: selectedReciter)
+                            guard let download else {
+                                logger.info("AudioBanner: couldn't create database download request")
+                                return
+                            }
+                            for try await _ in download.progress { }
+                            logger.info("AudioBanner: database download completed")
+                        }
+                    }
                 } else {
                     let downloaded = await self?.downloader.downloaded(reciter: selectedReciter, from: from, to: end) ?? true
                     logger.info("AudioBanner: reciter downloaded? \(downloaded)")

--- a/Features/AudioBannerFeature/AudioBannerViewModel.swift
+++ b/Features/AudioBannerFeature/AudioBannerViewModel.swift
@@ -266,7 +266,8 @@ public final class AudioBannerViewModel: ObservableObject {
                     reciter: selectedReciter,
                     rate: playbackRate,
                     from: from, to: end,
-                    verseRuns: verseRuns, listRuns: listRuns
+                    verseRuns: verseRuns, listRuns: listRuns,
+                    streaming: streaming
                 )
                 playingStarted()
             } catch {

--- a/Features/AudioBannerFeature/AudioBannerViewModel.swift
+++ b/Features/AudioBannerFeature/AudioBannerViewModel.swift
@@ -233,7 +233,9 @@ public final class AudioBannerViewModel: ObservableObject {
                                 logger.info("AudioBanner: couldn't create database download request")
                                 return
                             }
-                            for try await _ in download.progress { }
+                            for try await _ in download.progress {
+                                await self?.updateDownloadProgress()
+                            }
                             logger.info("AudioBanner: database download completed")
                         }
                     }

--- a/Features/AudioBannerFeature/AudioBannerViewModel.swift
+++ b/Features/AudioBannerFeature/AudioBannerViewModel.swift
@@ -233,9 +233,7 @@ public final class AudioBannerViewModel: ObservableObject {
                                 logger.info("AudioBanner: couldn't create database download request")
                                 return
                             }
-                            for try await _ in download.progress {
-                                await self?.updateDownloadProgress()
-                            }
+                            await self?.observe([download])
                             logger.info("AudioBanner: database download completed")
                         }
                     }
@@ -270,8 +268,6 @@ public final class AudioBannerViewModel: ObservableObject {
                     streaming: streaming
                 )
                 playingStarted()
-            } catch is CancellationError {
-                // User cancelled the download; cancelDownload() already reset state.
             } catch {
                 self?.playbackFailed(error)
             }

--- a/Features/AudioBannerFeature/AudioBannerViewModel.swift
+++ b/Features/AudioBannerFeature/AudioBannerViewModel.swift
@@ -219,21 +219,27 @@ public final class AudioBannerViewModel: ObservableObject {
 
         cancellableTasks.task { [weak self] in
             do {
-                let downloaded = await self?.downloader.downloaded(reciter: selectedReciter, from: from, to: end) ?? true
-                logger.info("AudioBanner: reciter downloaded? \(downloaded)")
-                if !downloaded {
-                    self?.startDownloading()
-                    let download = try await self?.downloader.download(from: from, to: end, reciter: selectedReciter)
-                    guard let download else {
-                        logger.info("AudioBanner: couldn't create a download request")
-                        return
+                let streaming = AudioPreferences.shared.streamingEnabled
+
+                if streaming {
+                    // gapped reciters stream directly with no download needed
+                } else {
+                    let downloaded = await self?.downloader.downloaded(reciter: selectedReciter, from: from, to: end) ?? true
+                    logger.info("AudioBanner: reciter downloaded? \(downloaded)")
+                    if !downloaded {
+                        self?.startDownloading()
+                        let download = try await self?.downloader.download(from: from, to: end, reciter: selectedReciter)
+                        guard let download else {
+                            logger.info("AudioBanner: couldn't create a download request")
+                            return
+                        }
+
+                        await self?.observe([download])
+
+                        for try await _ in download.progress { }
+
+                        logger.info("AudioBanner: download completed")
                     }
-
-                    await self?.observe([download])
-
-                    for try await _ in download.progress { }
-
-                    logger.info("AudioBanner: download completed")
                 }
 
                 guard let self else {

--- a/Features/SettingsFeature/Sources/SettingsRootView.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootView.swift
@@ -99,6 +99,22 @@ private struct SettingsRootViewUI: View {
                     action: navigateToAudioEndSelector
                 )
 
+                HStack {
+                    Image(systemName: "dot.radiowaves.left.and.right")
+                        .foregroundStyle(Color.accentColor)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(l("audio.streaming.title"))
+                        Text(l("audio.streaming.description"))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Toggle(l("audio.streaming.title"), isOn: $streamingEnabled)
+                        .labelsHidden()
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 6)
+
                 NoorListItem(
                     image: .init(.downloads),
                     title: .text(lAndroid("audio_manager")),

--- a/Features/SettingsFeature/Sources/SettingsRootView.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootView.swift
@@ -233,10 +233,12 @@ private struct SettingsRootViewUI: View {
 struct SettingsRootView_Previews: PreviewProvider {
     struct Container: View {
         @State var appearanceMode: AppearanceMode
+        @State var streamingEnabled = false
 
         var body: some View {
             SettingsRootViewUI(
                 appearanceMode: $appearanceMode,
+                streamingEnabled: $streamingEnabled,
                 error: .constant(nil),
                 audioEnd: "Surah",
                 isAuthenticated: false,

--- a/Features/SettingsFeature/Sources/SettingsRootView.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootView.swift
@@ -17,6 +17,7 @@ struct SettingsRootView: View {
     var body: some View {
         SettingsRootViewUI(
             appearanceMode: $viewModel.appearanceMode,
+            streamingEnabled: $viewModel.streamingEnabled,
             error: $viewModel.error,
             audioEnd: viewModel.audioEnd.name,
             isAuthenticated: viewModel.isAuthenticated,
@@ -42,6 +43,7 @@ private struct SettingsRootViewUI: View {
     // MARK: Internal
 
     @Binding var appearanceMode: AppearanceMode
+    @Binding var streamingEnabled: Bool
     @Binding var error: Error?
 
     let audioEnd: String

--- a/Features/SettingsFeature/Sources/SettingsRootView.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootView.swift
@@ -101,7 +101,6 @@ private struct SettingsRootViewUI: View {
 
                 HStack {
                     Image(systemName: "dot.radiowaves.left.and.right")
-                        .foregroundStyle(Color.accentColor)
                     VStack(alignment: .leading, spacing: 2) {
                         Text(l("audio.streaming.title"))
                         Text(l("audio.streaming.description"))
@@ -112,7 +111,6 @@ private struct SettingsRootViewUI: View {
                     Toggle(l("audio.streaming.title"), isOn: $streamingEnabled)
                         .labelsHidden()
                 }
-                .padding(.horizontal)
                 .padding(.vertical, 6)
 
                 NoorListItem(

--- a/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
@@ -52,6 +52,7 @@ final class SettingsRootViewModel: ObservableObject {
 
         themeService.appearanceModePublisher.assign(to: &$appearanceMode)
         audioPreferences.$audioEnd.assign(to: &$audioEnd)
+        audioPreferences.$streamingEnabled.assign(to: &$streamingEnabled)
     }
 
     // MARK: Internal

--- a/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
@@ -39,6 +39,7 @@ final class SettingsRootViewModel: ObservableObject {
     ) {
         appearanceMode = themeService.appearanceMode
         audioEnd = audioPreferences.audioEnd
+        streamingEnabled = audioPreferences.streamingEnabled
         self.analytics = analytics
         self.reviewService = reviewService
         self.authenticationClient = authenticationClient
@@ -69,6 +70,7 @@ final class SettingsRootViewModel: ObservableObject {
     weak var navigationController: UINavigationController?
 
     @Published var audioEnd: AudioEnd
+    @Published var streamingEnabled: Bool
     @Published var error: Error? = nil
     @Published var isAuthenticated: Bool = false
     @Published var loggedInUser: UserInfo? = nil

--- a/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
@@ -71,7 +71,12 @@ final class SettingsRootViewModel: ObservableObject {
     weak var navigationController: UINavigationController?
 
     @Published var audioEnd: AudioEnd
-    @Published var streamingEnabled: Bool
+    @Published var streamingEnabled: Bool {
+        didSet {
+            guard streamingEnabled != audioPreferences.streamingEnabled else { return }
+            audioPreferences.streamingEnabled = streamingEnabled
+        }
+    }
     @Published var error: Error? = nil
     @Published var isAuthenticated: Bool = false
     @Published var loggedInUser: UserInfo? = nil

--- a/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
@@ -71,15 +71,16 @@ final class SettingsRootViewModel: ObservableObject {
     weak var navigationController: UINavigationController?
 
     @Published var audioEnd: AudioEnd
+    @Published var error: Error? = nil
+    @Published var isAuthenticated: Bool = false
+    @Published var loggedInUser: UserInfo? = nil
+
     @Published var streamingEnabled: Bool {
         didSet {
             guard streamingEnabled != audioPreferences.streamingEnabled else { return }
             audioPreferences.streamingEnabled = streamingEnabled
         }
     }
-    @Published var error: Error? = nil
-    @Published var isAuthenticated: Bool = false
-    @Published var loggedInUser: UserInfo? = nil
 
     var currentUserEmail: String? {
         loggedInUser?.email


### PR DESCRIPTION
Closes https://github.com/quran/quran-ios/issues/838

Adds a Stream Audio toggle in Settings that lets users play Quran recitation without downloading audio files first. When enabled,
AVPlayer streams directly from the remote URLs — no storage used.

How it works

Gapped reciters — streams all audio files directly, no download needed
Gapless reciters — the timing database (~88 KB) is downloaded once on first play so the app knows where each ayah starts in the
audio file. After that, subsequent plays are instant with no delays. The large audio files themselves are always streamed
Default is off — existing download-first behavior is completely unchanged
Implementation notes

AVURLAsset already handles https:// URLs natively, so QueuePlayer/AVPlayer needed zero changes
The streaming flag flows from AudioPreferences → AudioBannerViewModel → QuranAudioPlayer → the request builders, where it
switches between localURL and remoteURL
Added databaseDownloaded() and downloadDatabase() to QuranAudioDownloader for the gapless DB-only fetch path