### PR TITLE
refactor: rename sync service dependency

### DIFF
--- a/Data/AuthenticationClient/Sources/AuthenticationClientMobileSyncImpl.swift
+++ b/Data/AuthenticationClient/Sources/AuthenticationClientMobileSyncImpl.swift
@@ -6,9 +6,9 @@ import VLogging
 public final actor AuthenticationClientMobileSyncImpl: AuthenticationClient {
     // MARK: Lifecycle
 
-    public init(authService: SyncAuthService, syncService: QuranDataService) {
+    public init(authService: SyncAuthService, quranDataService: QuranDataService) {
         self.authService = authService
-        self.syncService = syncService
+        self.quranDataService = quranDataService
     }
 
     // MARK: Public
@@ -42,7 +42,7 @@ public final actor AuthenticationClientMobileSyncImpl: AuthenticationClient {
 
     public func logout() async throws(AuthenticationClientError) {
         do {
-            try await syncService.logout(clearLocalData: true)
+            try await quranDataService.logout(clearLocalData: true)
         } catch {
             logger.error("Failed to logout via mobile sync: \(error)")
             throw AuthenticationClientError.errorAuthenticating(error)
@@ -69,5 +69,5 @@ public final actor AuthenticationClientMobileSyncImpl: AuthenticationClient {
     // MARK: Private
 
     private let authService: SyncAuthService
-    private let syncService: QuranDataService
+    private let quranDataService: QuranDataService
 }

--- a/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
@@ -16,8 +16,8 @@
     public struct MobileSyncLastPageService: LastPageService, @unchecked Sendable {
         // MARK: Lifecycle
 
-        public init(syncService: QuranDataService) {
-            self.syncService = syncService
+        public init(quranDataService: QuranDataService) {
+            self.quranDataService = quranDataService
         }
 
         // MARK: Public
@@ -26,7 +26,7 @@
             let subject = CurrentValueSubject<[LastPage], Never>([])
             let task = Task {
                 do {
-                    for try await sessions in syncService.readingSessionsSequence() {
+                    for try await sessions in quranDataService.readingSessionsSequence() {
                         if Task.isCancelled {
                             break
                         }
@@ -48,7 +48,7 @@
 
         public func add(page: Page) async throws -> LastPage {
             let firstVerse = page.firstVerse
-            let session = try await syncService.addReadingSession(
+            let session = try await quranDataService.addReadingSession(
                 sura: Int32(firstVerse.sura.suraNumber),
                 ayah: Int32(firstVerse.ayah),
                 timestamp: Date()
@@ -62,7 +62,7 @@
             }
 
             let firstVerse = toPage.firstVerse
-            let updatedSession = try await syncService.updateReadingSession(
+            let updatedSession = try await quranDataService.updateReadingSession(
                 localId: localId,
                 sura: Int32(firstVerse.sura.suraNumber),
                 ayah: Int32(firstVerse.ayah),
@@ -73,7 +73,7 @@
 
         // MARK: Private
 
-        private let syncService: QuranDataService
+        private let quranDataService: QuranDataService
 
         private func lastPage(for session: ReadingSession, quran: Quran) -> LastPage? {
             guard let sourceAyah = AyahNumber(quran: quran, sura: Int(session.sura), ayah: Int(session.ayah)) else {

--- a/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
@@ -53,14 +53,14 @@
     public struct MobileSyncNoteService {
         // MARK: Lifecycle
 
-        public init(syncService: QuranDataService) {
-            self.syncService = syncService
+        public init(quranDataService: QuranDataService) {
+            self.quranDataService = quranDataService
         }
 
         // MARK: Public
 
         public func notesSequence(quran: Quran) -> SyncedNotesSequence {
-            let sequence = syncService.notesSequence()
+            let sequence = quranDataService.notesSequence()
                 .map { notes in
                     Self.notes(from: notes, quran: quran)
                 }
@@ -68,7 +68,7 @@
         }
 
         public func createNote(body: String, startAyah: AyahNumber, endAyah: AyahNumber) async throws {
-            try await syncService.createNote(
+            try await quranDataService.createNote(
                 body: body,
                 startSura: Int32(startAyah.sura.suraNumber),
                 startAyah: Int32(startAyah.ayah),
@@ -82,7 +82,7 @@
         }
 
         public func updateNote(_ note: SyncedNote, body: String, startAyah: AyahNumber, endAyah: AyahNumber) async throws {
-            try await syncService.updateNote(
+            try await quranDataService.updateNote(
                 localId: note.localId,
                 body: body,
                 startSura: Int32(startAyah.sura.suraNumber),
@@ -93,7 +93,7 @@
         }
 
         public func removeNote(_ note: SyncedNote) async throws {
-            try await syncService.removeNote(localId: note.localId)
+            try await quranDataService.removeNote(localId: note.localId)
         }
 
         // MARK: Internal
@@ -122,6 +122,6 @@
 
         // MARK: Private
 
-        private let syncService: QuranDataService
+        private let quranDataService: QuranDataService
     }
 #endif

--- a/Example/QuranEngineApp/Classes/Container.swift
+++ b/Example/QuranEngineApp/Classes/Container.swift
@@ -42,12 +42,12 @@ class Container: AppDependencies {
 
     private(set) lazy var notePersistence: NotePersistence = CoreDataNotePersistence(stack: coreDataStack)
     #if QURAN_SYNC
-        private(set) lazy var syncService: QuranDataService = syncAppGraph.quranDataService
+        private(set) lazy var quranDataService: QuranDataService = syncAppGraph.quranDataService
 
         private(set) lazy var authenticationClient: (any AuthenticationClient)? = {
             let authService = syncAppGraph.authService
-            let syncService = syncAppGraph.quranDataService
-            return AuthenticationClientMobileSyncImpl(authService: authService, syncService: syncService)
+            let quranDataService = syncAppGraph.quranDataService
+            return AuthenticationClientMobileSyncImpl(authService: authService, quranDataService: quranDataService)
         }()
     #else
         let authenticationClient: (any AuthenticationClient)? = nil

--- a/Features/AppDependencies/AppDependencies.swift
+++ b/Features/AppDependencies/AppDependencies.swift
@@ -43,7 +43,7 @@ public protocol AppDependencies {
     var authenticationClient: (any AuthenticationClient)? { get }
 
     #if QURAN_SYNC
-        var syncService: QuranDataService { get }
+        var quranDataService: QuranDataService { get }
     #endif
 }
 
@@ -52,7 +52,7 @@ extension AppDependencies {
 
     public func lastPageService() -> any LastPageService {
         #if QURAN_SYNC
-            return MobileSyncLastPageService(syncService: syncService)
+            return MobileSyncLastPageService(quranDataService: quranDataService)
         #else
             return PersistenceLastPageService(persistence: lastPagePersistence)
         #endif
@@ -75,7 +75,7 @@ extension AppDependencies {
 
     #if QURAN_SYNC
         public func mobileSyncNoteService() -> MobileSyncNoteService {
-            MobileSyncNoteService(syncService: syncService)
+            MobileSyncNoteService(quranDataService: quranDataService)
         }
     #endif
 }

--- a/Features/AyahMenuFeature/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/AyahMenuBuilder.swift
@@ -86,7 +86,7 @@ public struct AyahMenuBuilder {
                 highlightVerses: input.highlightVerses,
                 highlightCollections: input.highlightCollections,
                 noteCount: input.noteCount,
-                ayahBookmarkCollectionService: AyahBookmarkCollectionService(syncService: container.syncService)
+                ayahBookmarkCollectionService: AyahBookmarkCollectionService(quranDataService: container.quranDataService)
             )
         #else
             let deps = AyahMenuViewModel.Deps(

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
@@ -56,21 +56,21 @@
         // MARK: Lifecycle
 
         public init(
-            syncService: QuranDataService,
+            quranDataService: QuranDataService,
             readingPreferences: ReadingPreferences = .shared
         ) {
-            self.syncService = syncService
+            self.quranDataService = quranDataService
             self.readingPreferences = readingPreferences
         }
 
         // MARK: Public
 
         public func createCollection(named name: String) async throws {
-            try await syncService.createCollection(named: name)
+            try await quranDataService.createCollection(named: name)
         }
 
         public func addAyahBookmarkToCollection(collectionLocalId: String, ayah: AyahNumber) async throws {
-            _ = try await syncService.addAyahBookmarkToCollection(
+            _ = try await quranDataService.addAyahBookmarkToCollection(
                 collectionLocalId: collectionLocalId,
                 sura: Int32(ayah.sura.suraNumber),
                 ayah: Int32(ayah.ayah)
@@ -78,11 +78,11 @@
         }
 
         public func removeCollection(localId: String) async throws {
-            try await syncService.removeCollection(localId: localId)
+            try await quranDataService.removeCollection(localId: localId)
         }
 
         public func removeBookmarkFromCollection(_ bookmark: AyahCollectionBookmark) async throws {
-            try await syncService.removeAyahBookmarkFromCollection(bookmark.bookmark)
+            try await quranDataService.removeAyahBookmarkFromCollection(bookmark.bookmark)
         }
 
         public func addAyahBookmarksIfNeeded(
@@ -110,15 +110,15 @@
         }
 
         public func collectionsSequence() -> AyahBookmarkCollectionsSequence {
-            let syncService = syncService
+            let quranDataService = quranDataService
             let readingPreferences = readingPreferences
-            let sequence = syncService.collectionsWithBookmarksSequence()
+            let sequence = quranDataService.collectionsWithBookmarksSequence()
                 .map { collections in
                     let collections = Self.collections(
                         from: collections,
                         quran: readingPreferences.reading.quran
                     )
-                    await syncService.createHighlightCollectionsIfNeeded(collections)
+                    await quranDataService.createHighlightCollectionsIfNeeded(collections)
                     return collections
                 }
             return AyahBookmarkCollectionsSequence(sequence)
@@ -150,7 +150,7 @@
 
         // MARK: Private
 
-        private let syncService: QuranDataService
+        private let quranDataService: QuranDataService
         private let readingPreferences: ReadingPreferences
 
         private static func bookmark(for bookmark: CollectionAyahBookmark, quran: Quran) -> AyahCollectionBookmark? {
@@ -226,8 +226,8 @@
     private let highlightCollectionCreationPlanners = HighlightCollectionCreationPlanners()
 
     private actor HighlightCollectionCreationPlanners {
-        func planner(for syncService: QuranDataService) -> HighlightCollectionCreationPlanner {
-            let id = ObjectIdentifier(syncService)
+        func planner(for quranDataService: QuranDataService) -> HighlightCollectionCreationPlanner {
+            let id = ObjectIdentifier(quranDataService)
             let planner = planners[id] ?? HighlightCollectionCreationPlanner()
             planners[id] = planner
             return planner

--- a/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
@@ -28,7 +28,7 @@ public struct BookmarksBuilder {
         #if QURAN_SYNC
             let showCollectionsAction: (@MainActor (UIViewController) async -> Void)?
             let showOldPageBookmarksAction: (@MainActor (UIViewController) async -> Void)?
-            let ayahBookmarkCollectionService = AyahBookmarkCollectionService(syncService: container.syncService)
+            let ayahBookmarkCollectionService = AyahBookmarkCollectionService(quranDataService: container.quranDataService)
             let navigateToPage: (Page) -> Void = { [weak listener] page in
                 listener?.navigateTo(page: page, lastPage: nil, highlightingSearchAyah: nil)
             }

--- a/Features/QuranViewFeature/QuranBuilder.swift
+++ b/Features/QuranViewFeature/QuranBuilder.swift
@@ -46,7 +46,7 @@ public struct QuranBuilder {
                 analytics: container.analytics
             )
             let syncedHighlightsObserver = QuranSyncedHighlightsObserver(
-                ayahBookmarkCollectionService: AyahBookmarkCollectionService(syncService: container.syncService),
+                ayahBookmarkCollectionService: AyahBookmarkCollectionService(quranDataService: container.quranDataService),
                 highlightsService: highlightsService
             )
             let interactorDeps = QuranInteractor.Deps(

--- a/Features/SettingsFeature/Tests/SettingsRootViewModelTests.swift
+++ b/Features/SettingsFeature/Tests/SettingsRootViewModelTests.swift
@@ -154,7 +154,7 @@ private struct AppDependenciesStub: AppDependencies {
     var notePersistence: NotePersistence { fatalError("Unused in tests") }
     var pageBookmarkPersistence: PageBookmarkPersistence { fatalError("Unused in tests") }
     #if QURAN_SYNC
-        var syncService: QuranDataService { fatalError("Unused in tests") }
+        var quranDataService: QuranDataService { fatalError("Unused in tests") }
     #endif
 }
 


### PR DESCRIPTION
## Summary

Renames the sync service dependency spelling from `syncService` to `quranDataService` where the dependency type is `QuranDataService`.

## Impact

This keeps sync-enabled app wiring, services, and tests aligned with the domain-specific service name without changing behavior.

## Validation

- `make build-sync`
- `make build-no-sync`
- `make format-lint`
- `make test-no-sync`
- `make test-sync`