### PR TITLE
Test MobileSync persistence against the real database

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,9 @@ Keeping these commands green locally should keep the CI workflow green as well.
 
 - Keep tests in their owning module's `Tests` target. `AllTargetsTests` exists only to link otherwise-untested targets for coverage; do not add behavioral tests there without explicit confirmation.
 - Prefer real objects whenever practical. Use real model types, services, persistence stacks, parsers, mappers, builders, and value objects instead of test doubles.
-- Use fakes only at process or platform boundaries: filesystem, network/session, clock/time, bundle/resources, keychain, OAuth/auth SDK, MobileSync/external SDKs, UIKit navigation/presentation seams.
+- Use fakes only at process or platform boundaries: filesystem, network/session, clock/time, bundle/resources, keychain, OAuth/auth SDK, external SDKs, UIKit navigation/presentation seams.
+- For `QURAN_SYNC` persistence behavior, always use the real MobileSync database through `MobileSyncTestDatabase` from `MobileSyncTestSupport`; never fake `QuranDataService`, `MobileSyncNoteService`, or another sync persistence service.
+- Use `Domain/AnnotationsService/Tests/MobileSyncNoteServiceTests.swift` as the reference pattern: `override func setUp() async throws { try await database.reset() }` (and the same reset in `tearDown`), then exercise the production service and assert database-observable state.
 - Do not add mocks or a mocking framework. Avoid generated mocks.
 - Do not introduce protocols only to make something mockable. Protocols should represent real architectural boundaries already useful in production.
 - If a fake is reused across modules, put it in a dedicated `*Fake` target next to the boundary module, like `SystemDependenciesFake`, `NetworkSupportFake`, or `AuthenticationClientFake`.

--- a/Data/AuthenticationClient/Tests/AuthenticationClientMobileSyncTests.swift
+++ b/Data/AuthenticationClient/Tests/AuthenticationClientMobileSyncTests.swift
@@ -1,0 +1,40 @@
+#if QURAN_SYNC
+import MobileSync
+import MobileSyncTestSupport
+import XCTest
+@testable import AuthenticationClient
+
+final class AuthenticationClientMobileSyncTests: XCTestCase {
+    private let database = MobileSyncTestDatabase.shared
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+    }
+
+    override func tearDown() async throws {
+        try await database.reset()
+        try await super.tearDown()
+    }
+
+    func test_logout_clearsMobileSyncDatabase() async throws {
+        try await database.quranDataService.createNote(
+            body: "Stored note",
+            startSura: 1,
+            startAyah: 1,
+            endSura: 1,
+            endAyah: 1
+        )
+        let client = AuthenticationClientMobileSyncImpl(
+            authService: database.authService,
+            quranDataService: database.quranDataService
+        )
+
+        try await client.logout()
+
+        let notes = database.quranDataService.notesSequence().makeAsyncIterator()
+        let storedNotes = try await notes.next()
+        XCTAssertTrue(storedNotes?.isEmpty == true)
+    }
+}
+#endif

--- a/Data/MobileSyncTestSupport/MobileSyncTestSupport.swift
+++ b/Data/MobileSyncTestSupport/MobileSyncTestSupport.swift
@@ -1,0 +1,31 @@
+#if QURAN_SYNC
+import MobileSync
+
+public final class MobileSyncTestDatabase: @unchecked Sendable {
+    public static let shared = MobileSyncTestDatabase()
+
+    public let appGraph: AppGraph
+
+    public var quranDataService: QuranDataService {
+        appGraph.quranDataService
+    }
+
+    public var authService: SyncAuthService {
+        appGraph.authService
+    }
+
+    public func reset() async throws {
+        try await quranDataService.logout(clearLocalData: true)
+    }
+
+    private init() {
+        AuthFlowFactoryProvider.shared.doInitialize()
+        appGraph = SharedDependencyGraph.shared.doInit(
+            driverFactory: DriverFactory(),
+            storage: AppleMobileSyncStorageFactory.shared.create(),
+            clientId: "",
+            clientSecret: nil
+        )
+    }
+}
+#endif

--- a/Domain/AnnotationsService/Tests/MobileSyncLastPageServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncLastPageServiceTests.swift
@@ -1,0 +1,58 @@
+#if QURAN_SYNC
+import Combine
+import MobileSyncTestSupport
+import QuranKit
+import XCTest
+@testable import AnnotationsService
+
+final class MobileSyncLastPageServiceTests: XCTestCase {
+    private let database = MobileSyncTestDatabase.shared
+    private var service: MobileSyncLastPageService!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+        service = MobileSyncLastPageService(quranDataService: database.quranDataService)
+    }
+
+    override func tearDown() async throws {
+        try await database.reset()
+        service = nil
+        try await super.tearDown()
+    }
+
+    func test_add_persistsReadingSessionAndPublishesLastPage() async throws {
+        let quran = Quran.hafsMadani1405
+        let page = quran.pages[10]
+        let published = expectation(description: "Publishes the persisted last page")
+        let cancellable = service.lastPages(quran: quran).sink { lastPages in
+            if lastPages.first?.page == page {
+                published.fulfill()
+            }
+        }
+
+        let lastPage = try await service.add(page: page)
+
+        XCTAssertEqual(lastPage.page, page)
+        XCTAssertNotNil(lastPage.localId)
+        await fulfillment(of: [published], timeout: 2)
+        cancellable.cancel()
+    }
+
+    func test_update_persistsNewPageOnExistingReadingSession() async throws {
+        let quran = Quran.hafsMadani1405
+        let original = try await service.add(page: quran.pages[10])
+
+        let updated = try await service.update(lastPage: original, toPage: quran.pages[20])
+
+        XCTAssertEqual(updated.localId, original.localId)
+        XCTAssertEqual(updated.page, quran.pages[20])
+        let sessions = database.quranDataService.readingSessionsSequence().makeAsyncIterator()
+        let storedSessions = try await sessions.next()
+        XCTAssertEqual(storedSessions?.count, 1)
+        XCTAssertEqual(storedSessions?.first?.localId, original.localId)
+        XCTAssertEqual(storedSessions?.first?.sura, Int32(quran.pages[20].firstVerse.sura.suraNumber))
+        XCTAssertEqual(storedSessions?.first?.ayah, Int32(quran.pages[20].firstVerse.ayah))
+    }
+}
+#endif

--- a/Domain/AnnotationsService/Tests/MobileSyncNoteServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncNoteServiceTests.swift
@@ -1,59 +1,73 @@
 #if QURAN_SYNC
-import MobileSync
+import MobileSyncTestSupport
 import QuranAnnotations
 import QuranKit
 import XCTest
 @testable import AnnotationsService
 
 final class MobileSyncNoteServiceTests: XCTestCase {
-    func test_notes_mapsContinuousRange() {
-        let notes = MobileSyncNoteService.notes(from: [
-            Note_(
-                body: "Remember this",
-                startSura: 1,
-                startAyah: 1,
-                endSura: 1,
-                endAyah: 2,
-                lastUpdated: .distantPast,
-                localId: "note-1"
-            ),
-        ], quran: .hafsMadani1405)
+    private let database = MobileSyncTestDatabase.shared
+    private var service: MobileSyncNoteService!
 
-        XCTAssertEqual(notes.count, 1)
-        XCTAssertEqual(notes[0].id, "note-1")
-        XCTAssertEqual(notes[0].text, "Remember this")
-        XCTAssertEqual(notes[0].startAyah, AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1))
-        XCTAssertEqual(notes[0].endAyah, AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 2))
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+        service = MobileSyncNoteService(quranDataService: database.quranDataService)
     }
 
-    func test_notes_keepsMultipleNotesForSameAyah() {
-        let notes = MobileSyncNoteService.notes(from: [
-            Self.note(localId: "note-1", body: "First"),
-            Self.note(localId: "note-2", body: "Second"),
-        ], quran: .hafsMadani1405)
-
-        XCTAssertEqual(Set(notes.map { note in note.id }), ["note-1", "note-2"])
+    override func tearDown() async throws {
+        try await database.reset()
+        service = nil
+        try await super.tearDown()
     }
 
-    func test_notes_sortsByLatestUpdatedDate() {
-        let notes = MobileSyncNoteService.notes(from: [
-            Self.note(localId: "older", body: "Older", lastUpdated: Date(timeIntervalSince1970: 1)),
-            Self.note(localId: "newer", body: "Newer", lastUpdated: Date(timeIntervalSince1970: 2)),
-        ], quran: .hafsMadani1405)
+    func test_createNote_persistsBodyAndRange() async throws {
+        try await service.createNote(body: "Remember this", startAyah: ayah(1), endAyah: ayah(2))
 
-        XCTAssertEqual(notes.map(\.id), ["newer", "older"])
+        let note = try await storedNote()
+        XCTAssertEqual(note.text, "Remember this")
+        XCTAssertEqual(note.startAyah, ayah(1))
+        XCTAssertEqual(note.endAyah, ayah(2))
     }
 
-    private static func note(localId: String, body: String, lastUpdated: Date = .distantPast) -> Note_ {
-        Note_(
-            body: body,
-            startSura: 1,
-            startAyah: 1,
-            endSura: 1,
-            endAyah: 1,
-            lastUpdated: lastUpdated,
-            localId: localId
-        )
+    func test_updateNote_persistsBodyAndRange() async throws {
+        try await service.createNote(body: "Original", startAyah: ayah(1), endAyah: ayah(1))
+        let original = try await storedNote()
+
+        try await service.updateNote(original, body: "Updated", startAyah: ayah(2), endAyah: ayah(3))
+
+        let updated = try await storedNote()
+        XCTAssertEqual(updated.id, original.id)
+        XCTAssertEqual(updated.text, "Updated")
+        XCTAssertEqual(updated.startAyah, ayah(2))
+        XCTAssertEqual(updated.endAyah, ayah(3))
+    }
+
+    func test_removeNote_deletesPersistedNote() async throws {
+        try await service.createNote(body: "Delete me", startAyah: ayah(1), endAyah: ayah(1))
+        let note = try await storedNote()
+
+        try await service.removeNote(note)
+
+        let deleted = expectation(description: "The database publishes the deletion")
+        let observation = Task {
+            for try await notes in service.notesSequence(quran: .hafsMadani1405) where notes.isEmpty {
+                deleted.fulfill()
+                return
+            }
+        }
+        await fulfillment(of: [deleted], timeout: 2)
+        observation.cancel()
+    }
+
+    private func storedNote() async throws -> QuranAnnotations.Note {
+        var iterator = service.notesSequence(quran: .hafsMadani1405).makeAsyncIterator()
+        let notes = try await iterator.next()
+        return try XCTUnwrap(notes?.first)
+    }
+
+    private func ayah(_ number: Int) -> AyahNumber {
+        AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: number)!
     }
 }
 #endif

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -1,0 +1,76 @@
+#if QURAN_SYNC
+import MobileSync
+import MobileSyncTestSupport
+import QuranAnnotations
+import QuranKit
+import QuranTextKit
+import UIKit
+import XCTest
+@testable import AyahMenuFeature
+@testable import BookmarksFeature
+
+@MainActor
+final class AyahMenuViewModelTests: XCTestCase {
+    private let database = MobileSyncTestDatabase.shared
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+    }
+
+    override func tearDown() async throws {
+        try await database.reset()
+        try await super.tearDown()
+    }
+
+    func test_updateHighlight_movesAyahBetweenCollectionsInMobileSyncDatabase() async throws {
+        let service = AyahBookmarkCollectionService(quranDataService: database.quranDataService)
+        try await service.createCollection(named: HighlightColor.red.collectionName)
+        try await service.createCollection(named: HighlightColor.blue.collectionName)
+        let collections = try await storedCollections()
+        let mapped = AyahBookmarkCollectionService.collections(from: collections, quran: .hafsMadani1405)
+        let red = try XCTUnwrap(mapped.first { $0.collection.name == HighlightColor.red.collectionName })
+        try await service.addAyahBookmarkToCollection(
+            collectionLocalId: red.collection.localId,
+            ayah: ayah
+        )
+        let populatedCollections = AyahBookmarkCollectionService.collections(
+            from: try await storedCollections(),
+            quran: .hafsMadani1405
+        )
+        let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-quran-database")
+        let sut = AyahMenuViewModel(deps: .init(
+            sourceView: UIView(),
+            pointInView: .zero,
+            verses: [ayah],
+            textRetriever: ShareableVerseTextRetriever(
+                databasesURL: unavailableDatabase,
+                quranFileURL: unavailableDatabase
+            ),
+            highlightVerses: [ayah: .red],
+            highlightCollections: populatedCollections,
+            noteCount: 0,
+            ayahBookmarkCollectionService: service
+        ))
+
+        await sut.updateHighlight(color: .blue)
+
+        let updated = try await storedCollections()
+        let redBookmarks = updated.first { $0.collection.name == HighlightColor.red.collectionName }?.bookmarks
+        let blueBookmarks = updated.first { $0.collection.name == HighlightColor.blue.collectionName }?.bookmarks
+        XCTAssertTrue(redBookmarks?.isEmpty == true)
+        XCTAssertEqual(blueBookmarks?.count, 1)
+        XCTAssertEqual(blueBookmarks?.first?.sura, 1)
+        XCTAssertEqual(blueBookmarks?.first?.ayah, 1)
+    }
+
+    private var ayah: AyahNumber {
+        AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
+    }
+
+    private func storedCollections() async throws -> [CollectionWithAyahBookmarks] {
+        let iterator = database.quranDataService.collectionsWithBookmarksSequence().makeAsyncIterator()
+        return try await iterator.next() ?? []
+    }
+}
+#endif

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionServiceTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionServiceTests.swift
@@ -1,173 +1,133 @@
 #if QURAN_SYNC
 import MobileSync
+import MobileSyncTestSupport
+import QuranAnnotations
 import QuranKit
 import XCTest
 @testable import BookmarksFeature
 
 final class AyahBookmarkCollectionServiceTests: XCTestCase {
-    // MARK: Internal
+    private let database = MobileSyncTestDatabase.shared
+    private var service: AyahBookmarkCollectionService!
 
-    func test_collections_mapsAyahNumbers() {
-        let collections = AyahBookmarkCollectionService.collections(from: [
-            Self.collection(
-                name: "Favorites",
-                bookmarks: [
-                    Self.bookmark(collectionLocalId: "favorites", sura: 1, ayah: 1),
-                ]
-            ),
-        ], quran: .hafsMadani1405)
-
-        XCTAssertEqual(collections.count, 1)
-        XCTAssertEqual(collections[0].collection.name, "Favorites")
-        XCTAssertEqual(collections[0].bookmarks.count, 1)
-        XCTAssertEqual(collections[0].bookmarks[0].ayah, AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1))
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+        service = AyahBookmarkCollectionService(quranDataService: database.quranDataService)
     }
 
-    func test_collections_skipsInvalidAyahs() {
-        let collections = AyahBookmarkCollectionService.collections(from: [
-            Self.collection(
-                name: "Favorites",
-                bookmarks: [
-                    Self.bookmark(collectionLocalId: "favorites", sura: 999, ayah: 1),
-                ]
-            ),
-        ], quran: .hafsMadani1405)
-
-        XCTAssertEqual(collections.count, 1)
-        XCTAssertTrue(collections[0].bookmarks.isEmpty)
+    override func tearDown() async throws {
+        try await database.reset()
+        service = nil
+        try await super.tearDown()
     }
 
-    func test_ayahsToAdd_skipsExistingBookmarks() {
-        let existingAyah = AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
-        let missingAyah = AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 2)!
-        let collection = Self.ayahBookmarkCollection(
-            name: "Favorites",
-            bookmarks: [
-                Self.ayahCollectionBookmark(collectionLocalId: "Favorites", ayah: existingAyah),
-            ]
+    func test_createCollection_persistsCollection() async throws {
+        try await service.createCollection(named: "Favorites")
+
+        let collections = try await storedCollections { collections in
+            collections.contains { $0.collection.name == "Favorites" }
+        }
+        XCTAssertEqual(collections.map(\.collection.name), ["Favorites"])
+    }
+
+    func test_removeCollection_deletesPersistedCollection() async throws {
+        try await service.createCollection(named: "Favorites")
+        let collection = try await storedCollection(named: "Favorites")
+
+        try await service.removeCollection(localId: collection.collection.localId)
+
+        let collections = try await storedCollections { $0.isEmpty }
+        XCTAssertTrue(collections.isEmpty)
+    }
+
+    func test_addAndRemoveAyahBookmark_persistsCollectionMembership() async throws {
+        try await service.createCollection(named: "Favorites")
+        let collection = try await storedCollection(named: "Favorites")
+
+        try await service.addAyahBookmarkToCollection(
+            collectionLocalId: collection.collection.localId,
+            ayah: ayah(1)
         )
 
-        let ayahsToAdd = AyahBookmarkCollectionService.ayahsToAdd(
-            [existingAyah, missingAyah],
-            to: collection
+        let stored = try await storedCollection(named: "Favorites") { $0.bookmarks.count == 1 }
+        XCTAssertEqual(stored.bookmarks.first?.sura, 1)
+        XCTAssertEqual(stored.bookmarks.first?.ayah, 1)
+
+        let bookmark = try XCTUnwrap(
+            AyahBookmarkCollectionService.collections(from: [stored], quran: .hafsMadani1405)
+                .first?.bookmarks.first
+        )
+        try await service.removeBookmarkFromCollection(bookmark)
+
+        let emptied = try await storedCollection(named: "Favorites") { $0.bookmarks.isEmpty }
+        XCTAssertTrue(emptied.bookmarks.isEmpty)
+    }
+
+    func test_addAyahBookmarksIfNeeded_persistsOnlyMissingUniqueAyahs() async throws {
+        try await service.createCollection(named: "Favorites")
+        let stored = try await storedCollection(named: "Favorites")
+        let collection = try XCTUnwrap(
+            AyahBookmarkCollectionService.collections(from: [stored], quran: .hafsMadani1405).first
         )
 
-        XCTAssertEqual(ayahsToAdd, [missingAyah])
+        try await service.addAyahBookmarksIfNeeded([ayah(1), ayah(1), ayah(2)], to: collection)
+
+        let updated = try await storedCollection(named: "Favorites") { $0.bookmarks.count == 2 }
+        XCTAssertEqual(Set(updated.bookmarks.map { "\($0.sura):\($0.ayah)" }), ["1:1", "1:2"])
     }
 
-    func test_ayahsToAdd_deduplicatesInputAyahs() {
-        let firstAyah = AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
-        let secondAyah = AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 2)!
-        let collection = Self.ayahBookmarkCollection(name: "Favorites")
+    func test_collectionsSequence_createsAllMissingHighlightCollectionsInDatabase() async throws {
+        var iterator = service.collectionsSequence().makeAsyncIterator()
+        let expectedNames = Set(HighlightColor.sortedColors.map(\.collectionName))
 
-        let ayahsToAdd = AyahBookmarkCollectionService.ayahsToAdd(
-            [firstAyah, firstAyah, secondAyah, firstAyah],
-            to: collection
-        )
+        let collections = try await nextCollections(from: &iterator) { collections in
+            expectedNames.isSubset(of: Set(collections.map(\.collection.name)))
+        }
 
-        XCTAssertEqual(ayahsToAdd, [firstAyah, secondAyah])
+        XCTAssertTrue(expectedNames.isSubset(of: Set(collections.map(\.collection.name))))
     }
 
-    func test_highlightCollectionCreationPlanner_reservesMultipleMissingCollections() async {
-        let sut = HighlightCollectionCreationPlanner()
-
-        let names = await sut.reserveMissingCollectionNames(from: [
-            Self.ayahBookmarkCollection(name: "yellow"),
-            Self.ayahBookmarkCollection(name: "Favorites"),
-        ])
-
-        XCTAssertEqual(names, ["green", "blue", "red", "purple"])
+    private func storedCollection(
+        named name: String,
+        where predicate: (CollectionWithAyahBookmarks) -> Bool = { _ in true }
+    ) async throws -> CollectionWithAyahBookmarks {
+        let collections = try await storedCollections { collections in
+            collections.contains { $0.collection.name == name && predicate($0) }
+        }
+        return try XCTUnwrap(collections.first { $0.collection.name == name })
     }
 
-    func test_highlightCollectionCreationPlanner_doesNotDuplicateReservedCollectionsForStaleEmissions() async {
-        let sut = HighlightCollectionCreationPlanner()
-
-        let initialNames = await sut.reserveMissingCollectionNames(from: [
-            Self.ayahBookmarkCollection(name: "Favorites"),
-        ])
-        let staleNames = await sut.reserveMissingCollectionNames(from: [
-            Self.ayahBookmarkCollection(name: "yellow"),
-        ])
-
-        XCTAssertEqual(initialNames, ["yellow", "green", "blue", "red", "purple"])
-        XCTAssertEqual(staleNames, [])
+    private func storedCollections(
+        where predicate: ([CollectionWithAyahBookmarks]) -> Bool
+    ) async throws -> [CollectionWithAyahBookmarks] {
+        let iterator = database.quranDataService.collectionsWithBookmarksSequence().makeAsyncIterator()
+        while let collections = try await iterator.next() {
+            if predicate(collections) {
+                return collections
+            }
+        }
+        throw TestError.expectedDatabaseStateNotObserved
     }
 
-    func test_highlightCollectionCreationPlanner_releasesOnlyFailedReservations() async {
-        let sut = HighlightCollectionCreationPlanner()
-
-        let initialNames = await sut.reserveMissingCollectionNames(from: [
-            Self.ayahBookmarkCollection(name: "Favorites"),
-        ])
-        await sut.releaseCollectionNames([initialNames[1]])
-        let retryNames = await sut.reserveMissingCollectionNames(from: [
-            Self.ayahBookmarkCollection(name: "yellow"),
-        ])
-
-        XCTAssertEqual(retryNames, ["green"])
+    private func nextCollections(
+        from iterator: inout AyahBookmarkCollectionsSequence.AsyncIterator,
+        where predicate: ([AyahBookmarkCollection]) -> Bool
+    ) async throws -> [AyahBookmarkCollection] {
+        while let collections = try await iterator.next() {
+            if predicate(collections) {
+                return collections
+            }
+        }
+        throw TestError.expectedDatabaseStateNotObserved
     }
 
-    // MARK: Private
-
-    private static func collection(
-        localId: String? = nil,
-        name: String,
-        bookmarks: [CollectionAyahBookmark]
-    ) -> CollectionWithAyahBookmarks {
-        CollectionWithAyahBookmarks(
-            collection: Collection_(
-                name: name,
-                lastUpdated: .distantPast,
-                localId: localId ?? name
-            ),
-            bookmarks: bookmarks
-        )
+    private func ayah(_ number: Int) -> AyahNumber {
+        AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: number)!
     }
+}
 
-    private static func bookmark(
-        collectionLocalId: String,
-        bookmarkLocalId: String? = nil,
-        sura: Int32,
-        ayah: Int32
-    ) -> CollectionAyahBookmark {
-        CollectionAyahBookmark(
-            collectionLocalId: collectionLocalId,
-            collectionRemoteId: nil,
-            bookmarkLocalId: bookmarkLocalId ?? "\(collectionLocalId)-\(sura)-\(ayah)",
-            bookmarkRemoteId: nil,
-            sura: sura,
-            ayah: ayah,
-            lastUpdated: .distantPast,
-            localId: "\(collectionLocalId)-collection-\(sura)-\(ayah)"
-        )
-    }
-
-    private static func ayahBookmarkCollection(
-        name: String,
-        bookmarks: [AyahCollectionBookmark] = []
-    ) -> AyahBookmarkCollection {
-        AyahBookmarkCollection(
-            collection: Collection_(
-                name: name,
-                lastUpdated: .distantPast,
-                localId: name
-            ),
-            bookmarks: bookmarks
-        )
-    }
-
-    private static func ayahCollectionBookmark(
-        collectionLocalId: String,
-        ayah: AyahNumber
-    ) -> AyahCollectionBookmark {
-        AyahCollectionBookmark(
-            bookmark: bookmark(
-                collectionLocalId: collectionLocalId,
-                sura: Int32(ayah.sura.suraNumber),
-                ayah: Int32(ayah.ayah)
-            ),
-            ayah: ayah
-        )
-    }
+private enum TestError: Error {
+    case expectedDatabaseStateNotObserved
 }
 #endif

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
@@ -1,10 +1,25 @@
 #if QURAN_SYNC
+import Combine
 import MobileSync
+import MobileSyncTestSupport
+import QuranKit
 import XCTest
 @testable import BookmarksFeature
 
+@MainActor
 final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
-    @MainActor
+    private let database = MobileSyncTestDatabase.shared
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+    }
+
+    override func tearDown() async throws {
+        try await database.reset()
+        try await super.tearDown()
+    }
+
     func test_sorted_groupsHighlightCollectionsBeforeUserCollections() {
         let collections = AyahBookmarkCollectionsViewModel.sorted([
             collection(name: "Z Collection"),
@@ -19,6 +34,67 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
             "A Collection",
             "Z Collection",
         ])
+    }
+
+    func test_createCollection_persistsThroughRealMobileSyncDatabase() async throws {
+        let sut = makeSUT()
+
+        await sut.createCollection(name: "Favorites")
+
+        let collections = try await storedCollections()
+        XCTAssertEqual(collections.map(\.collection.name), ["Favorites"])
+        XCTAssertNil(sut.error)
+    }
+
+    func test_deleteCollection_removesFromRealMobileSyncDatabase() async throws {
+        let service = makeService()
+        try await service.createCollection(named: "Favorites")
+        let stored = try await storedCollections()
+        let collection = try XCTUnwrap(
+            AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405).first
+        )
+        let sut = makeSUT(service: service)
+
+        await sut.deleteCollection(collection)
+
+        let collections = try await storedCollections()
+        XCTAssertTrue(collections.isEmpty)
+        XCTAssertNil(sut.error)
+    }
+
+    func test_start_observesCollectionsFromMobileSyncDatabase() async throws {
+        let service = makeService()
+        try await service.createCollection(named: "Favorites")
+        let sut = makeSUT(service: service)
+        let observed = expectation(description: "Observes persisted collection")
+        let observation = sut.$collections.sink { collections in
+            if collections.contains(where: { $0.collection.name == "Favorites" }) {
+                observed.fulfill()
+            }
+        }
+
+        let task = Task { await sut.start() }
+        await fulfillment(of: [observed], timeout: 2)
+
+        XCTAssertNil(sut.error)
+        task.cancel()
+        observation.cancel()
+    }
+
+    private func makeSUT(service: AyahBookmarkCollectionService? = nil) -> AyahBookmarkCollectionsViewModel {
+        AyahBookmarkCollectionsViewModel(
+            ayahBookmarkCollectionService: service ?? makeService(),
+            navigateToPage: { _ in }
+        )
+    }
+
+    private func makeService() -> AyahBookmarkCollectionService {
+        AyahBookmarkCollectionService(quranDataService: database.quranDataService)
+    }
+
+    private func storedCollections() async throws -> [CollectionWithAyahBookmarks] {
+        let iterator = database.quranDataService.collectionsWithBookmarksSequence().makeAsyncIterator()
+        return try await iterator.next() ?? []
     }
 
     private func collection(name: String) -> AyahBookmarkCollection {

--- a/Features/NoteEditorFeature/Sources/NoteEditorViewModel.swift
+++ b/Features/NoteEditorFeature/Sources/NoteEditorViewModel.swift
@@ -26,7 +26,7 @@ final class NoteEditorViewModel {
 
     #if QURAN_SYNC
     init(
-        noteService: NoteEditorSyncServicing,
+        noteService: MobileSyncNoteService,
         analytics: AnalyticsLibrary,
         mode: Mode,
         textForVerses: @escaping ([AyahNumber]) async throws -> String
@@ -182,7 +182,7 @@ final class NoteEditorViewModel {
     // MARK: Private
 
     #if QURAN_SYNC
-    private let noteService: NoteEditorSyncServicing
+    private let noteService: MobileSyncNoteService
     private let analytics: AnalyticsLibrary
     private let mode: Mode
     private let textForVerses: ([AyahNumber]) async throws -> String
@@ -265,17 +265,7 @@ final class NoteEditorViewModel {
     }
 }
 
-#if QURAN_SYNC
-// TODO: This is a narrow test seam around MobileSyncNoteService. Prefer removing it once
-// NoteEditorViewModelTests can use the real service with an in-memory database.
-protocol NoteEditorSyncServicing {
-    func createNote(body: String, startAyah: AyahNumber, endAyah: AyahNumber) async throws
-    func updateNote(_ note: Note, body: String, startAyah: AyahNumber, endAyah: AyahNumber) async throws
-    func removeNote(_ note: Note) async throws
-}
-
-extension MobileSyncNoteService: NoteEditorSyncServicing {}
-#else
+#if !QURAN_SYNC
 protocol NoteEditorLegacyServicing {
     func setNote(_ note: String, verses: [AyahNumber], color: HighlightColor) async throws
     func removeNotes(with verses: [AyahNumber]) async throws

--- a/Features/NoteEditorFeature/Tests/NoteEditorViewModelTests.swift
+++ b/Features/NoteEditorFeature/Tests/NoteEditorViewModelTests.swift
@@ -1,4 +1,7 @@
 import Analytics
+#if QURAN_SYNC
+import MobileSyncTestSupport
+#endif
 import QuranAnnotations
 import QuranKit
 import XCTest
@@ -9,6 +12,18 @@ import XCTest
 @MainActor
 final class NoteEditorViewModelTests: XCTestCase {
     #if QURAN_SYNC
+    private let database = MobileSyncTestDatabase.shared
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+    }
+
+    override func tearDown() async throws {
+        try await database.reset()
+        try await super.tearDown()
+    }
+
     func test_fetchNote_mapsSyncedEditNote() async throws {
         let note = syncedNote(body: "Stored note")
         let sut = makeSyncSUT(mode: .edit(note), text: "ayah text")
@@ -33,7 +48,8 @@ final class NoteEditorViewModelTests: XCTestCase {
         XCTAssertFalse(sut.viewModel.canDismissNote)
         XCTAssertFalse(sut.viewModel.shouldAutoSaveOnDismiss)
         XCTAssertFalse(didSave)
-        XCTAssertTrue(sut.noteService.events.isEmpty)
+        let notes = try await storedNotes()
+        XCTAssertTrue(notes.isEmpty)
         XCTAssertFalse(sut.listener.didDismiss)
     }
 
@@ -46,7 +62,8 @@ final class NoteEditorViewModelTests: XCTestCase {
         XCTAssertTrue(sut.viewModel.canDismissNote)
         XCTAssertFalse(sut.viewModel.shouldAutoSaveOnDismiss)
         XCTAssertTrue(didFinish)
-        XCTAssertTrue(sut.noteService.events.isEmpty)
+        let notes = try await storedNotes()
+        XCTAssertTrue(notes.isEmpty)
         XCTAssertTrue(sut.listener.didDismiss)
     }
 
@@ -57,12 +74,13 @@ final class NoteEditorViewModelTests: XCTestCase {
         let didFinish = await sut.viewModel.commitEditsAndExit(dismissOnSave: false)
 
         XCTAssertFalse(didFinish)
-        XCTAssertTrue(sut.noteService.events.isEmpty)
+        let notes = try await storedNotes()
+        XCTAssertTrue(notes.isEmpty)
         XCTAssertFalse(sut.listener.didDismiss)
     }
 
     func test_validDoneSave_updatesSyncedNoteAndDismisses() async throws {
-        let note = syncedNote(body: "Stored note")
+        let note = try await createStoredNote(body: "Stored note")
         let sut = makeSyncSUT(mode: .edit(note))
         let editableNote = try await sut.viewModel.fetchNote()
         editableNote.note = "Updated note"
@@ -70,15 +88,16 @@ final class NoteEditorViewModelTests: XCTestCase {
         let didSave = await sut.viewModel.commitEditsAndExit(dismissOnSave: true)
 
         XCTAssertTrue(didSave)
-        XCTAssertEqual(sut.noteService.events, [
-            .update(localId: note.id, body: "Updated note", startAyah: note.startAyah, endAyah: note.endAyah),
-        ])
+        let notes = try await storedNotes()
+        let stored = try XCTUnwrap(notes.first)
+        XCTAssertEqual(stored.id, note.id)
+        XCTAssertEqual(stored.text, "Updated note")
         XCTAssertEqual(sut.analytics.events, [.init(name: "UpdateNoteVersesNum", value: "2")])
         XCTAssertTrue(sut.listener.didDismiss)
     }
 
     func test_validAutoSave_updatesSyncedNoteWithoutDismissing() async throws {
-        let note = syncedNote(body: "Stored note")
+        let note = try await createStoredNote(body: "Stored note")
         let sut = makeSyncSUT(mode: .edit(note))
         let editableNote = try await sut.viewModel.fetchNote()
         editableNote.note = "Updated note"
@@ -88,26 +107,29 @@ final class NoteEditorViewModelTests: XCTestCase {
         XCTAssertTrue(didSave)
         XCTAssertTrue(sut.viewModel.canDismissNote)
         XCTAssertTrue(sut.viewModel.shouldAutoSaveOnDismiss)
-        XCTAssertEqual(sut.noteService.events.count, 1)
+        let notes = try await storedNotes()
+        XCTAssertEqual(notes.map(\.text), ["Updated note"])
         XCTAssertFalse(sut.listener.didDismiss)
     }
 
-    func test_createDelete_dismissesWithoutRemovingSyncedNote() async {
+    func test_createDelete_dismissesWithoutRemovingSyncedNote() async throws {
         let sut = makeSyncSUT(mode: .create(verses: [ayah(1)]))
 
         await sut.viewModel.forceDelete()
 
-        XCTAssertTrue(sut.noteService.events.isEmpty)
+        let notes = try await storedNotes()
+        XCTAssertTrue(notes.isEmpty)
         XCTAssertTrue(sut.listener.didDismiss)
     }
 
-    func test_editDelete_removesSyncedNoteAndDismisses() async {
-        let note = syncedNote(body: "Stored note")
+    func test_editDelete_removesSyncedNoteAndDismisses() async throws {
+        let note = try await createStoredNote(body: "Stored note")
         let sut = makeSyncSUT(mode: .edit(note))
 
         await sut.viewModel.forceDelete()
 
-        XCTAssertEqual(sut.noteService.events, [.remove(localId: note.id)])
+        let notes = try await storedNotes()
+        XCTAssertTrue(notes.isEmpty)
         XCTAssertTrue(sut.listener.didDismiss)
     }
 
@@ -119,15 +141,17 @@ final class NoteEditorViewModelTests: XCTestCase {
         let didSave = await sut.viewModel.commitEditsAndExit(dismissOnSave: true)
 
         XCTAssertTrue(didSave)
-        XCTAssertEqual(sut.noteService.events, [
-            .create(body: "Created note", startAyah: ayah(1), endAyah: ayah(3)),
-        ])
+        let notes = try await storedNotes()
+        let stored = try XCTUnwrap(notes.first)
+        XCTAssertEqual(stored.text, "Created note")
+        XCTAssertEqual(stored.startAyah, ayah(1))
+        XCTAssertEqual(stored.endAyah, ayah(3))
         XCTAssertEqual(sut.analytics.events, [.init(name: "UpdateNoteVersesNum", value: "2")])
         XCTAssertTrue(sut.listener.didDismiss)
     }
 
     func test_editSave_usesSyncedNoteVerseRangeAndLogsRangeVerseCount() async throws {
-        let note = syncedNote(body: "Stored note", startAyah: ayah(1), endAyah: ayah(3))
+        let note = try await createStoredNote(body: "Stored note", startAyah: ayah(1), endAyah: ayah(3))
         let sut = makeSyncSUT(mode: .edit(note))
         let editableNote = try await sut.viewModel.fetchNote()
         editableNote.note = "Updated note"
@@ -135,9 +159,12 @@ final class NoteEditorViewModelTests: XCTestCase {
         let didSave = await sut.viewModel.commitEditsAndExit(dismissOnSave: true)
 
         XCTAssertTrue(didSave)
-        XCTAssertEqual(sut.noteService.events, [
-            .update(localId: note.id, body: "Updated note", startAyah: ayah(1), endAyah: ayah(3)),
-        ])
+        let notes = try await storedNotes()
+        let stored = try XCTUnwrap(notes.first)
+        XCTAssertEqual(stored.id, note.id)
+        XCTAssertEqual(stored.text, "Updated note")
+        XCTAssertEqual(stored.startAyah, ayah(1))
+        XCTAssertEqual(stored.endAyah, ayah(3))
         XCTAssertEqual(sut.analytics.events, [.init(name: "UpdateNoteVersesNum", value: "3")])
     }
     #else
@@ -257,8 +284,8 @@ final class NoteEditorViewModelTests: XCTestCase {
     private func makeSyncSUT(
         mode: NoteEditorViewModel.Mode,
         text: String = "ayah text"
-    ) -> (viewModel: NoteEditorViewModel, noteService: SyncNoteServiceFake, analytics: AnalyticsSpy, listener: ListenerSpy) {
-        let noteService = SyncNoteServiceFake()
+    ) -> (viewModel: NoteEditorViewModel, noteService: MobileSyncNoteService, analytics: AnalyticsSpy, listener: ListenerSpy) {
+        let noteService = MobileSyncNoteService(quranDataService: database.quranDataService)
         let analytics = AnalyticsSpy()
         let listener = ListenerSpy()
         let viewModel = NoteEditorViewModel(
@@ -284,6 +311,27 @@ final class NoteEditorViewModelTests: XCTestCase {
             endAyah: endAyah ?? ayah(2),
             modifiedDate: Date(timeIntervalSince1970: 1)
         )
+    }
+
+    private func createStoredNote(
+        body: String,
+        startAyah: AyahNumber? = nil,
+        endAyah: AyahNumber? = nil
+    ) async throws -> Note {
+        let service = MobileSyncNoteService(quranDataService: database.quranDataService)
+        try await service.createNote(
+            body: body,
+            startAyah: startAyah ?? ayah(1),
+            endAyah: endAyah ?? ayah(2)
+        )
+        let notes = try await storedNotes()
+        return try XCTUnwrap(notes.first)
+    }
+
+    private func storedNotes() async throws -> [Note] {
+        let service = MobileSyncNoteService(quranDataService: database.quranDataService)
+        var iterator = service.notesSequence(quran: Self.quran).makeAsyncIterator()
+        return try await iterator.next() ?? []
     }
     #else
     private func makeLegacySUT(
@@ -328,27 +376,6 @@ private final class AnalyticsSpy: AnalyticsLibrary, @unchecked Sendable {
     }
 }
 
-private final class SyncNoteServiceFake: NoteEditorSyncServicing {
-    enum Event: Equatable {
-        case create(body: String, startAyah: AyahNumber, endAyah: AyahNumber)
-        case update(localId: String, body: String, startAyah: AyahNumber, endAyah: AyahNumber)
-        case remove(localId: String)
-    }
-
-    private(set) var events: [Event] = []
-
-    func createNote(body: String, startAyah: AyahNumber, endAyah: AyahNumber) async throws {
-        events.append(.create(body: body, startAyah: startAyah, endAyah: endAyah))
-    }
-
-    func updateNote(_ note: Note, body: String, startAyah: AyahNumber, endAyah: AyahNumber) async throws {
-        events.append(.update(localId: note.id, body: body, startAyah: startAyah, endAyah: endAyah))
-    }
-
-    func removeNote(_ note: Note) async throws {
-        events.append(.remove(localId: note.id))
-    }
-}
 #else
 private final class LegacyNoteServiceFake: NoteEditorLegacyServicing {
     struct SetNoteCall: Equatable {

--- a/Features/NotesFeature/Tests/NotesViewModelTests.swift
+++ b/Features/NotesFeature/Tests/NotesViewModelTests.swift
@@ -1,0 +1,85 @@
+#if QURAN_SYNC
+import AnnotationsService
+import Combine
+import MobileSyncTestSupport
+import QuranAnnotations
+import QuranKit
+import QuranTextKit
+import XCTest
+@testable import NotesFeature
+
+@MainActor
+final class NotesViewModelTests: XCTestCase {
+    private let database = MobileSyncTestDatabase.shared
+    private var noteService: MobileSyncNoteService!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+        noteService = MobileSyncNoteService(quranDataService: database.quranDataService)
+    }
+
+    override func tearDown() async throws {
+        try await database.reset()
+        noteService = nil
+        try await super.tearDown()
+    }
+
+    func test_deleteItem_removesNoteFromMobileSyncDatabase() async throws {
+        let ayah = AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
+        try await noteService.createNote(body: "Delete me", startAyah: ayah, endAyah: ayah)
+        let stored = try await storedNotes()
+        let note = try XCTUnwrap(stored.first)
+        let item = NoteItem(note: note, verseText: "Verse")
+        let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-quran-database")
+        let sut = NotesViewModel(
+            noteService: noteService,
+            textService: QuranTextDataService(
+                databasesURL: unavailableDatabase,
+                quranFileURL: unavailableDatabase
+            ),
+            navigateTo: { _ in },
+            editNote: { _ in }
+        )
+
+        await sut.deleteItem(item)
+
+        let notes = try await storedNotes()
+        XCTAssertTrue(notes.isEmpty)
+        XCTAssertNil(sut.error)
+    }
+
+    func test_start_observesNotesFromMobileSyncDatabase() async throws {
+        let ayah = AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
+        try await noteService.createNote(body: "Observed note", startAyah: ayah, endAyah: ayah)
+        let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-quran-database")
+        let sut = NotesViewModel(
+            noteService: noteService,
+            textService: QuranTextDataService(
+                databasesURL: unavailableDatabase,
+                quranFileURL: unavailableDatabase
+            ),
+            navigateTo: { _ in },
+            editNote: { _ in }
+        )
+        let observed = expectation(description: "Observes persisted note")
+        let observation = sut.$notes.sink { notes in
+            if notes.map(\.noteText) == ["Observed note"] {
+                observed.fulfill()
+            }
+        }
+
+        let task = Task { await sut.start() }
+        await fulfillment(of: [observed], timeout: 2)
+
+        XCTAssertNil(sut.error)
+        task.cancel()
+        observation.cancel()
+    }
+
+    private func storedNotes() async throws -> [QuranAnnotations.Note] {
+        var iterator = noteService.notesSequence(quran: .hafsMadani1405).makeAsyncIterator()
+        return try await iterator.next() ?? []
+    }
+}
+#endif

--- a/Features/QuranViewFeature/QuranBuilder.swift
+++ b/Features/QuranViewFeature/QuranBuilder.swift
@@ -40,6 +40,7 @@ public struct QuranBuilder {
         let pageBookmarkService = PageBookmarkService(persistence: container.pageBookmarkPersistence)
         #if QURAN_SYNC
         let syncedNoteService = container.mobileSyncNoteService()
+        let syncedNotesObserver = QuranSyncedNotesObserver(noteService: syncedNoteService, quran: quran)
         let syncedHighlightsObserver = QuranSyncedHighlightsObserver(
             ayahBookmarkCollectionService: AyahBookmarkCollectionService(quranDataService: container.quranDataService),
             highlightsService: highlightsService
@@ -57,7 +58,7 @@ public struct QuranBuilder {
             translationsSelectionBuilder: TranslationsListBuilder(container: container),
             translationVerseBuilder: TranslationVerseBuilder(container: container),
             resources: container.readingResources,
-            syncedNoteService: syncedNoteService,
+            syncedNotesObserver: syncedNotesObserver,
             noteEditorBuilder: NoteEditorBuilder(container: container),
             syncedHighlightsObserver: syncedHighlightsObserver
         )

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -72,7 +72,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let translationVerseBuilder: TranslationVerseBuilder
         let resources: ReadingResourcesService
         #if QURAN_SYNC
-        let syncedNoteService: MobileSyncNoteService
+        let syncedNotesObserver: QuranSyncedNotesObserver
         let noteEditorBuilder: NoteEditorBuilder
         let syncedHighlightsObserver: QuranSyncedHighlightsObserver
         #else
@@ -87,12 +87,6 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         self.deps = deps
         self.input = input
         logger.info("Quran: opening quran \(input)")
-    }
-
-    deinit {
-        #if QURAN_SYNC
-        syncedNotesObservationTask?.cancel()
-        #endif
     }
 
     // MARK: Internal
@@ -114,7 +108,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     func start() {
         #if QURAN_SYNC
         deps.syncedHighlightsObserver.start()
-        startSyncedNotesObservation(deps.syncedNoteService)
+        deps.syncedNotesObserver.start()
         #else
         startLegacyNotesObservation()
         #endif
@@ -196,15 +190,15 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
     #if QURAN_SYNC
     func deleteNotes(in verses: [AyahNumber]) async {
-        let syncedNoteService = deps.syncedNoteService
-        let notesToDelete = syncedNotes(interacting: verses)
+        let syncedNotesObserver = deps.syncedNotesObserver
+        let notesToDelete = syncedNotesObserver.notes(interacting: verses)
         if !notesToDelete.isEmpty {
             presenter?.confirmNoteDelete(
                 delete: { [weak self] in
                     do {
                         self?.contentViewModel?.removeAyahMenuHighlight()
                         for note in notesToDelete {
-                            try await syncedNoteService.removeNote(note)
+                            try await syncedNotesObserver.remove(note)
                         }
                     } catch {
                         crasher.recordError(error, reason: "Failed to delete synced notes")
@@ -371,10 +365,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     private let contentStatePreferences = QuranContentStatePreferences.shared
     private let selectedTranslationsPreferences = SelectedTranslationsPreferences.shared
 
-    #if QURAN_SYNC
-    private var syncedNotes: [Note] = []
-    private var syncedNotesObservationTask: Task<Void, Never>?
-    #else
+    #if !QURAN_SYNC
     private var notes: [Note] = []
     #endif
 
@@ -408,26 +399,6 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.notes = $0 }
             .store(in: &cancellables)
-    }
-    #endif
-
-    #if QURAN_SYNC
-    private func startSyncedNotesObservation(_ noteService: MobileSyncNoteService) {
-        let quran = deps.quran
-        syncedNotesObservationTask?.cancel()
-        syncedNotesObservationTask = Task {
-            do {
-                let sequence = noteService.notesSequence(quran: quran)
-                for try await notes in sequence {
-                    await MainActor.run { [weak self] in
-                        self?.syncedNotes = notes
-                    }
-                }
-            } catch is CancellationError {
-            } catch {
-                crasher.recordError(error, reason: "Failed to observe synced notes")
-            }
-        }
     }
     #endif
 
@@ -470,17 +441,11 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
     private func syncedNoteCount(interacting verses: [AyahNumber]) -> Int {
         #if QURAN_SYNC
-        syncedNotes.filter { $0.intersects(verses: verses) }.count
+        deps.syncedNotesObserver.notes(interacting: verses).count
         #else
         return 0
         #endif
     }
-
-    #if QURAN_SYNC
-    private func syncedNotes(interacting verses: [AyahNumber]) -> [Note] {
-        syncedNotes.filter { $0.intersects(verses: verses) }
-    }
-    #endif
 
     private func dismissWordPointer() {
         logger.info("Quran: dismiss word pointer")

--- a/Features/QuranViewFeature/QuranSyncedNotesObserver.swift
+++ b/Features/QuranViewFeature/QuranSyncedNotesObserver.swift
@@ -1,0 +1,52 @@
+#if QURAN_SYNC
+import AnnotationsService
+import Combine
+import Crashing
+import QuranAnnotations
+import QuranKit
+import VLogging
+
+@MainActor
+final class QuranSyncedNotesObserver {
+    init(noteService: MobileSyncNoteService, quran: Quran) {
+        self.noteService = noteService
+        self.quran = quran
+    }
+
+    deinit {
+        task?.cancel()
+    }
+
+    @Published private(set) var notes: [Note] = []
+
+    func start() {
+        guard task == nil else {
+            return
+        }
+        let noteService = noteService
+        let quran = quran
+        task = Task { [weak self] in
+            do {
+                for try await notes in noteService.notesSequence(quran: quran) {
+                    self?.notes = notes
+                }
+            } catch is CancellationError {
+            } catch {
+                crasher.recordError(error, reason: "Failed to observe synced notes")
+            }
+        }
+    }
+
+    func notes(interacting verses: [AyahNumber]) -> [Note] {
+        notes.filter { $0.intersects(verses: verses) }
+    }
+
+    func remove(_ note: Note) async throws {
+        try await noteService.removeNote(note)
+    }
+
+    private let noteService: MobileSyncNoteService
+    private let quran: Quran
+    private var task: Task<Void, Never>?
+}
+#endif

--- a/Features/QuranViewFeature/Tests/QuranSyncedHighlightsObserverTests.swift
+++ b/Features/QuranViewFeature/Tests/QuranSyncedHighlightsObserverTests.swift
@@ -1,0 +1,70 @@
+#if QURAN_SYNC
+import AnnotationsService
+import Combine
+import MobileSync
+import MobileSyncTestSupport
+import QuranAnnotations
+import QuranKit
+import XCTest
+@testable import BookmarksFeature
+@testable import QuranViewFeature
+
+@MainActor
+final class QuranSyncedHighlightsObserverTests: XCTestCase {
+    private let database = MobileSyncTestDatabase.shared
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+    }
+
+    override func tearDown() async throws {
+        try await database.reset()
+        try await super.tearDown()
+    }
+
+    func test_start_appliesPersistedMobileSyncBookmarksToHighlights() async throws {
+        let collectionService = AyahBookmarkCollectionService(quranDataService: database.quranDataService)
+        try await collectionService.createCollection(named: HighlightColor.green.collectionName)
+        let stored = try await storedCollections()
+        let collection = try XCTUnwrap(
+            AyahBookmarkCollectionService.collections(
+                from: stored,
+                quran: .hafsMadani1405
+            ).first
+        )
+        try await collectionService.addAyahBookmarkToCollection(
+            collectionLocalId: collection.collection.localId,
+            ayah: ayah
+        )
+        let highlightsService = QuranHighlightsService()
+        let observer = QuranSyncedHighlightsObserver(
+            ayahBookmarkCollectionService: collectionService,
+            highlightsService: highlightsService
+        )
+        let applied = expectation(description: "Applies persisted synced highlight")
+        let observation = highlightsService.$highlights.sink { [ayah] highlights in
+            if highlights.highlightVerses[ayah] == .green {
+                applied.fulfill()
+            }
+        }
+
+        observer.start()
+        await fulfillment(of: [applied], timeout: 2)
+
+        XCTAssertEqual(highlightsService.highlights.highlightVerses[ayah], .green)
+        XCTAssertEqual(observer.collections.first?.bookmarks.first?.ayah, ayah)
+        observation.cancel()
+        withExtendedLifetime(observer) {}
+    }
+
+    private var ayah: AyahNumber {
+        AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
+    }
+
+    private func storedCollections() async throws -> [CollectionWithAyahBookmarks] {
+        let iterator = database.quranDataService.collectionsWithBookmarksSequence().makeAsyncIterator()
+        return try await iterator.next() ?? []
+    }
+}
+#endif

--- a/Features/QuranViewFeature/Tests/QuranSyncedNotesObserverTests.swift
+++ b/Features/QuranViewFeature/Tests/QuranSyncedNotesObserverTests.swift
@@ -1,0 +1,66 @@
+#if QURAN_SYNC
+import AnnotationsService
+import Combine
+import MobileSyncTestSupport
+import QuranAnnotations
+import QuranKit
+import XCTest
+@testable import QuranViewFeature
+
+@MainActor
+final class QuranSyncedNotesObserverTests: XCTestCase {
+    private let database = MobileSyncTestDatabase.shared
+    private var noteService: MobileSyncNoteService!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+        noteService = MobileSyncNoteService(quranDataService: database.quranDataService)
+    }
+
+    override func tearDown() async throws {
+        try await database.reset()
+        noteService = nil
+        try await super.tearDown()
+    }
+
+    func test_start_observesPersistedNotesFromMobileSyncDatabase() async throws {
+        try await noteService.createNote(body: "Stored note", startAyah: ayah(1), endAyah: ayah(2))
+        let sut = QuranSyncedNotesObserver(noteService: noteService, quran: .hafsMadani1405)
+        let observed = expectation(description: "Observes persisted note")
+        let observation = sut.$notes.sink { notes in
+            if notes.map(\.text) == ["Stored note"] {
+                observed.fulfill()
+            }
+        }
+
+        sut.start()
+        await fulfillment(of: [observed], timeout: 2)
+
+        XCTAssertEqual(sut.notes(interacting: [ayah(2)]).map(\.text), ["Stored note"])
+        observation.cancel()
+        withExtendedLifetime(sut) {}
+    }
+
+    func test_remove_deletesNoteFromMobileSyncDatabase() async throws {
+        try await noteService.createNote(body: "Delete me", startAyah: ayah(1), endAyah: ayah(1))
+        let notes = try await storedNotes()
+        let note = try XCTUnwrap(notes.first)
+        let sut = QuranSyncedNotesObserver(noteService: noteService, quran: .hafsMadani1405)
+
+        try await sut.remove(note)
+
+        let remainingNotes = try await storedNotes()
+        XCTAssertTrue(remainingNotes.isEmpty)
+    }
+
+    private func storedNotes() async throws -> [Note] {
+        var iterator = noteService.notesSequence(quran: .hafsMadani1405).makeAsyncIterator()
+        return try await iterator.next() ?? []
+    }
+
+    private func ayah(_ number: Int) -> AyahNumber {
+        AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: number)!
+    }
+}
+#endif

--- a/Features/SettingsFeature/Tests/SettingsRootViewModelTests.swift
+++ b/Features/SettingsFeature/Tests/SettingsRootViewModelTests.swift
@@ -9,6 +9,7 @@ import BatchDownloader
 import Foundation
 import LastPagePersistence
 import MobileSync
+import MobileSyncTestSupport
 import NotePersistence
 import PageBookmarkPersistence
 import ReadingSelectorFeature
@@ -156,7 +157,7 @@ private struct AppDependenciesStub: AppDependencies {
     var notePersistence: NotePersistence { fatalError("Unused in tests") }
     var pageBookmarkPersistence: PageBookmarkPersistence { fatalError("Unused in tests") }
     #if QURAN_SYNC
-    var quranDataService: QuranDataService { fatalError("Unused in tests") }
+    var quranDataService: QuranDataService { MobileSyncTestDatabase.shared.quranDataService }
     #endif
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -192,6 +192,10 @@ private func uiTargets() -> [[Target]] {
 private func dataTargets() -> [[Target]] {
     let type = TargetType.data
     return [
+        target(type, name: "MobileSyncTestSupport", hasTests: false, dependencies: [
+            .product(name: "MobileSync", package: "mobile-sync-spm"),
+        ]),
+
         // MARK: - Page Bookmarks
 
         target(type, name: "PageBookmarkPersistence", dependencies: [
@@ -333,6 +337,7 @@ private func dataTargets() -> [[Target]] {
             .product(name: "MobileSync", package: "mobile-sync-spm"),
         ], testDependencies: [
             "AuthenticationClientFake",
+            "MobileSyncTestSupport",
             .product(name: "MobileSync", package: "mobile-sync-spm"),
         ]),
 
@@ -500,6 +505,7 @@ private func domainTargets() -> [[Target]] {
             "Analytics",
         ], testDependencies: [
             "LastPagePersistence",
+            "MobileSyncTestSupport",
             "PageBookmarkPersistence",
             "QuranKit",
         ]),
@@ -543,12 +549,15 @@ private func featuresTargets() -> [[Target]] {
             "ReciterService",
         ]),
 
-        target(type, name: "AyahMenuFeature", hasTests: false, dependencies: [
+        target(type, name: "AyahMenuFeature", sourcesInRoot: true, dependencies: [
             "AppDependencies",
             "QuranAudioKit",
             "AnnotationsService",
             "BookmarksFeature",
             "NoorUI",
+        ], testDependencies: [
+            "MobileSyncTestSupport",
+            .product(name: "MobileSync", package: "mobile-sync-spm"),
         ]),
 
         target(type, name: "WhatsNewFeature", hasTests: false, dependencies: [
@@ -608,6 +617,7 @@ private func featuresTargets() -> [[Target]] {
         ], testDependencies: [
             "Analytics",
             "AnnotationsService",
+            "MobileSyncTestSupport",
             "NoorUI",
             "QuranAnnotations",
             "QuranKit",
@@ -626,6 +636,7 @@ private func featuresTargets() -> [[Target]] {
             "AnnotationsService",
             "AuthenticationClient",
             "AuthenticationClientFake",
+            "MobileSyncTestSupport",
             .product(name: "MobileSync", package: "mobile-sync-spm"),
             "PageBookmarkPersistence",
         ]),
@@ -682,6 +693,8 @@ private func featuresTargets() -> [[Target]] {
             "ReadingService",
             "NoorUI",
             "NoteEditorFeature",
+        ], testDependencies: [
+            "MobileSyncTestSupport",
         ]),
 
         target(type, name: "TranslationVerseFeature", hasTests: false, dependencies: [
@@ -709,7 +722,7 @@ private func featuresTargets() -> [[Target]] {
             "Preferences",
         ]),
 
-        target(type, name: "QuranViewFeature", hasTests: false, dependencies: [
+        target(type, name: "QuranViewFeature", sourcesInRoot: true, dependencies: [
             "AudioBannerFeature",
             "QuranContentFeature",
             "AyahMenuFeature",
@@ -720,6 +733,9 @@ private func featuresTargets() -> [[Target]] {
             "TranslationVerseFeature",
             "FeaturesSupport",
             "BookmarksFeature",
+        ], testDependencies: [
+            "MobileSyncTestSupport",
+            .product(name: "MobileSync", package: "mobile-sync-spm"),
         ]),
 
         target(type, name: "SettingsFeature", dependencies: [
@@ -740,6 +756,7 @@ private func featuresTargets() -> [[Target]] {
             "AudioDownloadsFeature",
             "AuthenticationClient",
             "AuthenticationClientFake",
+            "MobileSyncTestSupport",
             .product(name: "MobileSync", package: "mobile-sync-spm"),
             "BatchDownloader",
             "LastPagePersistence",
@@ -793,6 +810,7 @@ func target(
     _ type: TargetType,
     name: String,
     hasTests: Bool = true,
+    sourcesInRoot: Bool = false,
     otherSettings: [SwiftSetting] = [],
     dependencies: [Target.Dependency] = [],
     resources: [Resource]? = nil,
@@ -804,7 +822,8 @@ func target(
         .target(
             name: name,
             dependencies: dependencies,
-            path: type.rawValue + "/" + name + (hasTests ? "/Sources" : ""),
+            path: type.rawValue + "/" + name + (hasTests && !sourcesInRoot ? "/Sources" : ""),
+            exclude: hasTests && sourcesInRoot ? ["Tests"] : [],
             resources: resources,
             swiftSettings: settings + otherSettings
         ),


### PR DESCRIPTION
## Summary

- add reusable `MobileSyncTestDatabase` support backed by the production MobileSync graph
- migrate sync persistence tests away from fake database dependencies
- add real-database coverage for notes, bookmarks, highlights, reading sessions, logout, and Quran observers
- document real MobileSync database testing as the required `QURAN_SYNC` pattern

## Why

Fake sync persistence tests did not verify the MobileSync database boundary, mapping, observation, or cleanup behavior. These tests now exercise the production services and assert database-observable state.

## Validation

- relevant sync suites: 52 tests passed
- `make build-sync`
- `make build-no-sync`
- `make format-lint`
- sync and no-sync package manifest validation
- fake sync database dependency audit