### PR TITLE
chore: upgrade SwiftFormat

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -3,16 +3,11 @@
 
 # Options
 
---importgrouping testable-bottom # sortedImports
---wraparguments before-first # wrapArguments
---wrapparameters before-first # wrapArguments
---funcattributes prev-line # wrapAttributes
---typeattributes prev-line # wrapAttributes
---beforemarks typealias,struct  # organizeDeclarations
-
---structthreshold 70
---classthreshold 70
---enumthreshold 70
+--import-grouping testable-bottom # sortedImports
+--wrap-arguments before-first # wrapArguments
+--wrap-parameters before-first # wrapArguments
+--func-attributes prev-line # wrapAttributes
+--type-attributes prev-line # wrapAttributes
 
 # Disabled
 
@@ -22,9 +17,22 @@
 --disable hoistAwait
 --disable hoistPatternLet
 --disable hoistTry
---disable redundantType
---disable unusedArguments
+--disable organizeDeclarations
 --disable redundantReturn
+--disable unusedArguments
+
+# SwiftFormat 0.62 migration: keep the version bump low-churn.
+--disable docComments
+# Keep force unwraps in XCTest until we migrate tests to Swift Testing and can use #require.
+--disable noForceUnwrapInTests
+--disable redundantClosure
+--disable redundantNilInit
+--disable redundantSwiftUIGroup
+--disable redundantVariable
+--disable redundantViewBuilder
+--disable simplifyGenericConstraints
+--disable wrapIfStatementBodies
+--disable wrapPropertyBodies
 
 # Enabled
 
@@ -32,4 +40,3 @@
 --enable blankLinesBetweenImports
 --enable blockComments
 --enable isEmpty
---enable organizeDeclarations

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -77,8 +77,6 @@ opt_in_rules:
   #NOT NEEDED - multiline_literal_brackets
   - multiline_parameters
   #NOT NEEDED - multiline_parameters_brackets
-  - multiple_closures_with_trailing_closure
-  - nesting
   - nimble_operator
   #NOT NEEDED - no_extension_access_modifier
   #NOT NEEDED - no_grouping_extension
@@ -119,7 +117,6 @@ opt_in_rules:
   - strict_fileprivate
   #NOT NEEDED - strong_iboutlet
   #NOT NEEDED - switch_case_on_newline
-  - syntactic_sugar
   #NOT NEEDED - test_case_accessibility
   #NOT NEEDED - toggle_bool
   #NOT NEEDED - trailing_closure

--- a/AllTargetsTests/Empty.swift
+++ b/AllTargetsTests/Empty.swift
@@ -11,6 +11,6 @@ import XCTest
 ///
 /// AllTargetsTests is a test target to link all other targets to ensure we produce coverage info for all code.
 final class Empty: XCTestCase {
-    func testEmpty() throws {
+    func testEmpty() {
     }
 }

--- a/Core/QueuePlayer/AudioPlaying.swift
+++ b/Core/QueuePlayer/AudioPlaying.swift
@@ -14,12 +14,6 @@ struct FramePlaying {
 }
 
 struct FilePlaying {
-    // MARK: Lifecycle
-
-    init(fileIndex: Int) {
-        self.fileIndex = fileIndex
-    }
-
     // MARK: Internal
 
     let fileIndex: Int

--- a/Core/Utilities/Sources/Extensions/Array+Extension.swift
+++ b/Core/Utilities/Sources/Extensions/Array+Extension.swift
@@ -20,7 +20,8 @@ extension Array where Element: Hashable {
 extension Array {
     public func sortedAs<T: Hashable>(_ other: [T], by keyPath: KeyPath<Element, T>) -> [Element] {
         let indices = [T: Int](
-            uniqueKeysWithValues: other.enumerated().map { ($0.element, $0.offset) })
+            uniqueKeysWithValues: other.enumerated().map { ($0.element, $0.offset) }
+        )
         return sorted { (lhs: Element, rhs: Element) in
             indices[lhs[keyPath: keyPath]]! < indices[rhs[keyPath: keyPath]]!
         }

--- a/Core/Utilities/Sources/Features/AsyncPublisher.swift
+++ b/Core/Utilities/Sources/Features/AsyncPublisher.swift
@@ -37,7 +37,6 @@ public struct AsyncPublisher<Element>: AsyncSequence {
         // the iterator.
         var cancellable: AnyCancellable?
         let stream = AsyncStream(Element.self, bufferingPolicy: bufferingPolicy) { continuation in
-
             cancellable = publisher.sink { completion in
                 continuation.finish()
             } receiveValue: { [weak cancellable] value in

--- a/Core/Utilities/Sources/Features/AsyncThrowingPublisher.swift
+++ b/Core/Utilities/Sources/Features/AsyncThrowingPublisher.swift
@@ -37,7 +37,6 @@ public struct AsyncThrowingPublisher<Element>: AsyncSequence {
         // the iterator.
         var cancellable: AnyCancellable?
         let stream = AsyncThrowingStream(Element.self, bufferingPolicy: bufferingPolicy) { continuation in
-
             cancellable = publisher.sink { completion in
                 switch completion {
                 case .finished:
@@ -78,7 +77,8 @@ public struct AsyncThrowingPublisher<Element>: AsyncSequence {
 
 public extension Publisher {
     func values(
-        bufferingPolicy: AsyncThrowingPublisher<Output>.BufferingPolicy = .unbounded)
+        bufferingPolicy: AsyncThrowingPublisher<Output>.BufferingPolicy = .unbounded
+    )
         -> AsyncThrowingPublisher<Output>
     {
         AsyncThrowingPublisher(

--- a/Core/Utilities/Tests/AsyncThrowingPublisherTests.swift
+++ b/Core/Utilities/Tests/AsyncThrowingPublisherTests.swift
@@ -41,7 +41,7 @@ class AsyncThrowingPublisherTests: XCTestCase {
         values = Values()
     }
 
-    func test_passThroughSubject_failure() async throws {
+    func test_passThroughSubject_failure() async {
         let asyncPublisher = subject.values()
 
         Task {
@@ -67,7 +67,7 @@ class AsyncThrowingPublisherTests: XCTestCase {
         await AsyncAssertEqual(await values.error as? PublishingError, PublishingError.invalid)
     }
 
-    func test_passThroughSubject_subjectCancellation() async throws {
+    func test_passThroughSubject_subjectCancellation() async {
         let prefix = 2
         let asyncPublisher = subject.values(bufferingPolicy: .unbounded)
 
@@ -94,7 +94,7 @@ class AsyncThrowingPublisherTests: XCTestCase {
         await AsyncAssertEqual(await values.results, Array(numbers.prefix(2)))
     }
 
-    func test_passThroughSubject_taskCancellation() async throws {
+    func test_passThroughSubject_taskCancellation() async {
         let asyncPublisher = subject.values(bufferingPolicy: .unbounded)
 
         let task = Task {

--- a/Data/CoreDataPersistence/Sources/CoreDataStack.swift
+++ b/Data/CoreDataPersistence/Sources/CoreDataStack.swift
@@ -87,7 +87,7 @@ public class CoreDataStack {
     private let lazyUniquifiers: () -> [CoreDataEntityUniquifier]
     private lazy var uniquifiers: [CoreDataEntityUniquifier] = lazyUniquifiers()
 
-    private lazy var historyProcessor: CoreDataPersistentHistoryProcessor = CoreDataPersistentHistoryProcessor(name: name, uniquifiers: uniquifiers)
+    private lazy var historyProcessor: CoreDataPersistentHistoryProcessor = .init(name: name, uniquifiers: uniquifiers)
 
     /// An operation queue for handling history processing tasks: watching changes, deduplicating entities, and triggering UI updates if needed.
     private lazy var historyQueue: OperationQueue = {

--- a/Data/SQLitePersistence/Tests/DatabaseConnectionTests.swift
+++ b/Data/SQLitePersistence/Tests/DatabaseConnectionTests.swift
@@ -25,7 +25,7 @@ class DatabaseConnectionTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_creation() throws {
+    func test_creation() {
         let connection = DatabaseConnection(url: testURL)
         XCTAssertNotNil(connection)
         // Initially database file is not created.
@@ -98,7 +98,7 @@ class DatabaseConnectionTests: XCTestCase {
         XCTAssertEqual(names, ["Alice"])
     }
 
-    func test_release() throws {
+    func test_release() {
         var connection: DatabaseConnection? = DatabaseConnection(url: testURL)
         weak var weakConnection = connection
         connection = nil // should call deinit

--- a/Domain/AnnotationsService/Tests/EmptyTests.swift
+++ b/Domain/AnnotationsService/Tests/EmptyTests.swift
@@ -8,6 +8,6 @@
 import XCTest
 
 final class EmptyTests: XCTestCase {
-    func test_empty() throws {
+    func test_empty() {
     }
 }

--- a/Domain/ImageService/Tests/LinePageGeometryTests.swift
+++ b/Domain/ImageService/Tests/LinePageGeometryTests.swift
@@ -13,7 +13,7 @@ import XCTest
 final class LinePageGeometryTests: XCTestCase {
     // MARK: Internal
 
-    func testPortraitLayoutMatchesSizingRules() throws {
+    func testPortraitLayoutMatchesSizingRules() {
         let layout = makeEngine().layout(
             LinePageGeometryInput(
                 availableSize: CGSize(width: 400, height: 800),
@@ -180,7 +180,7 @@ final class LinePageGeometryTests: XCTestCase {
         XCTAssertEqual(layout.verse(at: point), lastAyah)
     }
 
-    func testHiddenHeaderFooterDoesNotReserveChromeSpace() throws {
+    func testHiddenHeaderFooterDoesNotReserveChromeSpace() {
         let layout = makeEngine().layout(
             LinePageGeometryInput(
                 availableSize: CGSize(width: 600, height: 800),
@@ -200,7 +200,7 @@ final class LinePageGeometryTests: XCTestCase {
         XCTAssertNil(layout.sidelineFrame)
     }
 
-    func testNonOverlappingMetricsPlaceLinesInEvenSlots() throws {
+    func testNonOverlappingMetricsPlaceLinesInEvenSlots() {
         let metrics = LinePageMetrics.naskhLinePages
         let layout = makeEngine().layout(
             LinePageGeometryInput(

--- a/Domain/QuranTextKit/Sources/TranslationText/QuranTextDataService.swift
+++ b/Domain/QuranTextKit/Sources/TranslationText/QuranTextDataService.swift
@@ -163,8 +163,8 @@ public struct QuranTextDataService {
         let footnoteTextRanges = originalString.ranges(of: Self.footnotesRegex)
         let footnotes = footnoteTextRanges.map { originalString[$0] }
         let (string, footnoteRanges) = originalString.replacing(
-            sortedRanges: footnoteTextRanges)
-        { _, index -> String in
+            sortedRanges: footnoteTextRanges
+        ) { _, index -> String in
             lFormat("translation.text.footnote-number", index + 1)
         }
 

--- a/Domain/QuranTextKit/Tests/TwoPagesUtilsTests.swift
+++ b/Domain/QuranTextKit/Tests/TwoPagesUtilsTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import QuranTextKit
 
 class TwoPagesUtilsTests: XCTestCase {
-    func testHasEnoughHorizontalSpace() throws {
+    func testHasEnoughHorizontalSpace() {
         let hasEnoughSpace = TwoPagesUtils.hasEnoughHorizontalSpace()
         if UIScreen.main.bounds.width > 900 {
             XCTAssertTrue(hasEnoughSpace)

--- a/Domain/ReadingService/Sources/ReadingResourceDownloader.swift
+++ b/Domain/ReadingService/Sources/ReadingResourceDownloader.swift
@@ -9,13 +9,6 @@ import BatchDownloader
 import QuranKit
 
 struct ReadingResourceDownloader {
-    // MARK: Lifecycle
-
-    init(downloader: DownloadManager, remoteResources: ReadingRemoteResources?) {
-        self.downloader = downloader
-        self.remoteResources = remoteResources
-    }
-
     // MARK: Internal
 
     let downloader: DownloadManager

--- a/Domain/ReadingService/Tests/ReadingResourcesServiceTests.swift
+++ b/Domain/ReadingService/Tests/ReadingResourcesServiceTests.swift
@@ -57,7 +57,7 @@ final class ReadingResourcesServiceTests: XCTestCase {
         service = nil
     }
 
-    func test_bundledResource() async throws {
+    func test_bundledResource() async {
         // Given
         ReadingPreferences.shared.reading = .hafs_1405
         // Assume all reading directories exist.

--- a/Domain/ReciterService/Tests/RecentRecitersServiceTests.swift
+++ b/Domain/ReciterService/Tests/RecentRecitersServiceTests.swift
@@ -68,7 +68,7 @@ class RecentRecitersServiceTests: XCTestCase {
     }
 
     private func createReciter(id: Int) -> Reciter {
-        let name: String = "reciter" + String(id)
+        let name = "reciter" + String(id)
         return Reciter(
             id: id,
             nameKey: name,

--- a/Domain/SettingsService/ReviewPersistence.swift
+++ b/Domain/SettingsService/ReviewPersistence.swift
@@ -16,7 +16,7 @@ final class ReviewPersistence {
 
     // MARK: Public
 
-    public static let shared = ReviewPersistence()
+    static let shared = ReviewPersistence()
 
     // MARK: Internal
 

--- a/Domain/TranslationService/Tests/TranslationsDownloaderTests.swift
+++ b/Domain/TranslationService/Tests/TranslationsDownloaderTests.swift
@@ -40,7 +40,7 @@ class TranslationsDownloaderTests: XCTestCase {
         XCTAssertEqual(response.destinations, [translation.localPath])
     }
 
-    func test_runningDownloads_empty() async throws {
+    func test_runningDownloads_empty() async {
         let downloads = await downloader.runningTranslationDownloads()
         XCTAssertEqual(downloads, [])
     }

--- a/Domain/TranslationService/Tests/TranslationsRepositoryTests.swift
+++ b/Domain/TranslationService/Tests/TranslationsRepositoryTests.swift
@@ -34,7 +34,8 @@ class TranslationsRepositoryTests: XCTestCase {
 
     func test_firstTimeDownload() async throws {
         try nextResponse(TranslationsResponse(
-            data: translations.map { TranslationResponse($0) }))
+            data: translations.map { TranslationResponse($0) }
+        ))
 
         try await service.downloadAndSyncTranslations()
 

--- a/Example/QuranEngineApp/Classes/Container.swift
+++ b/Example/QuranEngineApp/Classes/Container.swift
@@ -171,9 +171,9 @@ private enum Constant {
     static let wordsDatabase = Bundle.main
         .url(forResource: "words", withExtension: "db")!
 
-    static let appHost: URL = URL(validURL: "https://quran.app/")
+    static let appHost: URL = .init(validURL: "https://quran.app/")
 
-    static let filesAppHost: URL = URL(validURL: "https://files.quran.app/")
+    static let filesAppHost: URL = .init(validURL: "https://files.quran.app/")
 
     static let databasesURL = FileManager.documentsURL
         .appendingPathComponent("databases", isDirectory: true)

--- a/Features/AyahMenuFeature/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewController.swift
@@ -25,7 +25,7 @@ final class AyahMenuViewController: UIViewController {
 
     // MARK: Public
 
-    override public func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
+    override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
         super.preferredContentSizeDidChange(forChildContentContainer: container)
         preferredContentSize = container.preferredContentSize
     }

--- a/Features/MoreMenuFeature/MoreMenuViewModel.swift
+++ b/Features/MoreMenuFeature/MoreMenuViewModel.swift
@@ -105,7 +105,7 @@ final class MoreMenuViewModel: ObservableObject {
 
     // MARK: Public
 
-    @Published public var mode: QuranMode {
+    @Published var mode: QuranMode {
         didSet {
             if mode == .translation {
                 wordPointerEnabled = false

--- a/Features/MoreMenuFeature/views/MoreMenuDeviceRotation.swift
+++ b/Features/MoreMenuFeature/views/MoreMenuDeviceRotation.swift
@@ -75,7 +75,7 @@ private struct DeviceOrientationResolver: UIViewControllerRepresentable {
     class DeviceOrientationResolverController: UIViewController {
         // MARK: Public
 
-        override public func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
             super.viewWillTransition(to: size, with: coordinator)
             coordinator.animate(alongsideTransition: nil) { _ in
                 self.orientationChanged?(self.orientation)

--- a/Features/QuranPagesFeature/PageGeometryActions.swift
+++ b/Features/QuranPagesFeature/PageGeometryActions.swift
@@ -26,8 +26,8 @@ public struct PageGeometryActions: Equatable {
 }
 
 private struct PageGeometryActionsPreferenceKey: PreferenceKey {
-    public static var defaultValue: [PageGeometryActions] = []
-    public static func reduce(value: inout [PageGeometryActions], nextValue: () -> [PageGeometryActions]) {
+    static var defaultValue: [PageGeometryActions] = []
+    static func reduce(value: inout [PageGeometryActions], nextValue: () -> [PageGeometryActions]) {
         value.append(contentsOf: nextValue())
     }
 }

--- a/Features/ReadingSelectorFeature/View/ReadingDetails.swift
+++ b/Features/ReadingSelectorFeature/View/ReadingDetails.swift
@@ -98,7 +98,8 @@ struct ReadingDetails<Value: Hashable, ImageView: View>: View {
                     .fill(
                         LinearGradient(
                             gradient: Gradient(
-                                colors: [Color.appIdentity, Color.appIdentity.opacity(0.7)]),
+                                colors: [Color.appIdentity, Color.appIdentity.opacity(0.7)]
+                            ),
                             startPoint: .leading,
                             endPoint: .trailing
                         )

--- a/Features/ReadingSelectorFeature/View/ReadingInfo.swift
+++ b/Features/ReadingSelectorFeature/View/ReadingInfo.swift
@@ -9,15 +9,6 @@ import Localization
 import QuranKit
 
 struct ReadingInfo<Value: Hashable>: Hashable, Identifiable {
-    // MARK: Lifecycle
-
-    init(value: Value, title: String, description: String, properties: [Reading.Property]) {
-        self.value = value
-        self.title = title
-        self.description = description
-        self.properties = properties
-    }
-
     // MARK: Internal
 
     let value: Value

--- a/Features/WhatsNewFeature/AppWhatsNewVersionStore.swift
+++ b/Features/WhatsNewFeature/AppWhatsNewVersionStore.swift
@@ -13,7 +13,7 @@ import WhatsNewKit
 final class AppWhatsNewVersionStore: WhatsNewVersionStore {
     // MARK: Public
 
-    public func has(version: WhatsNew.Version) -> Bool {
+    func has(version: WhatsNew.Version) -> Bool {
         false
     }
 

--- a/Features/WordPointerFeature/WordPointerViewController.swift
+++ b/Features/WordPointerFeature/WordPointerViewController.swift
@@ -129,7 +129,7 @@ public final class WordPointerViewController: UIViewController {
     private let viewModel: WordPointerViewModel
 
     // For word translation
-    private lazy var popover: PopoverView = PopoverView(view: container)
+    private lazy var popover: PopoverView = .init(view: container)
 
     private var pointerTop: NSLayoutConstraint!
     private var pointerLeft: NSLayoutConstraint!

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,10 @@ EXAMPLE_SDK ?= iphonesimulator
 EXAMPLE_DESTINATION ?= generic/platform=iOS
 
 SWIFT_FORMAT_REPO=https://github.com/nicklockwood/SwiftFormat
-SWIFT_FORMAT_VERSION=0.54.3
+SWIFT_FORMAT_VERSION=0.62.1
 SWIFT_FORMAT_DIR=$(BUILD_TOOLS_DIR)/SwiftFormat
 SWIFT_FORMAT_BIN=$(SWIFT_FORMAT_DIR)/.build/release/swiftformat
+SWIFT_FORMAT_VERSION_FILE=$(abspath $(SWIFT_FORMAT_DIR))/.swiftformat-version
 
 CURRENT_TARGET=$(if $(TARGET),$(TARGET),$(PACKAGE_SCHEME))
 WITHOUT_QURAN_SYNC=env -u QURAN_SYNC
@@ -63,13 +64,15 @@ clone-swiftformat:
 		echo "Cloning SwiftFormat repository..."; \
 		git clone --branch $(SWIFT_FORMAT_VERSION) --depth 1 $(SWIFT_FORMAT_REPO) $(SWIFT_FORMAT_DIR); \
 	else \
-		echo "SwiftFormat repository already exists."; \
+		echo "SwiftFormat repository already exists. Checking out $(SWIFT_FORMAT_VERSION)."; \
+		cd $(SWIFT_FORMAT_DIR) && git fetch --depth 1 origin tag $(SWIFT_FORMAT_VERSION) && git checkout $(SWIFT_FORMAT_VERSION); \
 	fi
 
 build-swiftformat: clone-swiftformat
-	@if [ ! -f $(SWIFT_FORMAT_BIN) ]; then \
+	@if [ ! -f $(SWIFT_FORMAT_BIN) ] || [ "$$(cat $(SWIFT_FORMAT_VERSION_FILE) 2>/dev/null)" != "$(SWIFT_FORMAT_VERSION)" ]; then \
 		echo "Building swiftformat in $(SWIFT_FORMAT_DIR)"; \
 		cd $(SWIFT_FORMAT_DIR) && swift build -c release; \
+		echo "$(SWIFT_FORMAT_VERSION)" > $(SWIFT_FORMAT_VERSION_FILE); \
 	else \
 		echo "SwiftFormat binary already exists."; \
 	fi
@@ -77,6 +80,7 @@ build-swiftformat: clone-swiftformat
 force-build-swiftformat: clone-swiftformat
 	@echo "Force building swiftformat in $(SWIFT_FORMAT_DIR)"
 	cd $(SWIFT_FORMAT_DIR) && swift build -c release
+	@echo "$(SWIFT_FORMAT_VERSION)" > $(SWIFT_FORMAT_VERSION_FILE)
 
 clean-swiftformat:
 	@rm -rf $(SWIFT_FORMAT_DIR)/.build

--- a/Model/QuranKit/Sources/QuranValueStorage.swift
+++ b/Model/QuranKit/Sources/QuranValueStorage.swift
@@ -8,7 +8,7 @@
 struct QuranValueStorage<T: QuranValueGroup>: Hashable, Comparable, @unchecked Sendable {
     // MARK: Public
 
-    public var next: T? {
+    var next: T? {
         let values = quran[keyPath: keyPath]
         if self == values.last?.storage {
             return nil
@@ -16,7 +16,7 @@ struct QuranValueStorage<T: QuranValueGroup>: Hashable, Comparable, @unchecked S
         return T(QuranValueStorage(quran: quran, value: value + 1, keyPath: keyPath))
     }
 
-    public var previous: T? {
+    var previous: T? {
         let values = quran[keyPath: keyPath]
         if self == values.first?.storage {
             return nil
@@ -24,7 +24,7 @@ struct QuranValueStorage<T: QuranValueGroup>: Hashable, Comparable, @unchecked S
         return T(QuranValueStorage(quran: quran, value: value - 1, keyPath: keyPath))
     }
 
-    public static func < (lhs: Self, rhs: Self) -> Bool {
+    static func < (lhs: Self, rhs: Self) -> Bool {
         lhs.value < rhs.value
     }
 

--- a/Model/QuranKit/Tests/AyahNumberTests.swift
+++ b/Model/QuranKit/Tests/AyahNumberTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class AyahNumberTests: XCTestCase {
     // MARK: Internal
 
-    func testVerses() throws {
+    func testVerses() {
         let verses = quran.verses
         XCTAssertEqual(verses.count, 6236)
         XCTAssertEqual(verses.first!.sura.suraNumber, 1)

--- a/Model/QuranKit/Tests/HizbTests.swift
+++ b/Model/QuranKit/Tests/HizbTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class HizbTests: XCTestCase {
     // MARK: Internal
 
-    func testHizbs() throws {
+    func testHizbs() {
         let hizbs = quran.hizbs
         XCTAssertEqual(hizbs.count, 60)
         XCTAssertEqual(hizbs.first!.hizbNumber, 1)

--- a/Model/QuranKit/Tests/JuzTests.swift
+++ b/Model/QuranKit/Tests/JuzTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class JuzTests: XCTestCase {
     // MARK: Internal
 
-    func testJuzs() throws {
+    func testJuzs() {
         let juzs = quran.juzs
         XCTAssertEqual(juzs.count, 30)
         XCTAssertEqual(juzs.first!.juzNumber, 1)

--- a/Model/QuranKit/Tests/PageTests.swift
+++ b/Model/QuranKit/Tests/PageTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class PageTests: XCTestCase {
     // MARK: Internal
 
-    func testPages() throws {
+    func testPages() {
         let pages = quran.pages
         XCTAssertEqual(pages.count, 604)
         XCTAssertEqual(pages.first!.pageNumber, 1)

--- a/Model/QuranKit/Tests/QuarterTests.swift
+++ b/Model/QuranKit/Tests/QuarterTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class QuarterTests: XCTestCase {
     // MARK: Internal
 
-    func testQuarters() throws {
+    func testQuarters() {
         let quarters = quran.quarters
         XCTAssertEqual(quarters.count, 240)
         XCTAssertEqual(quarters.first!.quarterNumber, 1)

--- a/Model/QuranKit/Tests/SuraTests.swift
+++ b/Model/QuranKit/Tests/SuraTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class SuraTests: XCTestCase {
     // MARK: Internal
 
-    func testSuras() throws {
+    func testSuras() {
         let suras = quran.suras
         XCTAssertEqual(suras.count, 114)
         XCTAssertEqual(suras.first!.suraNumber, 1)

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
@@ -303,15 +303,9 @@ private struct Row<Symbol: View, Accessory: View>: View {
 }
 
 private struct MenuGroup<Content: View>: View {
-    // MARK: Lifecycle
-
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
-
     // MARK: Internal
 
-    let content: Content
+    @ViewBuilder let content: Content
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {

--- a/UI/NoorUI/Features/Quran/ImageDecorationsView.swift
+++ b/UI/NoorUI/Features/Quran/ImageDecorationsView.swift
@@ -111,7 +111,7 @@ struct ImageDecorationsView: View {
 
     // MARK: Private
 
-    @State private var sizeInfo: SizeInfo = SizeInfo(imageSize: .zero, viewSize: .zero)
+    @State private var sizeInfo: SizeInfo = .init(imageSize: .zero, viewSize: .zero)
 }
 
 public struct SuraHeaderView: View {

--- a/UI/UIx/SwiftUI/Views/TextView.swift
+++ b/UI/UIx/SwiftUI/Views/TextView.swift
@@ -28,7 +28,7 @@ public struct TextView: View {
 
     // MARK: Private
 
-    private var font: UIFont = UIFont.preferredFont(forTextStyle: .body)
+    private var font: UIFont = .preferredFont(forTextStyle: .body)
 }
 
 extension TextView {

--- a/UI/UIx/UIKit/Extensions/UIColor+Extension.swift
+++ b/UI/UIx/UIKit/Extensions/UIColor+Extension.swift
@@ -45,7 +45,7 @@ extension UIColor {
 
         getRed(&r, green: &g, blue: &b, alpha: &a)
 
-        let rgb: Int = Int(r * 255) << 16 | Int(g * 255) << 8 | Int(b * 255) << 0
+        let rgb = Int(r * 255) << 16 | Int(g * 255) << 8 | Int(b * 255) << 0
 
         return String(format: "#%06x", rgb)
     }

--- a/UI/UIx/UIKit/Views/BackgroundColorButton.swift
+++ b/UI/UIx/UIKit/Views/BackgroundColorButton.swift
@@ -35,25 +35,25 @@ open class BackgroundColorButton: UIButton {
 
     // MARK: Open
 
-    @IBInspectable open var normalBackground: UIColor = UIColor.lightGray {
+    @IBInspectable open var normalBackground: UIColor = .lightGray {
         didSet {
             updateBackgroundColor()
         }
     }
 
-    @IBInspectable open var selectedBackground: UIColor = UIColor.blue {
+    @IBInspectable open var selectedBackground: UIColor = .blue {
         didSet {
             updateBackgroundColor()
         }
     }
 
-    @IBInspectable open var highlightedBackground: UIColor = UIColor.red {
+    @IBInspectable open var highlightedBackground: UIColor = .red {
         didSet {
             updateBackgroundColor()
         }
     }
 
-    @IBInspectable open var disabledBackground: UIColor = UIColor.darkGray {
+    @IBInspectable open var disabledBackground: UIColor = .darkGray {
         didSet {
             updateBackgroundColor()
         }

--- a/UI/UIx/UIKit/Views/CircleView.swift
+++ b/UI/UIx/UIKit/Views/CircleView.swift
@@ -41,13 +41,13 @@ open class CircleView: UIView {
         }
     }
 
-    @IBInspectable open var emptyColor: UIColor = UIColor.red {
+    @IBInspectable open var emptyColor: UIColor = .red {
         didSet {
             updateLayers()
         }
     }
 
-    @IBInspectable open var fillColor: UIColor = UIColor.green {
+    @IBInspectable open var fillColor: UIColor = .green {
         didSet {
             updateLayers()
         }

--- a/UI/UIx/UIKit/Views/RoundedShadowView.swift
+++ b/UI/UIx/UIKit/Views/RoundedShadowView.swift
@@ -53,7 +53,7 @@ public class RoundedShadowView: UIView {
         }
     }
 
-    public var shadowOffset: CGSize = CGSize(width: 0, height: 3) {
+    public var shadowOffset: CGSize = .init(width: 0, height: 3) {
         didSet {
             updateLayerUI()
         }

--- a/UI/UIx/UIKit/Views/ScrollViewController.swift
+++ b/UI/UIx/UIKit/Views/ScrollViewController.swift
@@ -22,7 +22,7 @@ public class ScrollViewController: UIViewController {
 
     // MARK: Public
 
-    public private(set) lazy var scrollView: UIScrollView = UIScrollView()
+    public private(set) lazy var scrollView: UIScrollView = .init()
 
     override public func loadView() {
         scrollView.backgroundColor = .clear

--- a/UI/UIx/UIKit/Views/SearchControllerWithNoCancelButton.swift
+++ b/UI/UIx/UIKit/Views/SearchControllerWithNoCancelButton.swift
@@ -35,5 +35,5 @@ open class SearchControllerWithNoCancelButton: UISearchController {
 
     // MARK: Private
 
-    private lazy var _searchBar: SearchBarWithNoCancelButton = SearchBarWithNoCancelButton()
+    private lazy var _searchBar: SearchBarWithNoCancelButton = .init()
 }


### PR DESCRIPTION
## Summary

- Upgrade the pinned SwiftFormat build tool from 0.54.3 to 0.62.1.
- Make the Makefile rebuild SwiftFormat when the pinned version changes.
- Keep high-churn 0.62 rules disabled while enabling the accepted cleanup rules for redundant types, public access, throws, and memberwise initializers.
- Keep `unusedArguments` disabled to preserve readable delegate and closure parameter names.
- Remove contradictory SwiftLint opt-ins that were already listed as disabled.

## Validation

- `make format-lint`
- `make build-no-sync`
- `make test-no-sync`
