### PR TITLE
refactor: rename Note.note to text

### DIFF
--- a/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
@@ -104,7 +104,7 @@ public struct MobileSyncNoteService {
 
         return QuranAnnotations.Note(
             id: note.localId,
-            note: note.body,
+            text: note.body,
             startAyah: start,
             endAyah: end,
             modifiedDate: note.lastUpdated

--- a/Domain/AnnotationsService/Sources/NoteService.swift
+++ b/Domain/AnnotationsService/Sources/NoteService.swift
@@ -91,7 +91,7 @@ private extension Note {
         self.init(
             verses: Set(note.verses.map { AyahNumber(quran: quran, $0) }),
             modifiedDate: note.modifiedDate,
-            note: note.note,
+            text: note.note,
             color: HighlightColor(rawValue: note.color) ?? .red
         )
     }

--- a/Domain/AnnotationsService/Tests/MobileSyncNoteServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncNoteServiceTests.swift
@@ -21,7 +21,7 @@ final class MobileSyncNoteServiceTests: XCTestCase {
 
         XCTAssertEqual(notes.count, 1)
         XCTAssertEqual(notes[0].id, "note-1")
-        XCTAssertEqual(notes[0].note, "Remember this")
+        XCTAssertEqual(notes[0].text, "Remember this")
         XCTAssertEqual(notes[0].startAyah, AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1))
         XCTAssertEqual(notes[0].endAyah, AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 2))
     }

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -228,7 +228,7 @@ final class AyahMenuViewModel {
     #if !QURAN_SYNC
     private func containsText(_ notes: [QuranAnnotations.Note]) -> Bool {
         notes.contains { note in
-            !(note.note ?? "").isEmpty
+            !(note.text ?? "").isEmpty
         }
     }
     #endif

--- a/Features/NoteEditorFeature/Sources/NoteEditorViewModel.swift
+++ b/Features/NoteEditorFeature/Sources/NoteEditorViewModel.swift
@@ -236,10 +236,10 @@ final class NoteEditorViewModel {
         case .create:
             return ""
         case .edit(let note):
-            return note.note
+            return note.text
         }
         #else
-        return note.note ?? ""
+        return note.text ?? ""
         #endif
     }
 

--- a/Features/NoteEditorFeature/Tests/NoteEditorViewModelTests.swift
+++ b/Features/NoteEditorFeature/Tests/NoteEditorViewModelTests.swift
@@ -234,7 +234,7 @@ final class NoteEditorViewModelTests: XCTestCase {
         let note = Note(
             verses: [ayah(3), ayah(1)],
             modifiedDate: Date(timeIntervalSince1970: 1),
-            note: "Stored note",
+            text: "Stored note",
             color: .red
         )
 
@@ -279,7 +279,7 @@ final class NoteEditorViewModelTests: XCTestCase {
     ) -> Note {
         Note(
             id: localId,
-            note: body,
+            text: body,
             startAyah: startAyah ?? ayah(1),
             endAyah: endAyah ?? ayah(2),
             modifiedDate: Date(timeIntervalSince1970: 1)
@@ -296,7 +296,7 @@ final class NoteEditorViewModelTests: XCTestCase {
         let note = Note(
             verses: [ayah(2), ayah(1)],
             modifiedDate: Date(timeIntervalSince1970: 1),
-            note: noteBody,
+            text: noteBody,
             color: color
         )
         let viewModel = NoteEditorViewModel(noteService: noteService, note: note)

--- a/Features/NotesFeature/Sources/NoteItem.swift
+++ b/Features/NotesFeature/Sources/NoteItem.swift
@@ -23,9 +23,9 @@ struct NoteItem: Equatable, Identifiable {
 
     var noteText: String {
         #if QURAN_SYNC
-        note.note
+        note.text
         #else
-        note.note ?? ""
+        note.text ?? ""
         #endif
     }
 }

--- a/Features/NotesFeature/Sources/NotesView.swift
+++ b/Features/NotesFeature/Sources/NotesView.swift
@@ -156,7 +156,7 @@ struct NotesView_Previews: PreviewProvider {
                     note: Note(
                         verses: [quran.suras[2].verses[3]],
                         modifiedDate: Date(),
-                        note: nil,
+                        text: nil,
                         color: .purple
                     ),
                     verseText: ayahText
@@ -165,7 +165,7 @@ struct NotesView_Previews: PreviewProvider {
                     note: Note(
                         verses: Set(quran.suras[2].verses),
                         modifiedDate: Date().addingTimeInterval(-24 * 60),
-                        note: "Remind myself to memorize it",
+                        text: "Remind myself to memorize it",
                         color: .green
                     ),
                     verseText: ayahText

--- a/Features/NotesFeature/Tests/NoteItemTests.swift
+++ b/Features/NotesFeature/Tests/NoteItemTests.swift
@@ -49,7 +49,7 @@ final class NoteItemTests: XCTestCase {
     private func note(id: String, body: String) -> Note {
         Note(
             id: id,
-            note: body,
+            text: body,
             startAyah: ayah,
             endAyah: ayah,
             modifiedDate: Date()
@@ -60,7 +60,7 @@ final class NoteItemTests: XCTestCase {
         Note(
             verses: [ayah],
             modifiedDate: Date(),
-            note: body,
+            text: body,
             color: .red
         )
     }

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -217,7 +217,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     #else
     func deleteNotes(_ notes: [QuranAnnotations.Note], in verses: [AyahNumber]) async {
         let containsText = notes.contains { note in
-            !(note.note ?? "").isEmpty
+            !(note.text ?? "").isEmpty
         }
         if containsText {
             // confirm deletion first if there is text

--- a/Model/QuranAnnotations/Note.swift
+++ b/Model/QuranAnnotations/Note.swift
@@ -12,9 +12,9 @@ public struct Note: Equatable {
     // MARK: Lifecycle
 
     #if QURAN_SYNC
-    public init(id: String, note: String, startAyah: AyahNumber, endAyah: AyahNumber, modifiedDate: Date) {
+    public init(id: String, text: String, startAyah: AyahNumber, endAyah: AyahNumber, modifiedDate: Date) {
         self.id = id
-        self.note = note
+        self.text = text
         if startAyah <= endAyah {
             self.startAyah = startAyah
             self.endAyah = endAyah
@@ -25,13 +25,13 @@ public struct Note: Equatable {
         self.modifiedDate = modifiedDate
     }
     #else
-    public init(verses: Set<AyahNumber>, modifiedDate: Date, note: String?, color: HighlightColor) {
+    public init(verses: Set<AyahNumber>, modifiedDate: Date, text: String?, color: HighlightColor) {
         let sortedVerses = verses.sorted()
         startAyah = sortedVerses[0]
         endAyah = sortedVerses[sortedVerses.count - 1]
         self.modifiedDate = modifiedDate
         self.color = color
-        self.note = note
+        self.text = text
     }
     #endif
 
@@ -47,10 +47,10 @@ public struct Note: Equatable {
 
     #if QURAN_SYNC
     public let id: String
-    public let note: String
+    public let text: String
     #else
     public let color: HighlightColor
-    public let note: String?
+    public let text: String?
     #endif
 
     public var verses: [AyahNumber] {


### PR DESCRIPTION
## Summary

- rename `Note.note` to `Note.text`
- rename the matching initializer argument to `text`
- update sync and non-sync mappings, consumers, previews, and tests

## Why

`text` describes the note body without the redundant `note.note` API.

## Impact

Source-breaking model API rename for callers of `QuranAnnotations.Note`; behavior and persisted data remain unchanged.

## Validation

- `make format-lint`
- `make test-no-sync`
- `make test-sync`

Stacked on #866.