### PR TITLE
chore(example): configure Arabic localization settings

### DIFF
--- a/Example/QuranEngineApp.xcodeproj/project.pbxproj
+++ b/Example/QuranEngineApp.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				ar,
 				Base,
 			);
 			mainGroup = D975EDB92A4791D6009DE942;

--- a/Example/QuranEngineApp.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Example/QuranEngineApp.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<false/>
+</dict>
+</plist>

--- a/Example/QuranEngineApp/Info.plist
+++ b/Example/QuranEngineApp/Info.plist
@@ -2,8 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleURLTypes</key>
-    <array>
+	<key>CFBundleAllowMixedLocalizations</key>
+	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
         <dict>
             <key>CFBundleURLName</key>
             <string>com.quran.QuranEngineApp</string>


### PR DESCRIPTION
## Summary
- Advertise Arabic as a known region in the example Xcode project.
- Allow mixed localizations so Swift package Arabic resources can be used by the host app.
- Add shared workspace settings for the example project.

## Validation
- make build-example