### PR TITLE
build: add explicit sync build modes

### DIFF
--- a/Documentation/MobileSyncLocalDevelopment.md
+++ b/Documentation/MobileSyncLocalDevelopment.md
@@ -4,48 +4,48 @@ This project keeps the mobile sync integration behind the `QURAN_SYNC` compilati
 
 ## Enable the feature
 
-### From Xcode
+### Build flags
 
-Set `QURAN_SYNC` directly in the example app target build settings:
-
-```text
-SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) QURAN_SYNC
-```
-
-Swift package targets also read `QURAN_SYNC` from `Package.swift`, so launch Xcode with the environment variable set when you want the package feature modules to compile with sync enabled:
+Package targets read `QURAN_SYNC` from the process environment in `Package.swift`. Any non-empty value other than `0` enables package sync support. Use `1` by convention:
 
 ```bash
-launchctl setenv QURAN_SYNC 1
-
-osascript -e 'quit app "Xcode"'
-pkill -x SWBBuildService 2>/dev/null || true
-pkill -x XCBBuildService 2>/dev/null || true
-
-open -a /Applications/Xcode.app Example/QuranEngineApp.xcodeproj
+QURAN_SYNC=1
 ```
 
-`launchctl setenv` makes `QURAN_SYNC` visible to Xcode and its build services. A shell-scoped environment variable, for example `QURAN_SYNC=1 open ...`, may not propagate to Swift package manifest evaluation.
-
-After toggling the flag:
-
-1. Use **File > Packages > Reset Package Caches**.
-2. Use **Product > Clean Build Folder**.
-3. Build or run the example app.
-
-To disable sync for later Xcode sessions:
+Use an empty, unset, or `0` value for the no-sync path:
 
 ```bash
-launchctl unsetenv QURAN_SYNC
+QURAN_SYNC=
+# or
+QURAN_SYNC=0
 ```
+
+The environment value only affects Swift Package evaluation. To compile app or project code guarded by `#if QURAN_SYNC`, add `QURAN_SYNC` to the target's `SWIFT_ACTIVE_COMPILATION_CONDITIONS` / "Active Compilation Conditions" build setting, or pass `-D QURAN_SYNC` through `OTHER_SWIFT_FLAGS`.
+
+When switching modes outside the Makefile, use separate DerivedData paths or **Product > Clean Build Folder** so Xcode does not reuse build products from the other mode.
 
 ### From the command line
 
+Use the Makefile targets for local verification:
+
 ```bash
-QURAN_SYNC=1 xcrun xcodebuild build \
+make build-example-no-sync
+make build-example-sync
+```
+
+These targets use separate DerivedData paths under `.build/DerivedData/no-sync` and `.build/DerivedData/sync`, so switching sync modes does not reuse stale build products and each mode still gets incremental builds. No package-cache reset is needed.
+
+The sync target sets `QURAN_SYNC` for `Package.swift` and passes `-D QURAN_SYNC` only to the Example app target:
+
+```bash
+QURAN_SYNC=1 xcrun xcodebuild \
+  -derivedDataPath .build/DerivedData/sync \
+  build \
   -project Example/QuranEngineApp.xcodeproj \
   -scheme QuranEngineApp \
   -sdk iphonesimulator \
-  -destination 'generic/platform=iOS'
+  -destination 'generic/platform=iOS' \
+  'OTHER_SWIFT_FLAGS=$(inherited) -D QURAN_SYNC'
 ```
 
 ## Required runtime environment variables

--- a/Example/QuranEngineApp.xcodeproj/project.pbxproj
+++ b/Example/QuranEngineApp.xcodeproj/project.pbxproj
@@ -348,7 +348,6 @@
 				MARKETING_VERSION = 1.20.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.quran.QuranEngineApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) QURAN_SYNC";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "QuranEngineApp/Classes/QuranEngineApp-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -381,7 +380,6 @@
 				MARKETING_VERSION = 1.20.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.quran.QuranEngineApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) QURAN_SYNC";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "QuranEngineApp/Classes/QuranEngineApp-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ EXAMPLE_PROJECT ?= Example/QuranEngineApp.xcodeproj
 EXAMPLE_SCHEME ?= QuranEngineApp
 EXAMPLE_SDK ?= iphonesimulator
 EXAMPLE_DESTINATION ?= generic/platform=iOS
+DERIVED_DATA_DIR ?= .build/DerivedData
 
 SWIFT_FORMAT_REPO=https://github.com/nicklockwood/SwiftFormat
 SWIFT_FORMAT_VERSION=0.62.1
@@ -17,8 +18,11 @@ SWIFT_FORMAT_BIN=$(SWIFT_FORMAT_DIR)/.build/release/swiftformat
 SWIFT_FORMAT_VERSION_FILE=$(abspath $(SWIFT_FORMAT_DIR))/.swiftformat-version
 
 CURRENT_TARGET=$(if $(TARGET),$(TARGET),$(PACKAGE_SCHEME))
-WITHOUT_QURAN_SYNC=env -u QURAN_SYNC
-WITH_QURAN_SYNC=env QURAN_SYNC=1
+WITHOUT_QURAN_SYNC=set -o pipefail; env QURAN_SYNC=
+WITH_QURAN_SYNC=set -o pipefail; env QURAN_SYNC=QURAN_SYNC
+WITHOUT_QURAN_SYNC_DERIVED_DATA=$(DERIVED_DATA_DIR)/no-sync
+WITH_QURAN_SYNC_DERIVED_DATA=$(DERIVED_DATA_DIR)/sync
+WITH_QURAN_SYNC_APP_SWIFT_FLAGS='OTHER_SWIFT_FLAGS=$$(inherited) -D QURAN_SYNC'
 
 .PHONY: test test-no-sync test-sync test-without-sync test-with-sync build build-no-sync build-sync build-without-sync build-with-sync build-example build-example-no-sync build-example-sync build-example-without-sync build-example-with-sync clone-swiftformat build-swiftformat force-build-swiftformat clean-swiftformat format-lint format-autocorrect install-swiftlint build-for-analyzer swiftlint-analyzer
 
@@ -29,10 +33,10 @@ test-no-sync: test-without-sync
 test-sync: test-with-sync
 
 test-without-sync:
-	set -o pipefail; $(WITHOUT_QURAN_SYNC) xcrun xcodebuild build test -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
+	$(WITHOUT_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITHOUT_QURAN_SYNC_DERIVED_DATA)" build test -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
 
 test-with-sync:
-	set -o pipefail; $(WITH_QURAN_SYNC) xcrun xcodebuild build test -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
+	$(WITH_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_QURAN_SYNC_DERIVED_DATA)" build test -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
 
 build: build-no-sync
 
@@ -41,10 +45,10 @@ build-no-sync: build-without-sync
 build-sync: build-with-sync
 
 build-without-sync:
-	set -o pipefail; $(WITHOUT_QURAN_SYNC) xcrun xcodebuild build -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" | xcbeautify --renderer github-actions
+	$(WITHOUT_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITHOUT_QURAN_SYNC_DERIVED_DATA)" build -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
 
 build-with-sync:
-	set -o pipefail; $(WITH_QURAN_SYNC) xcrun xcodebuild build -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" | xcbeautify --renderer github-actions
+	$(WITH_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_QURAN_SYNC_DERIVED_DATA)" build -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
 
 build-example: build-example-no-sync
 
@@ -53,10 +57,10 @@ build-example-no-sync: build-example-without-sync
 build-example-sync: build-example-with-sync
 
 build-example-without-sync:
-	set -o pipefail; $(WITHOUT_QURAN_SYNC) xcrun xcodebuild build -project $(EXAMPLE_PROJECT) -scheme $(EXAMPLE_SCHEME) -sdk "$(EXAMPLE_SDK)" -destination "$(EXAMPLE_DESTINATION)" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcbeautify --renderer github-actions
+	$(WITHOUT_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITHOUT_QURAN_SYNC_DERIVED_DATA)" build -project $(EXAMPLE_PROJECT) -scheme $(EXAMPLE_SCHEME) -sdk "$(EXAMPLE_SDK)" -destination "$(EXAMPLE_DESTINATION)" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO 2>&1 | xcbeautify --renderer github-actions
 
 build-example-with-sync:
-	set -o pipefail; $(WITH_QURAN_SYNC) xcrun xcodebuild build -project $(EXAMPLE_PROJECT) -scheme $(EXAMPLE_SCHEME) -sdk "$(EXAMPLE_SDK)" -destination "$(EXAMPLE_DESTINATION)" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcbeautify --renderer github-actions
+	$(WITH_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_QURAN_SYNC_DERIVED_DATA)" build -project $(EXAMPLE_PROJECT) -scheme $(EXAMPLE_SCHEME) -sdk "$(EXAMPLE_SDK)" -destination "$(EXAMPLE_DESTINATION)" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO $(WITH_QURAN_SYNC_APP_SWIFT_FLAGS) 2>&1 | xcbeautify --renderer github-actions
 
 clone-swiftformat:
 	@mkdir -p $(BUILD_TOOLS_DIR)


### PR DESCRIPTION
## Summary
- Add explicit sync/no-sync DerivedData paths to local Make targets.
- Pass the Example app Swift compiler condition separately from the package environment.
- Update Mobile Sync local development docs for the current `QURAN_SYNC` behavior.

## Validation
- `make build-example-no-sync`
- `make build-example-sync`
- `make format-lint`

## Notes
This is the base PR for the follow-up sync-gating cleanup PR.