### PR TITLE
Simplify sync-aware Make targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,17 +2,13 @@
 
 ## Make commands
 
-The Makefile exposes a few helpful commands:
+The Makefile exposes explicit targets for each sync mode:
 
-1. Use `make build` to compile `QuranEngine-Package` with `QURAN_SYNC` disabled (or override with `make build TARGET=NoorUI`).
-2. Use `make test` for package tests with `QURAN_SYNC` disabled, also honoring `TARGET` to point at another scheme/target.
-3. Use `make build-example` to build the Example app with `QURAN_SYNC` disabled.
-4. Run `make format-lint` for SwiftFormat checks.
+- no sync: `make build-no-sync`, `make test-no-sync`, `make build-example-no-sync`, `make run-example-no-sync`
+- sync enabled: `make build-sync`, `make test-sync`, `make build-example-sync`, `make run-example-sync`
+- SwiftFormat: `make format-lint`
 
-Ambient `QURAN_SYNC` may be set or unset through `launchctl`, so use explicit targets when sync state matters:
-
-- no sync: `make build-no-sync`, `make test-no-sync`, `make build-example-no-sync`
-- sync enabled: `make build-sync`, `make test-sync`, `make build-example-sync`
+Package build and test targets honor `TARGET` to select another scheme or target, such as `make build-no-sync TARGET=NoorUI`. Ambient `QURAN_SYNC` may be set or unset through `launchctl`, so always use an explicit sync-mode target.
 
 Keeping these commands green locally should keep the CI workflow green as well.
 

--- a/Documentation/MobileSyncLocalDevelopment.md
+++ b/Documentation/MobileSyncLocalDevelopment.md
@@ -31,9 +31,11 @@ Use the Makefile targets for local verification:
 ```bash
 make build-example-no-sync
 make build-example-sync
+make run-example-no-sync
+make run-example-sync
 ```
 
-These targets use separate DerivedData paths under `.build/DerivedData/no-sync` and `.build/DerivedData/sync`, so switching sync modes does not reuse stale build products and each mode still gets incremental builds. No package-cache reset is needed.
+These targets use separate DerivedData paths under `.build/DerivedData/no-sync` and `.build/DerivedData/sync`, so switching sync modes does not reuse stale build products and each mode still gets incremental builds. The run targets build, boot their configured simulator, install, and launch the Example app. No package-cache reset is needed.
 
 The sync target sets `QURAN_SYNC` for `Package.swift` and passes `-D QURAN_SYNC` only to the Example app target:
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ EXAMPLE_PROJECT ?= Example/QuranEngineApp.xcodeproj
 EXAMPLE_SCHEME ?= QuranEngineApp
 EXAMPLE_SDK ?= iphonesimulator
 EXAMPLE_DESTINATION ?= generic/platform=iOS
+EXAMPLE_BUNDLE_IDENTIFIER ?= com.quran.QuranEngineApp
+EXAMPLE_NO_SYNC_SIMULATOR ?= iPhone 17,26.1
+EXAMPLE_SYNC_SIMULATOR ?= iPhone 17 Pro,26.1
 DERIVED_DATA_DIR ?= .build/DerivedData
 
 SWIFT_FORMAT_REPO=https://github.com/nicklockwood/SwiftFormat
@@ -23,44 +26,59 @@ WITH_QURAN_SYNC=set -o pipefail; env QURAN_SYNC=QURAN_SYNC
 WITHOUT_QURAN_SYNC_DERIVED_DATA=$(DERIVED_DATA_DIR)/no-sync
 WITH_QURAN_SYNC_DERIVED_DATA=$(DERIVED_DATA_DIR)/sync
 WITH_QURAN_SYNC_APP_SWIFT_FLAGS='OTHER_SWIFT_FLAGS=$$(inherited) -D QURAN_SYNC'
+comma := ,
+simulator-os = $(lastword $(subst $(comma), ,$(1)))
+simulator-name = $(subst $(comma)$(call simulator-os,$(1)),,$(1))
+simulator-destination = platform=iOS Simulator,name=$(call simulator-name,$(1)),OS=$(call simulator-os,$(1))
 
-.PHONY: test test-no-sync test-sync test-without-sync test-with-sync build build-no-sync build-sync build-without-sync build-with-sync build-example build-example-no-sync build-example-sync build-example-without-sync build-example-with-sync clone-swiftformat build-swiftformat force-build-swiftformat clean-swiftformat format-lint format-autocorrect install-swiftlint build-for-analyzer swiftlint-analyzer
+define run-example-app
+	@simulator="$$(xcrun simctl list devices "iOS $(call simulator-os,$(1))" | grep -F "    $(call simulator-name,$(1)) (" | sed -nE 's/.*\(([[:xdigit:]-]{36})\).*/\1/p' | head -n 1)"; \
+	if [ -z "$$simulator" ]; then \
+		echo "$(call simulator-name,$(1)) with iOS $(call simulator-os,$(1)) is not available." >&2; \
+		exit 1; \
+	fi; \
+	if ! xcrun simctl list devices booted | grep -Fq "$$simulator"; then \
+		xcrun simctl boot "$$simulator"; \
+	fi; \
+	open -a Simulator --args -CurrentDeviceUDID "$$simulator"; \
+	xcrun simctl bootstatus "$$simulator" -b; \
+	xcrun simctl install "$$simulator" "$(2)/Build/Products/Debug-iphonesimulator/$(EXAMPLE_SCHEME).app"; \
+	xcrun simctl launch "$$simulator" "$(EXAMPLE_BUNDLE_IDENTIFIER)"
+endef
 
-test: test-no-sync
+.PHONY: test-no-sync test-sync
+.PHONY: build-no-sync build-sync
+.PHONY: build-example-no-sync build-example-sync
+.PHONY: run-example-no-sync run-example-sync
+.PHONY: clone-swiftformat build-swiftformat force-build-swiftformat clean-swiftformat format-lint format-autocorrect
+.PHONY: install-swiftlint build-for-analyzer swiftlint-analyzer
 
-test-no-sync: test-without-sync
-
-test-sync: test-with-sync
-
-test-without-sync:
+test-no-sync:
 	$(WITHOUT_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITHOUT_QURAN_SYNC_DERIVED_DATA)" build test -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
 
-test-with-sync:
+test-sync:
 	$(WITH_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_QURAN_SYNC_DERIVED_DATA)" build test -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
 
-build: build-no-sync
-
-build-no-sync: build-without-sync
-
-build-sync: build-with-sync
-
-build-without-sync:
+build-no-sync:
 	$(WITHOUT_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITHOUT_QURAN_SYNC_DERIVED_DATA)" build -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
 
-build-with-sync:
+build-sync:
 	$(WITH_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_QURAN_SYNC_DERIVED_DATA)" build -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
 
-build-example: build-example-no-sync
-
-build-example-no-sync: build-example-without-sync
-
-build-example-sync: build-example-with-sync
-
-build-example-without-sync:
+build-example-no-sync:
 	$(WITHOUT_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITHOUT_QURAN_SYNC_DERIVED_DATA)" build -project $(EXAMPLE_PROJECT) -scheme $(EXAMPLE_SCHEME) -sdk "$(EXAMPLE_SDK)" -destination "$(EXAMPLE_DESTINATION)" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO 2>&1 | xcbeautify --renderer github-actions
 
-build-example-with-sync:
+build-example-sync:
 	$(WITH_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_QURAN_SYNC_DERIVED_DATA)" build -project $(EXAMPLE_PROJECT) -scheme $(EXAMPLE_SCHEME) -sdk "$(EXAMPLE_SDK)" -destination "$(EXAMPLE_DESTINATION)" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO $(WITH_QURAN_SYNC_APP_SWIFT_FLAGS) 2>&1 | xcbeautify --renderer github-actions
+
+run-example-no-sync: EXAMPLE_DESTINATION = $(call simulator-destination,$(EXAMPLE_NO_SYNC_SIMULATOR))
+run-example-sync: EXAMPLE_DESTINATION = $(call simulator-destination,$(EXAMPLE_SYNC_SIMULATOR))
+
+run-example-no-sync: build-example-no-sync
+	$(call run-example-app,$(EXAMPLE_NO_SYNC_SIMULATOR),$(WITHOUT_QURAN_SYNC_DERIVED_DATA))
+
+run-example-sync: build-example-sync
+	$(call run-example-app,$(EXAMPLE_SYNC_SIMULATOR),$(WITH_QURAN_SYNC_DERIVED_DATA))
 
 clone-swiftformat:
 	@mkdir -p $(BUILD_TOOLS_DIR)


### PR DESCRIPTION
## Summary

- add dedicated no-sync and sync commands for building, testing, and running the Example app
- launch no-sync and sync builds on separate configured iOS 26.1 simulators
- remove ambiguous plain and `with`/`without` Make target aliases
- document the canonical command set and the new run commands

## Why

The run commands previously assumed a simulator was already booted, and the Makefile exposed several aliases for the same operation. This made local sync-mode verification less predictable and the command surface harder to understand.

## Impact

Developers now choose an explicit sync mode for every build or test. The run targets resolve their configured simulator by model and OS, boot it when needed, install the matching build, and launch the Example app.

## Validation

- dry-ran all eight canonical targets
- confirmed removed aliases no longer resolve
- ran `make run-example-no-sync`
- ran `make run-example-sync`
- ran `make format-lint`