### PR TITLE
refactor: require authentication client

### DIFF
--- a/Data/AuthenticationClient/Sources/AuthenticationClient.swift
+++ b/Data/AuthenticationClient/Sources/AuthenticationClient.swift
@@ -12,11 +12,11 @@ import MobileSync
 import UIKit
 
 public enum AuthenticationClientError: Error {
-    case errorAuthenticating(Error?)
+    case errorAuthenticating(Error)
 
     /// Thrown when an operation, that needs authentication, is attempted while the client
     /// hasn't been authenticated or if the client's access has been revoked.
-    case clientIsNotAuthenticated(Error?)
+    case clientIsNotAuthenticated(Error)
 }
 
 public enum AuthenticationState: Equatable {

--- a/Data/AuthenticationClient/Tests/AuthenticationClientTests.swift
+++ b/Data/AuthenticationClient/Tests/AuthenticationClientTests.swift
@@ -17,7 +17,7 @@ final class AuthenticationClientTests: XCTestCase {
 
     func testSafelyRestoreStateReturnsCurrentStateOnFailure() async {
         let sut = AuthenticationClientFake()
-        sut.restoreStateResult = .failure(.clientIsNotAuthenticated(nil))
+        sut.restoreStateResult = .failure(.clientIsNotAuthenticated(NSError(domain: "test", code: 1)))
         sut.authenticationStateValue = .authenticated
 
         let state = await sut.safelyRestoreState()

--- a/Data/AuthenticationClientFake/AuthenticationClientFake.swift
+++ b/Data/AuthenticationClientFake/AuthenticationClientFake.swift
@@ -78,7 +78,7 @@ public final class UnavailableAuthenticationClient: AuthenticationClient {
     }
 
     public func login(on _: UIViewController) async throws(AuthenticationClientError) {
-        throw .clientIsNotAuthenticated(nil)
+        throw .clientIsNotAuthenticated(UnavailableAuthenticationClientError())
     }
 
     public func restoreState() async throws(AuthenticationClientError) -> AuthenticationState {
@@ -86,16 +86,18 @@ public final class UnavailableAuthenticationClient: AuthenticationClient {
     }
 
     public func logout() async throws(AuthenticationClientError) {
-        throw .clientIsNotAuthenticated(nil)
+        throw .clientIsNotAuthenticated(UnavailableAuthenticationClientError())
     }
 
     public func authenticate(request _: URLRequest) async throws(AuthenticationClientError) -> URLRequest {
-        throw .clientIsNotAuthenticated(nil)
+        throw .clientIsNotAuthenticated(UnavailableAuthenticationClientError())
     }
 
     public func getAuthenticationHeaders() async throws(AuthenticationClientError) -> [String: String] {
-        throw .clientIsNotAuthenticated(nil)
+        throw .clientIsNotAuthenticated(UnavailableAuthenticationClientError())
     }
 }
+
+private struct UnavailableAuthenticationClientError: Error {}
 
 #endif

--- a/Example/QuranEngineApp/Classes/Container.swift
+++ b/Example/QuranEngineApp/Classes/Container.swift
@@ -45,7 +45,7 @@ class Container: AppDependencies {
     #if QURAN_SYNC
     private(set) lazy var quranDataService: QuranDataService = syncAppGraph.quranDataService
 
-    private(set) lazy var authenticationClient: (any AuthenticationClient)? = {
+    private(set) lazy var authenticationClient: any AuthenticationClient = {
         let authService = syncAppGraph.authService
         let quranDataService = syncAppGraph.quranDataService
         return AuthenticationClientMobileSyncImpl(authService: authService, quranDataService: quranDataService)

--- a/Features/AppDependencies/AppDependencies.swift
+++ b/Features/AppDependencies/AppDependencies.swift
@@ -42,7 +42,7 @@ public protocol AppDependencies {
     var pageBookmarkPersistence: PageBookmarkPersistence { get }
 
     #if QURAN_SYNC
-    var authenticationClient: (any AuthenticationClient)? { get }
+    var authenticationClient: any AuthenticationClient { get }
     var quranDataService: QuranDataService { get }
     #endif
 }

--- a/Features/BookmarksFeature/Sources/BookmarksViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksViewModel.swift
@@ -27,7 +27,7 @@ final class BookmarksViewModel: ObservableObject {
     init(
         analytics: AnalyticsLibrary,
         service: PageBookmarkService,
-        authenticationClient: (any AuthenticationClient)?,
+        authenticationClient: any AuthenticationClient,
         navigateTo: @escaping (Page) -> Void,
         showCollectionsAction: (@MainActor (UIViewController) async -> Void)? = nil,
         showOldPageBookmarksAction: (@MainActor (UIViewController) async -> Void)? = nil
@@ -88,11 +88,7 @@ final class BookmarksViewModel: ObservableObject {
 
     func start() async {
         #if QURAN_SYNC
-        if let authenticationClient {
-            isAuthenticated = await authenticationClient.safelyRestoreState() == .authenticated
-        } else {
-            isAuthenticated = false
-        }
+        isAuthenticated = await authenticationClient.safelyRestoreState() == .authenticated
         #endif
 
         let bookmarksSequence = readingPreferences.$reading
@@ -141,7 +137,6 @@ final class BookmarksViewModel: ObservableObject {
         }
 
         do {
-            let authenticationClient = try requireAuthenticationClient()
             try await authenticationClient.login(on: presenter)
             isAuthenticated = true
         } catch {
@@ -177,16 +172,9 @@ final class BookmarksViewModel: ObservableObject {
     private let service: PageBookmarkService
     private let readingPreferences = ReadingPreferences.shared
     #if QURAN_SYNC
-    private var authenticationClient: (any AuthenticationClient)?
+    private var authenticationClient: any AuthenticationClient
     private var presentCollectionsAction: (@MainActor (UIViewController) async -> Void)?
     private var presentOldPageBookmarksAction: (@MainActor (UIViewController) async -> Void)?
     private let preferences = BookmarksPreferences.shared
-
-    private func requireAuthenticationClient() throws -> any AuthenticationClient {
-        guard let authenticationClient else {
-            throw AuthenticationClientError.clientIsNotAuthenticated(nil)
-        }
-        return authenticationClient
-    }
     #endif
 }

--- a/Features/BookmarksFeature/Tests/BookmarksViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarksViewModelTests.swift
@@ -80,17 +80,6 @@ final class BookmarksViewModelTests: XCTestCase {
         XCTAssertNil(sut.error)
     }
 
-    func test_loginToQuranCom_setsError_whenClientIsMissing() async {
-        let sut = makeSyncSUT(authenticationClient: nil)
-        let presenter = UIViewController()
-        sut.presenter = presenter
-
-        await sut.loginToQuranCom()
-
-        guard case .clientIsNotAuthenticated = sut.error as? AuthenticationClientError else {
-            return XCTFail("Expected clientIsNotAuthenticated, got \(String(describing: sut.error))")
-        }
-    }
     #endif
 
     // MARK: Private
@@ -114,7 +103,7 @@ final class BookmarksViewModelTests: XCTestCase {
     }
 
     #if QURAN_SYNC
-    private func makeSyncSUT(authenticationClient: (any AuthenticationClient)?) -> BookmarksViewModel {
+    private func makeSyncSUT(authenticationClient: any AuthenticationClient) -> BookmarksViewModel {
         let service = PageBookmarkService(persistence: PageBookmarkPersistenceSpy())
         return BookmarksViewModel(
             analytics: AnalyticsSpy(),

--- a/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
@@ -32,7 +32,7 @@ final class SettingsRootViewModel: ObservableObject {
     init(
         analytics: AnalyticsLibrary,
         reviewService: ReviewService,
-        authenticationClient: (any AuthenticationClient)?,
+        authenticationClient: any AuthenticationClient,
         audioDownloadsBuilder: AudioDownloadsBuilder,
         translationsListBuilder: TranslationsListBuilder,
         readingSelectorBuilder: ReadingSelectorBuilder,
@@ -199,12 +199,6 @@ final class SettingsRootViewModel: ObservableObject {
 
     #if QURAN_SYNC
     func refreshAuthenticationState() async {
-        guard let authenticationClient else {
-            isAuthenticated = false
-            loggedInUser = nil
-            return
-        }
-
         isAuthenticated = await authenticationClient.safelyRestoreState() == .authenticated
         loggedInUser = isAuthenticated ? await authenticationClient.loggedInUser : nil
     }
@@ -215,7 +209,6 @@ final class SettingsRootViewModel: ObservableObject {
         }
 
         do {
-            let authenticationClient = try requireAuthenticationClient()
             try await authenticationClient.login(on: viewController)
             isAuthenticated = true
             loggedInUser = await authenticationClient.loggedInUser
@@ -227,7 +220,6 @@ final class SettingsRootViewModel: ObservableObject {
 
     func logoutFromQuranCom() async {
         do {
-            let authenticationClient = try requireAuthenticationClient()
             try await authenticationClient.logout()
             isAuthenticated = false
             loggedInUser = nil
@@ -242,14 +234,7 @@ final class SettingsRootViewModel: ObservableObject {
 
     #if QURAN_SYNC
     private let quranProfileURL: URL
-    private var authenticationClient: (any AuthenticationClient)?
-
-    private func requireAuthenticationClient() throws -> any AuthenticationClient {
-        guard let authenticationClient else {
-            throw AuthenticationClientError.clientIsNotAuthenticated(nil)
-        }
-        return authenticationClient
-    }
+    private var authenticationClient: any AuthenticationClient
     #endif
 
     private func showSingleChoiceSelector<T: Hashable>(

--- a/Features/SettingsFeature/Tests/SettingsRootViewModelTests.swift
+++ b/Features/SettingsFeature/Tests/SettingsRootViewModelTests.swift
@@ -117,7 +117,7 @@ final class SettingsRootViewModelTests: XCTestCase {
         return SettingsRootViewModel(
             analytics: AnalyticsSpy(),
             reviewService: ReviewService(analytics: AnalyticsSpy()),
-            authenticationClient: authenticationClient,
+            authenticationClient: authenticationClient ?? UnavailableAuthenticationClient(),
             audioDownloadsBuilder: AudioDownloadsBuilder(container: container),
             translationsListBuilder: TranslationsListBuilder(container: container),
             readingSelectorBuilder: ReadingSelectorBuilder(container: container),
@@ -139,7 +139,7 @@ private struct AnalyticsSpy: AnalyticsLibrary {
 }
 
 private struct AppDependenciesStub: AppDependencies {
-    let authenticationClient: (any AuthenticationClient)?
+    let authenticationClient: any AuthenticationClient
 
     var databasesURL: URL { URL(fileURLWithPath: "/tmp") }
     var wordsDatabase: URL { URL(fileURLWithPath: "/tmp/words.db") }


### PR DESCRIPTION
## Summary

- make the sync authentication client dependency non-optional
- remove unreachable missing-client fallbacks in bookmarks and settings
- require underlying authentication errors to be present

## Why

The sync app graph always provides an authentication client, so modeling it as optional adds unreachable states and defensive branches throughout feature view models.

## Impact

Sync-enabled feature code can use the authentication client directly. No-sync builds remain protected by `QURAN_SYNC`.

## Validation

- `git diff --cached --check`
- CI not awaited, per request