### PR TITLE
Unify Quran notes observation across sync modes

### DIFF
--- a/Features/QuranViewFeature/QuranBuilder.swift
+++ b/Features/QuranViewFeature/QuranBuilder.swift
@@ -39,8 +39,7 @@ public struct QuranBuilder {
         let quran = ReadingPreferences.shared.reading.quran
         let pageBookmarkService = PageBookmarkService(persistence: container.pageBookmarkPersistence)
         #if QURAN_SYNC
-        let syncedNoteService = container.mobileSyncNoteService()
-        let syncedNotesObserver = QuranSyncedNotesObserver(noteService: syncedNoteService, quran: quran)
+        let notesObserver = QuranNotesObserver(noteService: container.mobileSyncNoteService(), quran: quran)
         let syncedHighlightsObserver = QuranSyncedHighlightsObserver(
             ayahBookmarkCollectionService: AyahBookmarkCollectionService(quranDataService: container.quranDataService),
             highlightsService: highlightsService
@@ -58,11 +57,13 @@ public struct QuranBuilder {
             translationsSelectionBuilder: TranslationsListBuilder(container: container),
             translationVerseBuilder: TranslationVerseBuilder(container: container),
             resources: container.readingResources,
-            syncedNotesObserver: syncedNotesObserver,
+            notesObserver: notesObserver,
             noteEditorBuilder: NoteEditorBuilder(container: container),
             syncedHighlightsObserver: syncedHighlightsObserver
         )
         #else
+        let noteService = container.noteService()
+        let notesObserver = QuranNotesObserver(noteService: noteService, quran: quran)
         let interactorDeps = QuranInteractor.Deps(
             quran: quran,
             analytics: container.analytics,
@@ -76,8 +77,9 @@ public struct QuranBuilder {
             translationsSelectionBuilder: TranslationsListBuilder(container: container),
             translationVerseBuilder: TranslationVerseBuilder(container: container),
             resources: container.readingResources,
-            noteService: container.noteService(),
-            noteEditorBuilder: NoteEditorBuilder(container: container)
+            notesObserver: notesObserver,
+            noteEditorBuilder: NoteEditorBuilder(container: container),
+            noteService: noteService
         )
         #endif
         let interactor = QuranInteractor(deps: interactorDeps, input: input)

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -71,13 +71,12 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let translationsSelectionBuilder: TranslationsListBuilder
         let translationVerseBuilder: TranslationVerseBuilder
         let resources: ReadingResourcesService
-        #if QURAN_SYNC
-        let syncedNotesObserver: QuranSyncedNotesObserver
+        let notesObserver: QuranNotesObserver
         let noteEditorBuilder: NoteEditorBuilder
+        #if QURAN_SYNC
         let syncedHighlightsObserver: QuranSyncedHighlightsObserver
         #else
         let noteService: NoteService
-        let noteEditorBuilder: NoteEditorBuilder
         #endif
     }
 
@@ -106,11 +105,9 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     var visiblePages: [Page] { contentViewModel?.visiblePages ?? [] }
 
     func start() {
+        deps.notesObserver.start()
         #if QURAN_SYNC
         deps.syncedHighlightsObserver.start()
-        deps.syncedNotesObserver.start()
-        #else
-        startLegacyNotesObservation()
         #endif
 
         deps.pageBookmarkService.pageBookmarks(quran: deps.quran)
@@ -190,7 +187,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
     func deleteNotes(in verses: [AyahNumber]) async {
         #if QURAN_SYNC
-        let syncedNotesObserver = deps.syncedNotesObserver
+        let notesObserver = deps.notesObserver
         let notesToDelete = notesInteractingVerses(verses)
         if !notesToDelete.isEmpty {
             presenter?.confirmNoteDelete(
@@ -198,7 +195,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
                     do {
                         self?.contentViewModel?.removeAyahMenuHighlight()
                         for note in notesToDelete {
-                            try await syncedNotesObserver.remove(note)
+                            try await notesObserver.remove(note)
                         }
                     } catch {
                         crasher.recordError(error, reason: "Failed to delete synced notes")
@@ -245,13 +242,8 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             presentNoteEditor(note: note)
             return
         }
-        let color = deps.noteService.color(from: notes)
         do {
-            let note = try await deps.noteService.updateHighlight(
-                verses: verses,
-                color: color,
-                quran: deps.quran
-            )
+            let note = try await deps.notesObserver.prepareNote(for: verses)
             presentNoteEditor(note: note)
         } catch {
             crasher.recordError(error, reason: "Failed to prepare note editor")
@@ -374,10 +366,6 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     private let contentStatePreferences = QuranContentStatePreferences.shared
     private let selectedTranslationsPreferences = SelectedTranslationsPreferences.shared
 
-    #if !QURAN_SYNC
-    private var notes: [Note] = []
-    #endif
-
     private var deps: Deps
     private let input: QuranInput
     private var audioBanner: AudioBannerViewModel?
@@ -401,15 +389,6 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             reloadPageBookmark()
         }
     }
-
-    #if !QURAN_SYNC
-    private func startLegacyNotesObservation() {
-        deps.noteService.notes(quran: deps.quran)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in self?.notes = $0 }
-            .store(in: &cancellables)
-    }
-    #endif
 
     private func setVisiblePages(_ pages: [Page]) {
         logger.info("Quran: set visible pages \(pages)")
@@ -445,11 +424,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     #endif
 
     private func notesInteractingVerses(_ verses: [AyahNumber]) -> [Note] {
-        #if QURAN_SYNC
-        deps.syncedNotesObserver.notes(interacting: verses)
-        #else
-        notes.filter { $0.intersects(verses: verses) }
-        #endif
+        deps.notesObserver.notes(interacting: verses)
     }
 
     #if QURAN_SYNC

--- a/Features/QuranViewFeature/QuranNotesObserver.swift
+++ b/Features/QuranViewFeature/QuranNotesObserver.swift
@@ -1,25 +1,36 @@
-#if QURAN_SYNC
 import AnnotationsService
 import Combine
+#if QURAN_SYNC
 import Crashing
+#endif
+import Foundation
 import QuranAnnotations
 import QuranKit
-import VLogging
 
 @MainActor
-final class QuranSyncedNotesObserver {
+final class QuranNotesObserver {
+    #if QURAN_SYNC
     init(noteService: MobileSyncNoteService, quran: Quran) {
         self.noteService = noteService
         self.quran = quran
     }
+    #else
+    init(noteService: NoteService, quran: Quran) {
+        self.noteService = noteService
+        self.quran = quran
+    }
+    #endif
 
     deinit {
+        #if QURAN_SYNC
         task?.cancel()
+        #endif
     }
 
     @Published private(set) var notes: [Note] = []
 
     func start() {
+        #if QURAN_SYNC
         guard task == nil else {
             return
         }
@@ -32,21 +43,42 @@ final class QuranSyncedNotesObserver {
                 }
             } catch is CancellationError {
             } catch {
-                crasher.recordError(error, reason: "Failed to observe synced notes")
+                crasher.recordError(error, reason: "Failed to observe notes")
             }
         }
+        #else
+        guard observation == nil else {
+            return
+        }
+        observation = noteService.notes(quran: quran)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in self?.notes = $0 }
+        #endif
     }
 
     func notes(interacting verses: [AyahNumber]) -> [Note] {
         notes.filter { $0.intersects(verses: verses) }
     }
 
+    #if !QURAN_SYNC
+    func prepareNote(for verses: [AyahNumber]) async throws -> Note {
+        let color = noteService.color(from: notes(interacting: verses))
+        return try await noteService.updateHighlight(verses: verses, color: color, quran: quran)
+    }
+    #endif
+
+    #if QURAN_SYNC
     func remove(_ note: Note) async throws {
         try await noteService.removeNote(note)
     }
+    #endif
 
+    #if QURAN_SYNC
     private let noteService: MobileSyncNoteService
-    private let quran: Quran
     private var task: Task<Void, Never>?
+    #else
+    private let noteService: NoteService
+    private var observation: AnyCancellable?
+    #endif
+    private let quran: Quran
 }
-#endif

--- a/Features/QuranViewFeature/Tests/QuranNotesObserverTests.swift
+++ b/Features/QuranViewFeature/Tests/QuranNotesObserverTests.swift
@@ -8,7 +8,7 @@ import XCTest
 @testable import QuranViewFeature
 
 @MainActor
-final class QuranSyncedNotesObserverTests: XCTestCase {
+final class QuranNotesObserverTests: XCTestCase {
     private let database = MobileSyncTestDatabase.shared
     private var noteService: MobileSyncNoteService!
 
@@ -26,7 +26,7 @@ final class QuranSyncedNotesObserverTests: XCTestCase {
 
     func test_start_observesPersistedNotesFromMobileSyncDatabase() async throws {
         try await noteService.createNote(body: "Stored note", startAyah: ayah(1), endAyah: ayah(2))
-        let sut = QuranSyncedNotesObserver(noteService: noteService, quran: .hafsMadani1405)
+        let sut = QuranNotesObserver(noteService: noteService, quran: .hafsMadani1405)
         let observed = expectation(description: "Observes persisted note")
         let observation = sut.$notes.sink { notes in
             if notes.map(\.text) == ["Stored note"] {
@@ -46,7 +46,7 @@ final class QuranSyncedNotesObserverTests: XCTestCase {
         try await noteService.createNote(body: "Delete me", startAyah: ayah(1), endAyah: ayah(1))
         let notes = try await storedNotes()
         let note = try XCTUnwrap(notes.first)
-        let sut = QuranSyncedNotesObserver(noteService: noteService, quran: .hafsMadani1405)
+        let sut = QuranNotesObserver(noteService: noteService, quran: .hafsMadani1405)
 
         try await sut.remove(note)
 


### PR DESCRIPTION
## Summary

- rename `QuranSyncedNotesObserver` to `QuranNotesObserver`
- make it observe notes in both sync and legacy builds
- use the observer as `QuranInteractor`'s single live `[Note]` source
- move legacy note preparation and highlight-color selection behind the observer
- remove the interactor's separate legacy notes cache

## Why

The Quran feature maintained notes through two different paths: a sync-only observer and a legacy Combine subscription inside `QuranInteractor`. This duplicated state ownership and left persistence orchestration in the interactor.

## Impact

Both configurations now expose the same note observation and intersection API. `QuranInteractor` focuses on presentation decisions while the observer owns note retrieval and legacy note preparation.

## Stack

This PR is stacked on #869 and targets `afifi/fix-ayah-menu-note-editing`.

## Validation

- `make format-lint`
- `make test-no-sync`
- `make test-sync`
- `git diff --check`