### PR TITLE
Add configurable delay between repetitions

### DIFF
--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -105,8 +105,8 @@
 "audio.streaming.title" = "تشغيل الصوت عبر الإنترنت";
 "audio.streaming.description" = "يوفر مساحة التخزين ببث الصوت، لكنه يتطلب اتصالًا بالإنترنت.";
 "audio.download-play-amount.description" = "عند بدء تشغيل الصوت، سيتوقف مع نهاية";
-"audio.repetition-delay" = "التأخير بين التكرارات";
-"audio.repetition-delay.none" = "بدون تأخير";
+"audio.repetition-delay" = "إيقاف مؤقت بين التكرارات";
+"audio.repetition-delay.none" = "٠ث";
 "audio.repetition-delay.1s" = "١ث";
 "audio.repetition-delay.2s" = "٢ث";
 "audio.repetition-delay.3s" = "٣ث";

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -105,6 +105,12 @@
 "audio.streaming.title" = "تشغيل الصوت عبر الإنترنت";
 "audio.streaming.description" = "يوفر مساحة التخزين ببث الصوت، لكنه يتطلب اتصالًا بالإنترنت.";
 "audio.download-play-amount.description" = "عند بدء تشغيل الصوت، سيتوقف مع نهاية";
+"audio.repetition-delay" = "التأخير بين التكرارات";
+"audio.repetition-delay.none" = "بدون تأخير";
+"audio.repetition-delay.1s" = "١ث";
+"audio.repetition-delay.2s" = "٢ث";
+"audio.repetition-delay.3s" = "٣ث";
+"audio.repetition-delay.4s" = "٤ث";
 
 // MARK: - Bookmarks
 

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -110,7 +110,8 @@
 "audio.repetition-delay.1s" = "١ث";
 "audio.repetition-delay.2s" = "٢ث";
 "audio.repetition-delay.3s" = "٣ث";
-"audio.repetition-delay.4s" = "٤ث";
+"audio.repetition-delay.5s" = "٥ث";
+"audio.repetition-delay.10s" = "١٠ث";
 
 // MARK: - Bookmarks
 

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -105,7 +105,7 @@
 "audio.streaming.title" = "تشغيل الصوت عبر الإنترنت";
 "audio.streaming.description" = "يوفر مساحة التخزين ببث الصوت، لكنه يتطلب اتصالًا بالإنترنت.";
 "audio.download-play-amount.description" = "عند بدء تشغيل الصوت، سيتوقف مع نهاية";
-"audio.repetition-delay" = "إيقاف مؤقت بين التكرارات";
+"audio.repetition-delay" = "مدة الإيقاف بين التكرارات (بالثواني)";
 "audio.repetition-delay.none" = "٠ث";
 "audio.repetition-delay.1s" = "١ث";
 "audio.repetition-delay.2s" = "٢ث";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -118,7 +118,7 @@
 "audio.streaming.description" = "Saves disk space by streaming audio, but requires an internet connection.";
 "audio.download-play-amount.description" = "When playing audio, it will play to the end of the";
 
-"audio.repetition-delay" = "Pause Between Repetitions";
+"audio.repetition-delay" = "Pause Between Repetitions (seconds)";
 "audio.repetition-delay.none" = "0s";
 "audio.repetition-delay.1s" = "1s";
 "audio.repetition-delay.2s" = "2s";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -118,6 +118,13 @@
 "audio.streaming.description" = "Saves disk space by streaming audio, but requires an internet connection.";
 "audio.download-play-amount.description" = "When playing audio, it will play to the end of the";
 
+"audio.repetition-delay" = "Delay Between Repetitions";
+"audio.repetition-delay.none" = "No delay";
+"audio.repetition-delay.1s" = "1s";
+"audio.repetition-delay.2s" = "2s";
+"audio.repetition-delay.3s" = "3s";
+"audio.repetition-delay.4s" = "4s";
+
 // MARK: - Bookmarks
 
 "bookmarks.no-data.title" = "Adding Bookmarks...";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -118,8 +118,8 @@
 "audio.streaming.description" = "Saves disk space by streaming audio, but requires an internet connection.";
 "audio.download-play-amount.description" = "When playing audio, it will play to the end of the";
 
-"audio.repetition-delay" = "Delay Between Repetitions";
-"audio.repetition-delay.none" = "No delay";
+"audio.repetition-delay" = "Pause Between Repetitions";
+"audio.repetition-delay.none" = "0s";
 "audio.repetition-delay.1s" = "1s";
 "audio.repetition-delay.2s" = "2s";
 "audio.repetition-delay.3s" = "3s";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -123,7 +123,8 @@
 "audio.repetition-delay.1s" = "1s";
 "audio.repetition-delay.2s" = "2s";
 "audio.repetition-delay.3s" = "3s";
-"audio.repetition-delay.4s" = "4s";
+"audio.repetition-delay.5s" = "5s";
+"audio.repetition-delay.10s" = "10s";
 
 // MARK: - Bookmarks
 

--- a/Core/QueuePlayer/AudioPlayer.swift
+++ b/Core/QueuePlayer/AudioPlayer.swift
@@ -52,12 +52,14 @@ class AudioPlayer {
     }
 
     func pause() {
+        isDelaying = false
         delayTask = nil
         timer?.pause()
         player.pause()
     }
 
     func stop() {
+        isDelaying = false
         delayTask = nil
         timer?.cancel()
         player.stop()
@@ -101,6 +103,8 @@ class AudioPlayer {
     private let request: AudioRequest
     private var audioPlaying: AudioPlaying
     private var playbackRate: Float
+
+    private var isDelaying = false
 
     private var player: Player {
         didSet {
@@ -183,9 +187,12 @@ class AudioPlayer {
                     audioPlaying.resetFramePlays()
                     let delay = request.repetitionDelay
                     if delay != .none {
+                        isDelaying = true
+                        player.pause()
                         delayTask = Task { [weak self] in
                             try? await Task.sleep(nanoseconds: UInt64(delay.seconds * 1_000_000_000))
                             guard !Task.isCancelled else { return }
+                            self?.isDelaying = false
                             self?.play(fileIndex: 0, frameIndex: 0, forceSeek: true)
                         }
                     } else {
@@ -222,6 +229,7 @@ class AudioPlayer {
     // MARK: - PlayerDelegate
 
     private func rateChanged(to rate: Float) {
+        guard !isDelaying else { return }
         actions?.playbackRateChanged(rate)
     }
 

--- a/Core/QueuePlayer/AudioPlayer.swift
+++ b/Core/QueuePlayer/AudioPlayer.swift
@@ -52,11 +52,13 @@ class AudioPlayer {
     }
 
     func pause() {
+        delayTask = nil
         timer?.pause()
         player.pause()
     }
 
     func stop() {
+        delayTask = nil
         timer?.cancel()
         player.stop()
         actions?.playbackEnded()
@@ -109,6 +111,10 @@ class AudioPlayer {
     }
 
     private var timer: Timing.Timer? {
+        didSet { oldValue?.cancel() }
+    }
+
+    private var delayTask: Task<Void, Never>? {
         didSet { oldValue?.cancel() }
     }
 
@@ -175,7 +181,16 @@ class AudioPlayer {
                     // start a new run
                     audioPlaying.incrementRequestPlays()
                     audioPlaying.resetFramePlays()
-                    play(fileIndex: 0, frameIndex: 0, forceSeek: true)
+                    let delay = request.repetitionDelay
+                    if delay != .none {
+                        delayTask = Task { [weak self] in
+                            try? await Task.sleep(nanoseconds: UInt64(delay.seconds * 1_000_000_000))
+                            guard !Task.isCancelled else { return }
+                            self?.play(fileIndex: 0, frameIndex: 0, forceSeek: true)
+                        }
+                    } else {
+                        play(fileIndex: 0, frameIndex: 0, forceSeek: true)
+                    }
                 }
             }
         } else {

--- a/Core/QueuePlayer/AudioRequest.swift
+++ b/Core/QueuePlayer/AudioRequest.swift
@@ -11,11 +11,12 @@ import Foundation
 public struct AudioRequest: Equatable, Sendable {
     // MARK: Lifecycle
 
-    public init(files: [AudioFile], endTime: TimeInterval?, frameRuns: Runs, requestRuns: Runs) {
+    public init(files: [AudioFile], endTime: TimeInterval?, frameRuns: Runs, requestRuns: Runs, repetitionDelay: RepetitionDelay = .none) {
         self.files = files
         self.endTime = endTime
         self.frameRuns = frameRuns
         self.requestRuns = requestRuns
+        self.repetitionDelay = repetitionDelay
     }
 
     // MARK: Public
@@ -24,6 +25,7 @@ public struct AudioRequest: Equatable, Sendable {
     public let endTime: TimeInterval?
     public let frameRuns: Runs
     public let requestRuns: Runs
+    public let repetitionDelay: RepetitionDelay
 }
 
 public struct AudioFile: Equatable, Sendable {

--- a/Core/QueuePlayer/RepetitionDelay.swift
+++ b/Core/QueuePlayer/RepetitionDelay.swift
@@ -1,0 +1,24 @@
+//
+//  RepetitionDelay.swift
+//  QueuePlayer
+//
+
+public enum RepetitionDelay: Int, Hashable, Sendable, CaseIterable {
+    case none
+    case oneSecond
+    case twoSeconds
+    case threeSeconds
+    case fourSeconds
+
+    // MARK: Public
+
+    public var seconds: Double {
+        switch self {
+        case .none: return 0
+        case .oneSecond: return 1
+        case .twoSeconds: return 2
+        case .threeSeconds: return 3
+        case .fourSeconds: return 4
+        }
+    }
+}

--- a/Core/QueuePlayer/RepetitionDelay.swift
+++ b/Core/QueuePlayer/RepetitionDelay.swift
@@ -8,7 +8,8 @@ public enum RepetitionDelay: Int, Hashable, Sendable, CaseIterable {
     case oneSecond
     case twoSeconds
     case threeSeconds
-    case fourSeconds
+    case fiveSeconds
+    case tenSeconds
 
     // MARK: Public
 
@@ -18,7 +19,8 @@ public enum RepetitionDelay: Int, Hashable, Sendable, CaseIterable {
         case .oneSecond: return 1
         case .twoSeconds: return 2
         case .threeSeconds: return 3
-        case .fourSeconds: return 4
+        case .fiveSeconds: return 5
+        case .tenSeconds: return 10
         }
     }
 }

--- a/Domain/QuranAudioKit/Sources/AudioPlayer/GaplessAudioRequestBuilder.swift
+++ b/Domain/QuranAudioKit/Sources/AudioPlayer/GaplessAudioRequestBuilder.swift
@@ -34,6 +34,17 @@ struct GaplessAudioRequest: QuranAudioRequest {
             image: nil
         )
     }
+
+    func withRepetitionDelay(_ delay: RepetitionDelay) -> any QuranAudioRequest {
+        let updatedRequest = AudioRequest(
+            files: request.files,
+            endTime: request.endTime,
+            frameRuns: request.frameRuns,
+            requestRuns: request.requestRuns,
+            repetitionDelay: delay
+        )
+        return GaplessAudioRequest(request: updatedRequest, ayahs: ayahs, reciter: reciter)
+    }
 }
 
 struct GaplessAudioRequestBuilder: QuranAudioRequestBuilder {

--- a/Domain/QuranAudioKit/Sources/AudioPlayer/GappedAudioRequestBuilder.swift
+++ b/Domain/QuranAudioKit/Sources/AudioPlayer/GappedAudioRequestBuilder.swift
@@ -33,6 +33,17 @@ struct GappedAudioRequest: QuranAudioRequest {
             image: nil
         )
     }
+
+    func withRepetitionDelay(_ delay: RepetitionDelay) -> any QuranAudioRequest {
+        let updatedRequest = AudioRequest(
+            files: request.files,
+            endTime: request.endTime,
+            frameRuns: request.frameRuns,
+            requestRuns: request.requestRuns,
+            repetitionDelay: delay
+        )
+        return GappedAudioRequest(request: updatedRequest, ayahs: ayahs, reciter: reciter)
+    }
 }
 
 final class GappedAudioRequestBuilder: QuranAudioRequestBuilder {

--- a/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioPlayer.swift
+++ b/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioPlayer.swift
@@ -92,6 +92,7 @@ public class QuranAudioPlayer {
         to end: AyahNumber,
         verseRuns: Runs,
         listRuns: Runs,
+        repetitionDelay: RepetitionDelay = .none,
         streaming: Bool = false
     ) async throws {
         let details: [String: Any] = [
@@ -106,7 +107,8 @@ public class QuranAudioPlayer {
         try await unzipper.unzip(reciter: reciter)
 
         let builder = getAudioRequestBuilder(for: reciter)
-        let audioRequest = try await builder.buildRequest(with: reciter, from: start, to: end, frameRuns: verseRuns, requestRuns: listRuns, streaming: streaming)
+        var audioRequest = try await builder.buildRequest(with: reciter, from: start, to: end, frameRuns: verseRuns, requestRuns: listRuns, streaming: streaming)
+        audioRequest = audioRequest.withRepetitionDelay(repetitionDelay)
         let request = audioRequest.getRequest()
         willPlay(request)
         self.audioRequest = audioRequest

--- a/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioRequestBuilder.swift
+++ b/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioRequestBuilder.swift
@@ -15,6 +15,7 @@ protocol QuranAudioRequest: Sendable {
     func getRequest() -> AudioRequest
     func getAyahNumberFrom(fileIndex: Int, frameIndex: Int) -> AyahNumber
     func getPlayerInfo(for fileIndex: Int) -> PlayerItemInfo
+    func withRepetitionDelay(_ delay: RepetitionDelay) -> any QuranAudioRequest
 }
 
 protocol QuranAudioRequestBuilder {

--- a/Domain/QuranAudioKit/Sources/Preferences/AudioPreferences.swift
+++ b/Domain/QuranAudioKit/Sources/Preferences/AudioPreferences.swift
@@ -6,6 +6,7 @@
 //
 
 import Preferences
+import QueuePlayer
 import QuranAudio
 
 public class AudioPreferences {
@@ -26,9 +27,13 @@ public class AudioPreferences {
     @Preference(audioStreamingEnabledKey)
     public var streamingEnabled: Bool
 
+    @TransformedPreference(audioRepetitionDelayKey, transformer: .rawRepresentable(defaultValue: .oneSecond))
+    public var repetitionDelay: RepetitionDelay
+
     // MARK: Private
 
     private static let audioEndKey = PreferenceKey<Int>(key: "audioEndKey", defaultValue: AudioEnd.juz.rawValue)
     private static let audioPlaybackRateKey = PreferenceKey<Float>(key: "audioPlaybackRate", defaultValue: 1.0)
     private static let audioStreamingEnabledKey = PreferenceKey<Bool>(key: "audioStreamingEnabled", defaultValue: false)
+    private static let audioRepetitionDelayKey = PreferenceKey<Int>(key: "audioRepetitionDelay", defaultValue: RepetitionDelay.oneSecond.rawValue)
 }

--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptions.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptions.swift
@@ -13,12 +13,13 @@ import QuranKit
 public struct AdvancedAudioOptions {
     // MARK: Lifecycle
 
-    public init(reciter: Reciter, start: AyahNumber, end: AyahNumber, verseRuns: Runs, listRuns: Runs) {
+    public init(reciter: Reciter, start: AyahNumber, end: AyahNumber, verseRuns: Runs, listRuns: Runs, repetitionDelay: RepetitionDelay = .oneSecond) {
         self.reciter = reciter
         self.start = start
         self.end = end
         self.verseRuns = verseRuns
         self.listRuns = listRuns
+        self.repetitionDelay = repetitionDelay
     }
 
     // MARK: Public
@@ -28,4 +29,5 @@ public struct AdvancedAudioOptions {
     public var end: AyahNumber
     public var verseRuns: Runs
     public var listRuns: Runs
+    public var repetitionDelay: RepetitionDelay
 }

--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
@@ -103,8 +103,10 @@ struct AdvancedAudioOptionsRootViewUI: View {
             )
 
             RunsChoicesSection(title: lAndroid("play_each_verse"), runs: $verseRuns)
-            RunsChoicesSection(title: lAndroid("play_verses_range"), runs: $listRuns)
-            DelayChoicesSection(repetitionDelay: $repetitionDelay)
+            PlaySetChoicesSection(
+                listRuns: $listRuns,
+                repetitionDelay: $repetitionDelay
+            )
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -187,14 +189,27 @@ private struct RunsChoicesSection: View {
     }
 }
 
-private struct DelayChoicesSection: View {
+private struct PlaySetChoicesSection: View {
+    @Binding var listRuns: Runs
     @Binding var repetitionDelay: RepetitionDelay
 
     var body: some View {
-        Section(header: Text(l("audio.repetition-delay"))) {
-            ChoicesView(items: RepetitionDelay.sorted, selection: $repetitionDelay) {
+        Section(header: Text(lAndroid("play_verses_range").replacingOccurrences(of: ":", with: ""))) {
+            ChoicesView(items: Runs.sorted, selection: $listRuns) {
                 $0.localizedDescription
             }
+
+            VStack(alignment: .leading, spacing: 10) {
+                Text(l("audio.repetition-delay"))
+                    .font(.footnote.weight(.medium))
+                    .foregroundStyle(.secondary)
+
+                ChoicesView(items: RepetitionDelay.sorted, selection: $repetitionDelay) {
+                    $0.localizedDescription
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 6)
         }
     }
 }

--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
@@ -37,6 +37,7 @@ private struct AdvancedAudioOptionsRootView: View {
             endAt: $viewModel.endAt,
             verseRuns: $viewModel.verseRuns,
             listRuns: $viewModel.listRuns,
+            repetitionDelay: $viewModel.repetitionDelay,
             playbackRate: viewModel.playbackRate,
             dismiss: { viewModel.dismiss() },
             play: { viewModel.play() },
@@ -58,6 +59,7 @@ struct AdvancedAudioOptionsRootViewUI: View {
     @Binding var endAt: EndAtChoice
     @Binding var verseRuns: Runs
     @Binding var listRuns: Runs
+    @Binding var repetitionDelay: RepetitionDelay
     let playbackRate: Float
     let dismiss: @MainActor @Sendable () -> Void
     let play: @MainActor @Sendable () -> Void
@@ -102,6 +104,7 @@ struct AdvancedAudioOptionsRootViewUI: View {
 
             RunsChoicesSection(title: lAndroid("play_each_verse"), runs: $verseRuns)
             RunsChoicesSection(title: lAndroid("play_verses_range"), runs: $listRuns)
+            DelayChoicesSection(repetitionDelay: $repetitionDelay)
         }
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -178,6 +181,18 @@ private struct RunsChoicesSection: View {
     var body: some View {
         Section(header: Text(title.replacingOccurrences(of: ":", with: ""))) {
             ChoicesView(items: Runs.sorted, selection: $runs) {
+                $0.localizedDescription
+            }
+        }
+    }
+}
+
+private struct DelayChoicesSection: View {
+    @Binding var repetitionDelay: RepetitionDelay
+
+    var body: some View {
+        Section(header: Text(l("audio.repetition-delay"))) {
+            ChoicesView(items: RepetitionDelay.sorted, selection: $repetitionDelay) {
                 $0.localizedDescription
             }
         }

--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsViewModel.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsViewModel.swift
@@ -37,6 +37,7 @@ final class AdvancedAudioOptionsViewModel: ObservableObject {
         toVerse = options.end
         verseRuns = options.verseRuns
         listRuns = options.listRuns
+        repetitionDelay = options.repetitionDelay
         playbackRate = AudioPreferences.shared.playbackRate
         endAt = Self.deduceEndAt(from: options.start, to: options.end)
 
@@ -51,6 +52,7 @@ final class AdvancedAudioOptionsViewModel: ObservableObject {
     @Published var toVerse: AyahNumber
     @Published var verseRuns: Runs
     @Published var listRuns: Runs
+    @Published var repetitionDelay: RepetitionDelay
     @Published var reciter: Reciter
     @Published var endAt: EndAtChoice
     @Published var playbackRate: Float
@@ -128,7 +130,8 @@ final class AdvancedAudioOptionsViewModel: ObservableObject {
             start: fromVerse,
             end: toVerse,
             verseRuns: verseRuns,
-            listRuns: listRuns
+            listRuns: listRuns,
+            repetitionDelay: repetitionDelay
         )
     }
 }

--- a/Features/AdvancedAudioOptionsFeature/Sources/RepetitionDelay++.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/RepetitionDelay++.swift
@@ -1,0 +1,24 @@
+//
+//  RepetitionDelay++.swift
+//  Quran
+//
+
+import Foundation
+import Localization
+import QueuePlayer
+
+extension RepetitionDelay {
+    static var sorted: [RepetitionDelay] {
+        [.none, .oneSecond, .twoSeconds, .threeSeconds, .fourSeconds]
+    }
+
+    var localizedDescription: String {
+        switch self {
+        case .none: return l("audio.repetition-delay.none")
+        case .oneSecond: return l("audio.repetition-delay.1s")
+        case .twoSeconds: return l("audio.repetition-delay.2s")
+        case .threeSeconds: return l("audio.repetition-delay.3s")
+        case .fourSeconds: return l("audio.repetition-delay.4s")
+        }
+    }
+}

--- a/Features/AdvancedAudioOptionsFeature/Sources/RepetitionDelay++.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/RepetitionDelay++.swift
@@ -9,7 +9,7 @@ import QueuePlayer
 
 extension RepetitionDelay {
     static var sorted: [RepetitionDelay] {
-        [.none, .oneSecond, .twoSeconds, .threeSeconds, .fourSeconds]
+        [.none, .oneSecond, .twoSeconds, .threeSeconds, .fiveSeconds, .tenSeconds]
     }
 
     var localizedDescription: String {
@@ -18,7 +18,8 @@ extension RepetitionDelay {
         case .oneSecond: return l("audio.repetition-delay.1s")
         case .twoSeconds: return l("audio.repetition-delay.2s")
         case .threeSeconds: return l("audio.repetition-delay.3s")
-        case .fourSeconds: return l("audio.repetition-delay.4s")
+        case .fiveSeconds: return l("audio.repetition-delay.5s")
+        case .tenSeconds: return l("audio.repetition-delay.10s")
         }
     }
 }

--- a/Features/AdvancedAudioOptionsFeature/Tests/AdvancedAudioOptionsViewModelTests.swift
+++ b/Features/AdvancedAudioOptionsFeature/Tests/AdvancedAudioOptionsViewModelTests.swift
@@ -144,6 +144,21 @@ final class AdvancedAudioOptionsViewModelTests: XCTestCase {
         XCTAssertEqual(Runs.five.localizedDescription, "5×")
     }
 
+    // MARK: - RepetitionDelay
+
+    func test_repetitionDelaySorted_matchesExpectedOrder() {
+        XCTAssertEqual(RepetitionDelay.sorted, [.none, .oneSecond, .twoSeconds, .threeSeconds, .fiveSeconds, .tenSeconds])
+    }
+
+    func test_repetitionDelaySeconds_matchesExpectedValues() {
+        XCTAssertEqual(RepetitionDelay.none.seconds, 0)
+        XCTAssertEqual(RepetitionDelay.oneSecond.seconds, 1)
+        XCTAssertEqual(RepetitionDelay.twoSeconds.seconds, 2)
+        XCTAssertEqual(RepetitionDelay.threeSeconds.seconds, 3)
+        XCTAssertEqual(RepetitionDelay.fiveSeconds.seconds, 5)
+        XCTAssertEqual(RepetitionDelay.tenSeconds.seconds, 10)
+    }
+
     // MARK: - EndAtChoice
 
     func test_endAtChoice_audioEndMapping() {

--- a/Features/AudioBannerFeature/AudioBannerViewModel.swift
+++ b/Features/AudioBannerFeature/AudioBannerViewModel.swift
@@ -143,6 +143,7 @@ public final class AudioBannerViewModel: ObservableObject {
 
     private var verseRuns: Runs = .one
     private var listRuns: Runs = .one
+    private var repetitionDelay: RepetitionDelay = AudioPreferences.shared.repetitionDelay
     private var reciters: [Reciter] = []
     private var cancellableTasks: Set<CancellableTask> = []
 
@@ -205,7 +206,7 @@ public final class AudioBannerViewModel: ObservableObject {
         audioRange = (start: from, end: end)
     }
 
-    private func play(from: AyahNumber, to: AyahNumber?, verseRuns: Runs, listRuns: Runs) {
+    private func play(from: AyahNumber, to: AyahNumber?, verseRuns: Runs, listRuns: Runs, repetitionDelay: RepetitionDelay = .oneSecond) {
         guard let selectedReciter else {
             return
         }
@@ -214,6 +215,7 @@ public final class AudioBannerViewModel: ObservableObject {
         audioRange = (start: from, end: end)
         self.verseRuns = verseRuns
         self.listRuns = listRuns
+        self.repetitionDelay = repetitionDelay
 
         recentRecitersService.updateRecentRecitersList(selectedReciter)
 
@@ -265,6 +267,7 @@ public final class AudioBannerViewModel: ObservableObject {
                     rate: playbackRate,
                     from: from, to: end,
                     verseRuns: verseRuns, listRuns: listRuns,
+                    repetitionDelay: repetitionDelay,
                     streaming: streaming
                 )
                 playingStarted()
@@ -519,7 +522,8 @@ extension AudioBannerViewModel: AdvancedAudioOptionsListener {
             start: audioRange.start,
             end: audioRange.end,
             verseRuns: verseRuns,
-            listRuns: listRuns
+            listRuns: listRuns,
+            repetitionDelay: repetitionDelay
         )
     }
 
@@ -539,7 +543,8 @@ extension AudioBannerViewModel: AdvancedAudioOptionsListener {
     public func updateAudioOptions(to newOptions: AdvancedAudioOptions) {
         logger.info("AudioBanner: playing advanced audio options \(newOptions)")
         selectReciter(newOptions.reciter)
-        play(from: newOptions.start, to: newOptions.end, verseRuns: newOptions.verseRuns, listRuns: newOptions.listRuns)
+        AudioPreferences.shared.repetitionDelay = newOptions.repetitionDelay
+        play(from: newOptions.start, to: newOptions.end, verseRuns: newOptions.verseRuns, listRuns: newOptions.listRuns, repetitionDelay: newOptions.repetitionDelay)
     }
 
     public func dismissAudioOptions() {


### PR DESCRIPTION
Closes #839

Adds a delay option between repetition cycles in the Advanced Audio screen.

## Changes

- New `RepetitionDelay` enum (`none`, `1s`, `2s`, `3s`, `4s`) in `QueuePlayer`
- `AudioPlayer` pauses the underlying player during the delay to prevent audio bleed-through, then restarts from the beginning of the range
- Delay is persisted in `AudioPreferences` with a default of 1s
- New "Delay Between Repetitions" section added to the Advanced Audio screen using the existing pill style
- Threaded through `AdvancedAudioOptions`, `AdvancedAudioOptionsViewModel`, and `AudioBannerViewModel`

## Testing

1. Open Advanced Audio and set a verse range with 2+ repetitions
2. Leave delay at 1s, play, and confirm a 1-second pause between cycles
3. Switch to "No delay" and confirm cycles loop without a gap
4. Tap pause during the delay window and confirm playback stops cleanly