### PR TITLE
refactor: gate sync-only app code

### DIFF
--- a/Data/AuthenticationClient/Sources/AuthenticationClient.swift
+++ b/Data/AuthenticationClient/Sources/AuthenticationClient.swift
@@ -5,6 +5,8 @@
 //  Created by Mohannad Hassan on 19/12/2024.
 //
 
+#if QURAN_SYNC
+
 import Foundation
 import MobileSync
 import UIKit
@@ -56,3 +58,5 @@ public extension AuthenticationClient {
         }
     }
 }
+
+#endif

--- a/Data/AuthenticationClient/Sources/AuthenticationClientMobileSyncImpl.swift
+++ b/Data/AuthenticationClient/Sources/AuthenticationClientMobileSyncImpl.swift
@@ -1,3 +1,5 @@
+#if QURAN_SYNC
+
 import Foundation
 import MobileSync
 import UIKit
@@ -71,3 +73,5 @@ public final actor AuthenticationClientMobileSyncImpl: AuthenticationClient {
     private let authService: SyncAuthService
     private let quranDataService: QuranDataService
 }
+
+#endif

--- a/Data/AuthenticationClient/Tests/AuthenticationClientTests.swift
+++ b/Data/AuthenticationClient/Tests/AuthenticationClientTests.swift
@@ -1,3 +1,5 @@
+#if QURAN_SYNC
+
 import AuthenticationClientFake
 import XCTest
 @testable import AuthenticationClient
@@ -24,3 +26,5 @@ final class AuthenticationClientTests: XCTestCase {
         XCTAssertEqual(sut.events, [.restoreState, .readAuthenticationState])
     }
 }
+
+#endif

--- a/Data/AuthenticationClientFake/AuthenticationClientFake.swift
+++ b/Data/AuthenticationClientFake/AuthenticationClientFake.swift
@@ -1,3 +1,5 @@
+#if QURAN_SYNC
+
 import AuthenticationClient
 import Foundation
 import MobileSync
@@ -95,3 +97,5 @@ public final class UnavailableAuthenticationClient: AuthenticationClient {
         throw .clientIsNotAuthenticated(nil)
     }
 }
+
+#endif

--- a/Example/QuranEngineApp/Classes/Container.swift
+++ b/Example/QuranEngineApp/Classes/Container.swift
@@ -7,13 +7,13 @@
 
 import Analytics
 import AppDependencies
-import AuthenticationClient
 import BatchDownloader
 import CoreDataModel
 import CoreDataPersistence
 import Foundation
 import LastPagePersistence
 #if QURAN_SYNC
+import AuthenticationClient
 import MobileSync
 #endif
 import NotePersistence
@@ -41,6 +41,7 @@ class Container: AppDependencies {
     private(set) lazy var pageBookmarkPersistence: PageBookmarkPersistence = CoreDataPageBookmarkPersistence(stack: coreDataStack)
 
     private(set) lazy var notePersistence: NotePersistence = CoreDataNotePersistence(stack: coreDataStack)
+
     #if QURAN_SYNC
     private(set) lazy var quranDataService: QuranDataService = syncAppGraph.quranDataService
 
@@ -49,8 +50,6 @@ class Container: AppDependencies {
         let quranDataService = syncAppGraph.quranDataService
         return AuthenticationClientMobileSyncImpl(authService: authService, quranDataService: quranDataService)
     }()
-    #else
-    let authenticationClient: (any AuthenticationClient)? = nil
     #endif
 
     private(set) lazy var downloadManager: DownloadManager = {

--- a/Features/AppDependencies/AppDependencies.swift
+++ b/Features/AppDependencies/AppDependencies.swift
@@ -40,9 +40,9 @@ public protocol AppDependencies {
     var lastPagePersistence: LastPagePersistence { get }
     var notePersistence: NotePersistence { get }
     var pageBookmarkPersistence: PageBookmarkPersistence { get }
-    var authenticationClient: (any AuthenticationClient)? { get }
 
     #if QURAN_SYNC
+    var authenticationClient: (any AuthenticationClient)? { get }
     var quranDataService: QuranDataService { get }
     #endif
 }

--- a/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
@@ -64,7 +64,6 @@ public struct BookmarksBuilder {
         let viewModel = BookmarksViewModel(
             analytics: container.analytics,
             service: service,
-            authenticationClient: container.authenticationClient,
             navigateTo: { [weak listener] page in
                 listener?.navigateTo(page: page, lastPage: nil, highlightingSearchAyah: nil)
             }

--- a/Features/BookmarksFeature/Sources/BookmarksView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksView.swift
@@ -21,19 +21,30 @@ struct BookmarksView: View {
     }
 
     var body: some View {
+        #if QURAN_SYNC
         BookmarksViewUI(
             editMode: $viewModel.editMode,
             error: $viewModel.error,
             bookmarks: viewModel.bookmarks,
-            shouldShowSyncBanner: viewModel.shouldShowSyncBanner,
             start: { await viewModel.start() },
             selectAction: { viewModel.navigateTo($0) },
             deleteAction: { await viewModel.deleteItem($0) },
+            shouldShowSyncBanner: viewModel.shouldShowSyncBanner,
             dismissSyncBanner: { viewModel.dismissSyncBanner() },
             signInAction: { await viewModel.loginToQuranCom() },
             showCollectionsAction: viewModel.showCollectionsAction,
             showOldPageBookmarksAction: viewModel.showOldPageBookmarksAction
         )
+        #else
+        BookmarksViewUI(
+            editMode: $viewModel.editMode,
+            error: $viewModel.error,
+            bookmarks: viewModel.bookmarks,
+            start: { await viewModel.start() },
+            selectAction: { viewModel.navigateTo($0) },
+            deleteAction: { await viewModel.deleteItem($0) }
+        )
+        #endif
     }
 }
 
@@ -45,15 +56,17 @@ private struct BookmarksViewUI: View {
     @Binding var error: Error?
 
     let bookmarks: [PageBookmark]
-    let shouldShowSyncBanner: Bool
-
     let start: AsyncAction
     let selectAction: ItemAction<PageBookmark>
     let deleteAction: AsyncItemAction<PageBookmark>
+
+    #if QURAN_SYNC
+    let shouldShowSyncBanner: Bool
     let dismissSyncBanner: () -> Void
     let signInAction: @MainActor () async -> Void
     let showCollectionsAction: AsyncAction?
     let showOldPageBookmarksAction: AsyncAction?
+    #endif
 
     var body: some View {
         Group {
@@ -93,6 +106,7 @@ private struct BookmarksViewUI: View {
         )
     }
 
+    #if QURAN_SYNC
     private var syncBanner: some View {
         BookmarksSyncBanner(
             dismiss: dismissSyncBanner,
@@ -100,7 +114,6 @@ private struct BookmarksViewUI: View {
         )
     }
 
-    #if QURAN_SYNC
     private var oldPageBookmarksRow: some View {
         NoorListItem(
             image: .init(.bookmark, color: .secondary),
@@ -164,6 +177,7 @@ private struct BookmarksViewUI: View {
     }
 }
 
+#if QURAN_SYNC
 @MainActor
 private struct BookmarksSyncBanner: View {
     @ScaledMetric private var closeButtonInset = 8.0
@@ -220,6 +234,7 @@ private struct BookmarksSyncBanner: View {
         .clipShape(RoundedRectangle(cornerRadius: containerCornerRadius, style: .continuous))
     }
 }
+#endif
 
 struct BookmarksView_Previews: PreviewProvider {
     struct Preview: View {
@@ -235,16 +250,17 @@ struct BookmarksView_Previews: PreviewProvider {
         @State var error: Error? = nil
 
         var body: some View {
+            #if QURAN_SYNC
             let showCollectionsAction: AsyncAction? = {}
             NavigationView {
                 BookmarksViewUI(
                     editMode: $editMode,
                     error: $error,
                     bookmarks: items,
-                    shouldShowSyncBanner: true,
                     start: {},
                     selectAction: { _ in },
                     deleteAction: { item in items = items.filter { $0 != item } },
+                    shouldShowSyncBanner: true,
                     dismissSyncBanner: {},
                     signInAction: {},
                     showCollectionsAction: showCollectionsAction,
@@ -267,6 +283,34 @@ struct BookmarksView_Previews: PreviewProvider {
                     }
                 }
             }
+            #else
+            NavigationView {
+                BookmarksViewUI(
+                    editMode: $editMode,
+                    error: $error,
+                    bookmarks: items,
+                    start: {},
+                    selectAction: { _ in },
+                    deleteAction: { item in items = items.filter { $0 != item } }
+                )
+                .navigationTitle(lAndroid("menu_bookmarks"))
+                .toolbar {
+                    if items.isEmpty {
+                        Button("Populate") { items = Self.staticItems }
+                    } else {
+                        Button("Empty") { items = [] }
+                    }
+
+                    if error == nil {
+                        Button("Error") { error = URLError(.notConnectedToInternet) }
+                    }
+
+                    Button(editMode == .inactive ? "Edit" : "Done") {
+                        withAnimation { editMode = editMode == .inactive ? .active : .inactive }
+                    }
+                }
+            }
+            #endif
         }
     }
 

--- a/Features/BookmarksFeature/Sources/BookmarksViewController.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksViewController.swift
@@ -41,7 +41,9 @@ final class BookmarksViewController: UIHostingController<BookmarksView> {
 
     private func initialize() {
         title = lAndroid("menu_bookmarks")
+        #if QURAN_SYNC
         viewModel.presenter = self
+        #endif
 
         editController = EditController(
             navigationItem: navigationItem,

--- a/Features/BookmarksFeature/Sources/BookmarksViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksViewModel.swift
@@ -7,7 +7,9 @@
 
 import Analytics
 import AnnotationsService
+#if QURAN_SYNC
 import AuthenticationClient
+#endif
 import Combine
 import FeaturesSupport
 import QuranAnnotations
@@ -21,6 +23,7 @@ import VLogging
 final class BookmarksViewModel: ObservableObject {
     // MARK: Lifecycle
 
+    #if QURAN_SYNC
     init(
         analytics: AnalyticsLibrary,
         service: PageBookmarkService,
@@ -37,12 +40,24 @@ final class BookmarksViewModel: ObservableObject {
         presentOldPageBookmarksAction = showOldPageBookmarksAction
         isSyncBannerDismissed = preferences.isSyncBannerDismissed
     }
+    #else
+    init(
+        analytics: AnalyticsLibrary,
+        service: PageBookmarkService,
+        navigateTo: @escaping (Page) -> Void
+    ) {
+        self.analytics = analytics
+        self.service = service
+        self.navigateTo = navigateTo
+    }
+    #endif
 
     // MARK: Internal
 
     @Published var editMode: EditMode = .inactive
     @Published var error: Error? = nil
     @Published var bookmarks: [PageBookmark] = []
+    #if QURAN_SYNC
     @Published var isAuthenticated: Bool = false
     @Published var isSyncBannerDismissed: Bool
 
@@ -69,13 +84,16 @@ final class BookmarksViewModel: ObservableObject {
             await self?.showOldPageBookmarks()
         }
     }
+    #endif
 
     func start() async {
+        #if QURAN_SYNC
         if let authenticationClient {
             isAuthenticated = await authenticationClient.safelyRestoreState() == .authenticated
         } else {
             isAuthenticated = false
         }
+        #endif
 
         let bookmarksSequence = readingPreferences.$reading
             .prepend(readingPreferences.reading)
@@ -116,11 +134,7 @@ final class BookmarksViewModel: ObservableObject {
         }
     }
 
-    func dismissSyncBanner() {
-        isSyncBannerDismissed = true
-        preferences.isSyncBannerDismissed = true
-    }
-
+    #if QURAN_SYNC
     func loginToQuranCom() async {
         guard let presenter else {
             return
@@ -136,6 +150,11 @@ final class BookmarksViewModel: ObservableObject {
         }
     }
 
+    func dismissSyncBanner() {
+        isSyncBannerDismissed = true
+        preferences.isSyncBannerDismissed = true
+    }
+
     func showCollections() async {
         guard let presenter else {
             return
@@ -149,16 +168,18 @@ final class BookmarksViewModel: ObservableObject {
         }
         await presentOldPageBookmarksAction?(presenter)
     }
+    #endif
 
     // MARK: Private
 
     private let navigateTo: (Page) -> Void
     private let analytics: AnalyticsLibrary
     private let service: PageBookmarkService
-    private let authenticationClient: (any AuthenticationClient)?
-    private let presentCollectionsAction: (@MainActor (UIViewController) async -> Void)?
-    private let presentOldPageBookmarksAction: (@MainActor (UIViewController) async -> Void)?
     private let readingPreferences = ReadingPreferences.shared
+    #if QURAN_SYNC
+    private var authenticationClient: (any AuthenticationClient)?
+    private var presentCollectionsAction: (@MainActor (UIViewController) async -> Void)?
+    private var presentOldPageBookmarksAction: (@MainActor (UIViewController) async -> Void)?
     private let preferences = BookmarksPreferences.shared
 
     private func requireAuthenticationClient() throws -> any AuthenticationClient {
@@ -167,4 +188,5 @@ final class BookmarksViewModel: ObservableObject {
         }
         return authenticationClient
     }
+    #endif
 }

--- a/Features/BookmarksFeature/Tests/BookmarksViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarksViewModelTests.swift
@@ -1,11 +1,17 @@
 import Analytics
 import AnnotationsService
+#if QURAN_SYNC
 import AuthenticationClient
 import AuthenticationClientFake
+#endif
 import Combine
 import Foundation
 import PageBookmarkPersistence
+import QuranAnnotations
+import QuranKit
+#if QURAN_SYNC
 import UIKit
+#endif
 import XCTest
 @testable import BookmarksFeature
 
@@ -13,6 +19,7 @@ import XCTest
 final class BookmarksViewModelTests: XCTestCase {
     // MARK: Internal
 
+    #if QURAN_SYNC
     override func setUp() {
         super.setUp()
         BookmarksPreferences.shared.isSyncBannerDismissed = false
@@ -22,11 +29,24 @@ final class BookmarksViewModelTests: XCTestCase {
         BookmarksPreferences.shared.isSyncBannerDismissed = false
         super.tearDown()
     }
+    #endif
 
+    func test_deleteItem_removesBookmarkPage() async {
+        let persistence = PageBookmarkPersistenceSpy()
+        let sut = makeSUT(persistence: persistence)
+        let bookmark = PageBookmark(page: Quran.hafsMadani1405.pages[0], creationDate: Date())
+
+        await sut.deleteItem(bookmark)
+
+        XCTAssertEqual(persistence.removedPages, [bookmark.page.pageNumber])
+        XCTAssertNil(sut.error)
+    }
+
+    #if QURAN_SYNC
     func test_start_setsAuthenticatedState_whenRestoreSucceeds() async {
         let client = AuthenticationClientFake()
         client.restoreStateResult = .success(.authenticated)
-        let sut = makeSUT(authenticationClient: client)
+        let sut = makeSyncSUT(authenticationClient: client)
 
         let task = Task { await sut.start() }
         await waitUntil { sut.isAuthenticated }
@@ -39,7 +59,7 @@ final class BookmarksViewModelTests: XCTestCase {
         let client = AuthenticationClientFake()
         client.restoreStateResult = .failure(.clientIsNotAuthenticated(NSError(domain: "test", code: 1)))
         client.authenticationStateValue = .authenticated
-        let sut = makeSUT(authenticationClient: client)
+        let sut = makeSyncSUT(authenticationClient: client)
 
         let task = Task { await sut.start() }
         await waitUntil { sut.isAuthenticated }
@@ -49,7 +69,7 @@ final class BookmarksViewModelTests: XCTestCase {
 
     func test_loginToQuranCom_setsAuthenticated_whenLoginSucceeds() async {
         let client = AuthenticationClientFake()
-        let sut = makeSUT(authenticationClient: client)
+        let sut = makeSyncSUT(authenticationClient: client)
         let presenter = UIViewController()
         sut.presenter = presenter
 
@@ -61,7 +81,7 @@ final class BookmarksViewModelTests: XCTestCase {
     }
 
     func test_loginToQuranCom_setsError_whenClientIsMissing() async {
-        let sut = makeSUT(authenticationClient: nil)
+        let sut = makeSyncSUT(authenticationClient: nil)
         let presenter = UIViewController()
         sut.presenter = presenter
 
@@ -71,10 +91,30 @@ final class BookmarksViewModelTests: XCTestCase {
             return XCTFail("Expected clientIsNotAuthenticated, got \(String(describing: sut.error))")
         }
     }
+    #endif
 
     // MARK: Private
 
-    private func makeSUT(authenticationClient: (any AuthenticationClient)?) -> BookmarksViewModel {
+    private func makeSUT(persistence: PageBookmarkPersistenceSpy = PageBookmarkPersistenceSpy()) -> BookmarksViewModel {
+        let service = PageBookmarkService(persistence: persistence)
+        #if QURAN_SYNC
+        return BookmarksViewModel(
+            analytics: AnalyticsSpy(),
+            service: service,
+            authenticationClient: UnavailableAuthenticationClient(),
+            navigateTo: { _ in }
+        )
+        #else
+        return BookmarksViewModel(
+            analytics: AnalyticsSpy(),
+            service: service,
+            navigateTo: { _ in }
+        )
+        #endif
+    }
+
+    #if QURAN_SYNC
+    private func makeSyncSUT(authenticationClient: (any AuthenticationClient)?) -> BookmarksViewModel {
         let service = PageBookmarkService(persistence: PageBookmarkPersistenceSpy())
         return BookmarksViewModel(
             analytics: AnalyticsSpy(),
@@ -98,18 +138,24 @@ final class BookmarksViewModelTests: XCTestCase {
         }
         XCTFail("Condition was not met in time", file: file, line: line)
     }
+    #endif
 }
 
 private struct AnalyticsSpy: AnalyticsLibrary {
     func logEvent(_: String, value _: String) {}
 }
 
-private struct PageBookmarkPersistenceSpy: PageBookmarkPersistence {
+private final class PageBookmarkPersistenceSpy: PageBookmarkPersistence {
+    var removedPages: [Int] = []
+
     func pageBookmarks() -> AnyPublisher<[PageBookmarkPersistenceModel], Never> {
         Just([]).eraseToAnyPublisher()
     }
 
     func insertPageBookmark(_: Int) async throws {}
-    func removePageBookmark(_: Int) async throws {}
+    func removePageBookmark(_ page: Int) async throws {
+        removedPages.append(page)
+    }
+
     func removeAllPageBookmarks() async throws {}
 }

--- a/Features/SettingsFeature/Sources/SettingsBuilder.swift
+++ b/Features/SettingsFeature/Sources/SettingsBuilder.swift
@@ -26,6 +26,7 @@ public struct SettingsBuilder {
     // MARK: Public
 
     public func build(navigationController: UINavigationController) -> UIViewController {
+        #if QURAN_SYNC
         let viewModel = SettingsRootViewModel(
             analytics: container.analytics,
             reviewService: ReviewService(analytics: container.analytics),
@@ -37,6 +38,17 @@ public struct SettingsBuilder {
             quranProfileURL: container.quranProfileURL,
             navigationController: navigationController
         )
+        #else
+        let viewModel = SettingsRootViewModel(
+            analytics: container.analytics,
+            reviewService: ReviewService(analytics: container.analytics),
+            audioDownloadsBuilder: AudioDownloadsBuilder(container: container),
+            translationsListBuilder: TranslationsListBuilder(container: container),
+            readingSelectorBuilder: ReadingSelectorBuilder(container: container),
+            diagnosticsBuilder: DiagnosticsBuilder(container: container),
+            navigationController: navigationController
+        )
+        #endif
         let view = SettingsRootView(viewModel: viewModel)
         let viewController = UIHostingController(rootView: view)
         viewController.title = lAndroid("menu_settings")

--- a/Features/SettingsFeature/Sources/SettingsRootView.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootView.swift
@@ -15,14 +15,12 @@ struct SettingsRootView: View {
     @StateObject var viewModel: SettingsRootViewModel
 
     var body: some View {
+        #if QURAN_SYNC
         SettingsRootViewUI(
             appearanceMode: $viewModel.appearanceMode,
             streamingEnabled: $viewModel.streamingEnabled,
             error: $viewModel.error,
             audioEnd: viewModel.audioEnd.name,
-            isAuthenticated: viewModel.isAuthenticated,
-            loggedInUserEmail: viewModel.currentUserEmail,
-            openQuranComProfile: { viewModel.openQuranComProfile() },
             navigateToAudioEndSelector: { viewModel.navigateToAudioEndSelector() },
             navigateToAudioManager: { viewModel.navigateToAudioManager() },
             navigateToTranslationsList: { viewModel.navigateToTranslationsList() },
@@ -32,10 +30,30 @@ struct SettingsRootView: View {
             writeReview: { viewModel.writeReview() },
             contactUs: { viewModel.contactUs() },
             navigateToDiagnotics: { viewModel.navigateToDiagnotics() },
+            isAuthenticated: viewModel.isAuthenticated,
+            loggedInUserEmail: viewModel.currentUserEmail,
+            openQuranComProfile: { viewModel.openQuranComProfile() },
             refreshAuthenticationState: { await viewModel.refreshAuthenticationState() },
             loginAction: { await viewModel.loginToQuranCom() },
             logoutAction: { await viewModel.logoutFromQuranCom() }
         )
+        #else
+        SettingsRootViewUI(
+            appearanceMode: $viewModel.appearanceMode,
+            streamingEnabled: $viewModel.streamingEnabled,
+            error: $viewModel.error,
+            audioEnd: viewModel.audioEnd.name,
+            navigateToAudioEndSelector: { viewModel.navigateToAudioEndSelector() },
+            navigateToAudioManager: { viewModel.navigateToAudioManager() },
+            navigateToTranslationsList: { viewModel.navigateToTranslationsList() },
+            navigateToReadingSelector: { viewModel.navigateToReadingSelectors() },
+            donate: { viewModel.donate() },
+            shareApp: { viewModel.shareApp() },
+            writeReview: { viewModel.writeReview() },
+            contactUs: { viewModel.contactUs() },
+            navigateToDiagnotics: { viewModel.navigateToDiagnotics() }
+        )
+        #endif
     }
 }
 
@@ -47,9 +65,6 @@ private struct SettingsRootViewUI: View {
     @Binding var error: Error?
 
     let audioEnd: String
-    let isAuthenticated: Bool
-    let loggedInUserEmail: String?
-    let openQuranComProfile: AsyncAction
     let navigateToAudioEndSelector: AsyncAction
     let navigateToAudioManager: AsyncAction
     let navigateToTranslationsList: AsyncAction
@@ -59,9 +74,15 @@ private struct SettingsRootViewUI: View {
     let writeReview: AsyncAction
     let contactUs: AsyncAction
     let navigateToDiagnotics: AsyncAction
+
+    #if QURAN_SYNC
+    let isAuthenticated: Bool
+    let loggedInUserEmail: String?
+    let openQuranComProfile: AsyncAction
     let refreshAuthenticationState: AsyncAction
     let loginAction: AsyncAction
     let logoutAction: AsyncAction
+    #endif
 
     var body: some View {
         NoorList {
@@ -169,12 +190,15 @@ private struct SettingsRootViewUI: View {
                 )
             }
         }
+        #if QURAN_SYNC
         .task { await refreshAuthenticationState() }
+        #endif
         .errorAlert(error: $error)
     }
 
     // MARK: Private
 
+    #if QURAN_SYNC
     private var unauthenticatedQuranComSection: some View {
         Group {
             NoorListItem(
@@ -226,6 +250,7 @@ private struct SettingsRootViewUI: View {
         let range = text.startIndex ..< text.endIndex
         return "\(text, highlighting: [HighlightingRange(range, foregroundColor: foregroundColor, fontWeight: fontWeight)])"
     }
+    #endif
 }
 
 struct SettingsRootView_Previews: PreviewProvider {
@@ -234,14 +259,12 @@ struct SettingsRootView_Previews: PreviewProvider {
         @State var streamingEnabled = false
 
         var body: some View {
+            #if QURAN_SYNC
             SettingsRootViewUI(
                 appearanceMode: $appearanceMode,
                 streamingEnabled: $streamingEnabled,
                 error: .constant(nil),
                 audioEnd: "Surah",
-                isAuthenticated: false,
-                loggedInUserEmail: nil,
-                openQuranComProfile: {},
                 navigateToAudioEndSelector: {},
                 navigateToAudioManager: {},
                 navigateToTranslationsList: {},
@@ -251,10 +274,30 @@ struct SettingsRootView_Previews: PreviewProvider {
                 writeReview: {},
                 contactUs: {},
                 navigateToDiagnotics: {},
+                isAuthenticated: false,
+                loggedInUserEmail: nil,
+                openQuranComProfile: {},
                 refreshAuthenticationState: {},
                 loginAction: {},
                 logoutAction: {}
             )
+            #else
+            SettingsRootViewUI(
+                appearanceMode: $appearanceMode,
+                streamingEnabled: $streamingEnabled,
+                error: .constant(nil),
+                audioEnd: "Surah",
+                navigateToAudioEndSelector: {},
+                navigateToAudioManager: {},
+                navigateToTranslationsList: {},
+                navigateToReadingSelector: {},
+                donate: {},
+                shareApp: {},
+                writeReview: {},
+                contactUs: {},
+                navigateToDiagnotics: {}
+            )
+            #endif
         }
     }
 

--- a/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
@@ -7,10 +7,12 @@
 
 import Analytics
 import AudioDownloadsFeature
-import AuthenticationClient
 import Combine
 import Localization
+#if QURAN_SYNC
+import AuthenticationClient
 import MobileSync
+#endif
 import NoorUI
 import QuranAudio
 import QuranAudioKit
@@ -26,6 +28,7 @@ import VLogging
 final class SettingsRootViewModel: ObservableObject {
     // MARK: Lifecycle
 
+    #if QURAN_SYNC
     init(
         analytics: AnalyticsLibrary,
         reviewService: ReviewService,
@@ -54,6 +57,32 @@ final class SettingsRootViewModel: ObservableObject {
         audioPreferences.$audioEnd.assign(to: &$audioEnd)
         audioPreferences.$streamingEnabled.assign(to: &$streamingEnabled)
     }
+    #else
+    init(
+        analytics: AnalyticsLibrary,
+        reviewService: ReviewService,
+        audioDownloadsBuilder: AudioDownloadsBuilder,
+        translationsListBuilder: TranslationsListBuilder,
+        readingSelectorBuilder: ReadingSelectorBuilder,
+        diagnosticsBuilder: DiagnosticsBuilder,
+        navigationController: UINavigationController
+    ) {
+        appearanceMode = themeService.appearanceMode
+        audioEnd = audioPreferences.audioEnd
+        streamingEnabled = audioPreferences.streamingEnabled
+        self.analytics = analytics
+        self.reviewService = reviewService
+        self.audioDownloadsBuilder = audioDownloadsBuilder
+        self.translationsListBuilder = translationsListBuilder
+        self.readingSelectorBuilder = readingSelectorBuilder
+        self.diagnosticsBuilder = diagnosticsBuilder
+        self.navigationController = navigationController
+
+        themeService.appearanceModePublisher.assign(to: &$appearanceMode)
+        audioPreferences.$audioEnd.assign(to: &$audioEnd)
+        audioPreferences.$streamingEnabled.assign(to: &$streamingEnabled)
+    }
+    #endif
 
     // MARK: Internal
 
@@ -72,18 +101,16 @@ final class SettingsRootViewModel: ObservableObject {
 
     @Published var audioEnd: AudioEnd
     @Published var error: Error? = nil
+    #if QURAN_SYNC
     @Published var isAuthenticated: Bool = false
     @Published var loggedInUser: UserInfo? = nil
+    #endif
 
     @Published var streamingEnabled: Bool {
         didSet {
             guard streamingEnabled != audioPreferences.streamingEnabled else { return }
             audioPreferences.streamingEnabled = streamingEnabled
         }
-    }
-
-    var currentUserEmail: String? {
-        loggedInUser?.email
     }
 
     @Published var appearanceMode: AppearanceMode {
@@ -152,11 +179,17 @@ final class SettingsRootViewModel: ObservableObject {
         navigationController?.present(viewController, animated: true)
     }
 
+    #if QURAN_SYNC
+    var currentUserEmail: String? {
+        loggedInUser?.email
+    }
+
     func openQuranComProfile() {
         logger.info("Settings: Open Quran.com profile.")
         let viewController = SFSafariViewController(url: quranProfileURL)
         navigationController?.present(viewController, animated: true)
     }
+    #endif
 
     func navigateToDiagnotics() {
         logger.info("Settings: navigateToDiagnotics")
@@ -164,6 +197,7 @@ final class SettingsRootViewModel: ObservableObject {
         navigationController?.pushViewController(viewController, animated: true)
     }
 
+    #if QURAN_SYNC
     func refreshAuthenticationState() async {
         guard let authenticationClient else {
             isAuthenticated = false
@@ -202,11 +236,13 @@ final class SettingsRootViewModel: ObservableObject {
             self.error = error
         }
     }
+    #endif
 
     // MARK: Private
 
-    private let authenticationClient: (any AuthenticationClient)?
+    #if QURAN_SYNC
     private let quranProfileURL: URL
+    private var authenticationClient: (any AuthenticationClient)?
 
     private func requireAuthenticationClient() throws -> any AuthenticationClient {
         guard let authenticationClient else {
@@ -214,6 +250,7 @@ final class SettingsRootViewModel: ObservableObject {
         }
         return authenticationClient
     }
+    #endif
 
     private func showSingleChoiceSelector<T: Hashable>(
         title: String,

--- a/Features/SettingsFeature/Tests/SettingsRootViewModelTests.swift
+++ b/Features/SettingsFeature/Tests/SettingsRootViewModelTests.swift
@@ -1,3 +1,5 @@
+#if QURAN_SYNC
+
 import Analytics
 import AppDependencies
 import AudioDownloadsFeature
@@ -168,3 +170,5 @@ private func makeUser(email: String?) -> UserInfo {
         photoUrl: nil
     )
 }
+
+#endif


### PR DESCRIPTION
## Summary
- Keep AuthenticationClient and MobileSync implementations behind `QURAN_SYNC`.
- Gate sync-specific Bookmarks and Settings props/functions while preserving shared no-sync behavior.
- Keep Bookmarks tests running in both modes, with only sync-specific tests conditional.
- Gate Example app sync wiring so both example build modes compile.

## Validation
- `make build-no-sync`
- `make build-sync`
- `make test-no-sync`
- `make test-sync`
- `make build-example-no-sync`
- `make build-example-sync`
- `make format-lint`

## Notes
Stacked on #861 (`afifi/quran-sync-build-flags`).