### PR TITLE
Fix existing note editing from the ayah menu

### DIFF
--- a/Features/AyahMenuFeature/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/AyahMenuBuilder.swift
@@ -23,14 +23,14 @@ public struct AyahMenuInput {
         sourceView: UIView,
         pointInView: CGPoint,
         verses: [AyahNumber],
-        noteCount: Int,
+        notes: [QuranAnnotations.Note],
         highlightVerses: [AyahNumber: HighlightColor],
         highlightCollections: [AyahBookmarkCollection]
     ) {
         self.sourceView = sourceView
         self.pointInView = pointInView
         self.verses = verses
-        self.noteCount = noteCount
+        self.notes = notes
         self.highlightVerses = highlightVerses
         self.highlightCollections = highlightCollections
     }
@@ -53,12 +53,10 @@ public struct AyahMenuInput {
     let sourceView: UIView
     let pointInView: CGPoint
     let verses: [AyahNumber]
+    let notes: [QuranAnnotations.Note]
     #if QURAN_SYNC
-    let noteCount: Int
     let highlightVerses: [AyahNumber: HighlightColor]
     let highlightCollections: [AyahBookmarkCollection]
-    #else
-    let notes: [QuranAnnotations.Note]
     #endif
 }
 
@@ -83,9 +81,9 @@ public struct AyahMenuBuilder {
             pointInView: input.pointInView,
             verses: input.verses,
             textRetriever: textRetriever,
+            notes: input.notes,
             highlightVerses: input.highlightVerses,
             highlightCollections: input.highlightCollections,
-            noteCount: input.noteCount,
             ayahBookmarkCollectionService: AyahBookmarkCollectionService(quranDataService: container.quranDataService)
         )
         #else

--- a/Features/AyahMenuFeature/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewController.swift
@@ -53,8 +53,7 @@ final class AyahMenuViewController: UIViewController {
             repeatSubtitle: viewModel.repeatSubtitle,
             actions: actions,
             isTranslationView: viewModel.isTranslationView,
-            usesSyncedNotesIcon: viewModel.usesSyncedNotesIcon,
-            noteCount: viewModel.noteCount
+            usesSyncedNotesIcon: viewModel.usesSyncedNotesIcon
         )
         showAyahMenu(dataObject)
     }

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -29,16 +29,8 @@ public protocol AyahMenuListener: AnyObject {
 
     func shareText(_ lines: [String], in sourceView: UIView, at point: CGPoint)
     func showTranslation(_ verses: [AyahNumber])
-
-    #if QURAN_SYNC
-    func addSyncedNote(verses: [AyahNumber])
+    func showNoteEditor(for verses: [AyahNumber]) async
     func deleteNotes(in verses: [AyahNumber]) async
-    #endif
-
-    #if !QURAN_SYNC
-    func editNote(_ note: QuranAnnotations.Note)
-    func deleteNotes(_ notes: [QuranAnnotations.Note], in verses: [AyahNumber]) async
-    #endif
 }
 
 // MARK: - ViewModel
@@ -50,13 +42,12 @@ final class AyahMenuViewModel {
         let pointInView: CGPoint
         let verses: [AyahNumber]
         let textRetriever: ShareableVerseTextRetriever
+        let notes: [QuranAnnotations.Note]
         #if QURAN_SYNC
         let highlightVerses: [AyahNumber: HighlightColor]
         let highlightCollections: [AyahBookmarkCollection]
-        let noteCount: Int
         let ayahBookmarkCollectionService: AyahBookmarkCollectionService
         #else
-        let notes: [QuranAnnotations.Note]
         let noteService: NoteService
         #endif
         let quranContentStatePreferences = QuranContentStatePreferences.shared
@@ -111,17 +102,9 @@ final class AyahMenuViewModel {
         #endif
     }
 
-    var noteCount: Int {
-        #if QURAN_SYNC
-        return deps.noteCount
-        #else
-        return 0
-        #endif
-    }
-
     var noteState: AyahMenuUI.NoteState {
         #if QURAN_SYNC
-        return noteCount > 0 ? .noted : .noHighlight
+        return deps.notes.isEmpty ? .noHighlight : .noted
         #else
         if deps.notes.isEmpty {
             return .noHighlight
@@ -154,24 +137,12 @@ final class AyahMenuViewModel {
     func deleteNotes() async {
         logger.info("AyahMenu: delete notes. Verses: \(deps.verses)")
         listener?.dismissAyahMenu()
-        #if QURAN_SYNC
         await listener?.deleteNotes(in: deps.verses)
-        #else
-        await listener?.deleteNotes(deps.notes, in: deps.verses)
-        #endif
     }
 
     func editNote() async {
         logger.info("AyahMenu: edit notes. Verses: \(deps.verses)")
-        #if QURAN_SYNC
-        listener?.addSyncedNote(verses: deps.verses)
-        #else
-        let notes = deps.notes
-        let color = deps.noteService.color(from: notes)
-        if let note = await updateLegacyHighlight(color: color) {
-            listener?.editNote(note)
-        }
-        #endif
+        await listener?.showNoteEditor(for: deps.verses)
     }
 
     func updateHighlight(color: HighlightColor) async {

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -47,9 +47,9 @@ final class AyahMenuViewModelTests: XCTestCase {
                 databasesURL: unavailableDatabase,
                 quranFileURL: unavailableDatabase
             ),
+            notes: [],
             highlightVerses: [ayah: .red],
             highlightCollections: populatedCollections,
-            noteCount: 0,
             ayahBookmarkCollectionService: service
         ))
 

--- a/Features/NoteEditorFeature/Sources/NoteEditorBuilder.swift
+++ b/Features/NoteEditorFeature/Sources/NoteEditorBuilder.swift
@@ -24,28 +24,7 @@ public struct NoteEditorBuilder {
     // MARK: Public
 
     #if QURAN_SYNC
-    public func build(withListener listener: NoteEditorListener, note: Note) -> UIViewController {
-        build(withListener: listener, mode: .edit(note))
-    }
-
-    public func build(withListener listener: NoteEditorListener, verses: [AyahNumber]) -> UIViewController {
-        build(withListener: listener, mode: .create(verses: verses))
-    }
-    #else
-    public func build(withListener listener: NoteEditorListener, note: Note) -> UIViewController {
-        let viewModel = NoteEditorViewModel(noteService: container.noteService(), note: note)
-        let viewController = NoteEditorViewController(viewModel: viewModel)
-        viewModel.listener = listener
-        return viewController
-    }
-    #endif
-
-    // MARK: Internal
-
-    let container: AppDependencies
-
-    #if QURAN_SYNC
-    private func build(withListener listener: NoteEditorListener, mode: NoteEditorViewModel.Mode) -> UIViewController {
+    public func build(withListener listener: NoteEditorListener, mode: NoteEditorMode) -> UIViewController {
         let textService = container.textDataService()
         let viewModel = NoteEditorViewModel(
             noteService: container.mobileSyncNoteService(),
@@ -64,5 +43,16 @@ public struct NoteEditorBuilder {
         viewModel.listener = listener
         return viewController
     }
+    #else
+    public func build(withListener listener: NoteEditorListener, note: Note) -> UIViewController {
+        let viewModel = NoteEditorViewModel(noteService: container.noteService(), note: note)
+        let viewController = NoteEditorViewController(viewModel: viewModel)
+        viewModel.listener = listener
+        return viewController
+    }
     #endif
+
+    // MARK: Internal
+
+    let container: AppDependencies
 }

--- a/Features/NoteEditorFeature/Sources/NoteEditorMode.swift
+++ b/Features/NoteEditorFeature/Sources/NoteEditorMode.swift
@@ -1,0 +1,9 @@
+#if QURAN_SYNC
+import QuranAnnotations
+import QuranKit
+
+public enum NoteEditorMode: Equatable {
+    case create(verses: [AyahNumber])
+    case edit(Note)
+}
+#endif

--- a/Features/NoteEditorFeature/Sources/NoteEditorViewModel.swift
+++ b/Features/NoteEditorFeature/Sources/NoteEditorViewModel.swift
@@ -28,7 +28,7 @@ final class NoteEditorViewModel {
     init(
         noteService: MobileSyncNoteService,
         analytics: AnalyticsLibrary,
-        mode: Mode,
+        mode: NoteEditorMode,
         textForVerses: @escaping ([AyahNumber]) async throws -> String
     ) {
         self.noteService = noteService
@@ -44,13 +44,6 @@ final class NoteEditorViewModel {
     #endif
 
     // MARK: Internal
-
-    #if QURAN_SYNC
-    enum Mode {
-        case create(verses: [AyahNumber])
-        case edit(Note)
-    }
-    #endif
 
     enum DeleteConfirmationStyle: Equatable {
         case note
@@ -184,7 +177,7 @@ final class NoteEditorViewModel {
     #if QURAN_SYNC
     private let noteService: MobileSyncNoteService
     private let analytics: AnalyticsLibrary
-    private let mode: Mode
+    private let mode: NoteEditorMode
     private let textForVerses: ([AyahNumber]) async throws -> String
     #else
     private let noteService: NoteEditorLegacyServicing

--- a/Features/NoteEditorFeature/Tests/NoteEditorViewModelTests.swift
+++ b/Features/NoteEditorFeature/Tests/NoteEditorViewModelTests.swift
@@ -282,7 +282,7 @@ final class NoteEditorViewModelTests: XCTestCase {
 
     #if QURAN_SYNC
     private func makeSyncSUT(
-        mode: NoteEditorViewModel.Mode,
+        mode: NoteEditorMode,
         text: String = "ayah text"
     ) -> (viewModel: NoteEditorViewModel, noteService: MobileSyncNoteService, analytics: AnalyticsSpy, listener: ListenerSpy) {
         let noteService = MobileSyncNoteService(quranDataService: database.quranDataService)

--- a/Features/NotesFeature/Sources/NotesViewController.swift
+++ b/Features/NotesFeature/Sources/NotesViewController.swift
@@ -65,7 +65,11 @@ final class NotesViewController: UIHostingController<NotesView>, UISearchBarDele
     }
 
     func editNote(_ note: Note) {
+        #if QURAN_SYNC
+        let viewController = noteEditorBuilder.build(withListener: self, mode: .edit(note))
+        #else
         let viewController = noteEditorBuilder.build(withListener: self, note: note)
+        #endif
         present(viewController, animated: true)
     }
 

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -188,10 +188,10 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         }
     }
 
-    #if QURAN_SYNC
     func deleteNotes(in verses: [AyahNumber]) async {
+        #if QURAN_SYNC
         let syncedNotesObserver = deps.syncedNotesObserver
-        let notesToDelete = syncedNotesObserver.notes(interacting: verses)
+        let notesToDelete = notesInteractingVerses(verses)
         if !notesToDelete.isEmpty {
             presenter?.confirmNoteDelete(
                 delete: { [weak self] in
@@ -207,9 +207,8 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
                 cancel: { self.contentViewModel?.removeAyahMenuHighlight() }
             )
         }
-    }
-    #else
-    func deleteNotes(_ notes: [QuranAnnotations.Note], in verses: [AyahNumber]) async {
+        #else
+        let notes = notesInteractingVerses(verses)
         let containsText = notes.contains { note in
             !(note.text ?? "").isEmpty
         }
@@ -223,8 +222,8 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             // delete highlight
             await forceDeleteNotes(notes, verses: verses)
         }
+        #endif
     }
-    #endif
 
     func shareText(_ lines: [String], in sourceView: UIView, at point: CGPoint) {
         logger.info("Quran: share text")
@@ -232,23 +231,33 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         presenter?.shareText(lines, in: sourceView, at: point, completion: {})
     }
 
-    #if !QURAN_SYNC
-    func editNote(_ note: Note) {
-        dismissAyahMenu()
-        presenter?.rotateToPortraitIfPhone()
-        let viewController = deps.noteEditorBuilder.build(withListener: self, note: note)
-        presenter?.present(viewController, animated: true)
+    func showNoteEditor(for verses: [AyahNumber]) async {
+        let notes = notesInteractingVerses(verses)
+        #if QURAN_SYNC
+        let mode: NoteEditorMode = if let note = notes.first {
+            .edit(note)
+        } else {
+            .create(verses: verses)
+        }
+        presentNoteEditor(mode: mode)
+        #else
+        if let note = notes.first {
+            presentNoteEditor(note: note)
+            return
+        }
+        let color = deps.noteService.color(from: notes)
+        do {
+            let note = try await deps.noteService.updateHighlight(
+                verses: verses,
+                color: color,
+                quran: deps.quran
+            )
+            presentNoteEditor(note: note)
+        } catch {
+            crasher.recordError(error, reason: "Failed to prepare note editor")
+        }
+        #endif
     }
-    #endif
-
-    #if QURAN_SYNC
-    func addSyncedNote(verses: [AyahNumber]) {
-        dismissAyahMenu()
-        presenter?.rotateToPortraitIfPhone()
-        let viewController = deps.noteEditorBuilder.build(withListener: self, verses: verses)
-        presenter?.present(viewController, animated: true)
-    }
-    #endif
 
     func dismissNoteEditor() {
         logger.info("Quran: dismiss note editor")
@@ -280,7 +289,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             sourceView: sourceView,
             pointInView: point,
             verses: verses,
-            noteCount: syncedNoteCount(interacting: verses),
+            notes: notesInteractingVerses(verses),
             highlightVerses: deps.highlightsService.highlights.highlightVerses,
             highlightCollections: deps.syncedHighlightsObserver.collections
         )
@@ -433,19 +442,31 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             crasher.recordError(error, reason: "Failed to remove notes")
         }
     }
-
-    private func notesInteractingVerses(_ verses: [AyahNumber]) -> [Note] {
-        notes.filter { $0.intersects(verses: verses) }
-    }
     #endif
 
-    private func syncedNoteCount(interacting verses: [AyahNumber]) -> Int {
+    private func notesInteractingVerses(_ verses: [AyahNumber]) -> [Note] {
         #if QURAN_SYNC
-        deps.syncedNotesObserver.notes(interacting: verses).count
+        deps.syncedNotesObserver.notes(interacting: verses)
         #else
-        return 0
+        notes.filter { $0.intersects(verses: verses) }
         #endif
     }
+
+    #if QURAN_SYNC
+    private func presentNoteEditor(mode: NoteEditorMode) {
+        dismissAyahMenu()
+        presenter?.rotateToPortraitIfPhone()
+        let viewController = deps.noteEditorBuilder.build(withListener: self, mode: mode)
+        presenter?.present(viewController, animated: true)
+    }
+    #else
+    private func presentNoteEditor(note: Note) {
+        dismissAyahMenu()
+        presenter?.rotateToPortraitIfPhone()
+        let viewController = deps.noteEditorBuilder.build(withListener: self, note: note)
+        presenter?.present(viewController, animated: true)
+    }
+    #endif
 
     private func dismissWordPointer() {
         logger.info("Quran: dismiss word pointer")

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
@@ -54,8 +54,7 @@ public enum AyahMenuUI {
             repeatSubtitle: String,
             actions: Actions,
             isTranslationView: Bool,
-            usesSyncedNotesIcon: Bool = false,
-            noteCount: Int = 0
+            usesSyncedNotesIcon: Bool = false
         ) {
             self.highlightingColor = highlightingColor
             self.state = state
@@ -64,7 +63,6 @@ public enum AyahMenuUI {
             self.actions = actions
             self.isTranslationView = isTranslationView
             self.usesSyncedNotesIcon = usesSyncedNotesIcon
-            self.noteCount = noteCount
         }
 
         // MARK: Internal
@@ -76,7 +74,6 @@ public enum AyahMenuUI {
         let repeatSubtitle: String
         let isTranslationView: Bool
         let usesSyncedNotesIcon: Bool
-        let noteCount: Int
     }
 
     // MARK: Public

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
@@ -90,10 +90,6 @@ private struct AyahMenuViewList: View {
     var addNote: some View {
         Row(title: l("ayah.menu.add-note"), action: dataObject.actions.addNote) {
             noteIcon(legacySystemName: "plus.bubble.fill")
-        } accessory: {
-            if dataObject.noteCount > 0 {
-                NoteCountBadge(count: dataObject.noteCount)
-            }
         }
     }
 
@@ -206,22 +202,6 @@ private struct AyahMenuViewList: View {
                     .foregroundColor(dataObject.highlightingColor.color)
             }
         }
-    }
-}
-
-private struct NoteCountBadge: View {
-    let count: Int
-
-    @ScaledMetric private var horizontalPadding = ContentDimension.interPageSpacing
-    @ScaledMetric private var verticalPadding = ContentDimension.interSpacing
-
-    var body: some View {
-        Text(NumberFormatter.shared.format(count))
-            .font(.footnote)
-            .foregroundColor(Color.label)
-            .padding(.horizontal, horizontalPadding)
-            .padding(.vertical, verticalPadding)
-            .background(Capsule().fill(Color(.secondarySystemFill)))
     }
 }
 


### PR DESCRIPTION
## Summary

- route note-editor presentation through `QuranInteractor` for both sync modes
- edit the first intersecting note instead of always creating a synced note
- expose `NoteEditorMode` as the shared editor input
- remove note-count state and its badge from the ayah menu
- consolidate the note listener callbacks across sync configurations

## Root cause

The synced ayah-menu path only passed selected verses to the listener, so the Quran feature always launched the editor in create mode even when an intersecting note already existed.

## Impact

Selecting Add/Edit Note now opens the existing intersecting note when available. A new note is prepared only when no note exists. The non-sync path follows the same first-note behavior without rewriting an existing note's verse association.

## Validation

- `make format-lint`
- `make test-no-sync`
- `make test-sync`
- `git diff --check`