### PR TITLE
Allow deleting old page bookmarks

### DIFF
--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
@@ -21,8 +21,41 @@ public struct AyahCollectionBookmark {
     public let ayah: AyahNumber
 }
 
-enum AyahBookmarkCollectionName {
+private enum AyahBookmarkCollectionName {
     static let oldPageBookmarks = "Old Page Bookmarks"
+}
+
+enum AyahBookmarkCollectionKind: Equatable {
+    case oldPageBookmarks
+    case colored(HighlightColor)
+    case user
+
+    fileprivate init(collection: Collection_) {
+        if collection.name == AyahBookmarkCollectionName.oldPageBookmarks {
+            self = .oldPageBookmarks
+        } else if let color = HighlightColor(collectionName: collection.name) {
+            self = .colored(color)
+        } else {
+            self = .user
+        }
+    }
+
+    var highlightColor: HighlightColor? {
+        guard case .colored(let color) = self else {
+            return nil
+        }
+        return color
+    }
+
+    var isOldPageBookmarks: Bool {
+        self == .oldPageBookmarks
+    }
+}
+
+extension AyahBookmarkCollection {
+    var kind: AyahBookmarkCollectionKind {
+        AyahBookmarkCollectionKind(collection: collection)
+    }
 }
 
 public struct AyahBookmarkCollectionsSequence: AsyncSequence {

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
@@ -21,8 +21,7 @@ struct AyahBookmarkCollectionsBuilder {
     }
 
     func buildCollection(_ collection: AyahBookmarkCollection) -> UIViewController {
-        let highlightColor = HighlightColor(collectionName: collection.collection.name)
-        let isOldPageBookmarks = collection.collection.name == AyahBookmarkCollectionName.oldPageBookmarks
+        let kind = collection.kind
         let viewModel = AyahBookmarkCollectionsViewModel(
             ayahBookmarkCollectionService: ayahBookmarkCollectionService,
             collectionLocalID: collection.collection.localId,
@@ -30,8 +29,7 @@ struct AyahBookmarkCollectionsBuilder {
         )
         return AyahBookmarkCollectionsViewController(
             viewModel: viewModel,
-            title: highlightColor?.localizedName ?? collection.collection.name,
-            allowsBookmarkDeletion: !isOldPageBookmarks
+            title: kind.highlightColor?.localizedName ?? collection.collection.name
         )
     }
 

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
@@ -15,25 +15,17 @@ import UIx
 struct AyahBookmarkCollectionsView: View {
     // MARK: Lifecycle
 
-    init(
-        viewModel: AyahBookmarkCollectionsViewModel,
-        allowsBookmarkDeletion: Bool = true
-    ) {
+    init(viewModel: AyahBookmarkCollectionsViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
-        self.allowsBookmarkDeletion = allowsBookmarkDeletion
     }
 
     // MARK: Internal
 
     @StateObject var viewModel: AyahBookmarkCollectionsViewModel
-    let allowsBookmarkDeletion: Bool
 
     var body: some View {
         NoorList {
-            AyahBookmarkCollectionsContent(
-                viewModel: viewModel,
-                allowsBookmarkDeletion: allowsBookmarkDeletion
-            )
+            AyahBookmarkCollectionsContent(viewModel: viewModel)
         }
         .task { await viewModel.start() }
         .errorAlert(error: $viewModel.error)
@@ -43,7 +35,6 @@ struct AyahBookmarkCollectionsView: View {
 @MainActor
 struct AyahBookmarkCollectionsContent: View {
     @ObservedObject var viewModel: AyahBookmarkCollectionsViewModel
-    let allowsBookmarkDeletion: Bool
     @State private var isExpanded = true
 
     var body: some View {
@@ -66,18 +57,9 @@ struct AyahBookmarkCollectionsContent: View {
         )
     }
 
-    private var deleteBookmarkAction: AsyncItemAction<AyahCollectionBookmark>? {
-        guard allowsBookmarkDeletion else {
-            return nil
-        }
-        return { bookmark in
-            await viewModel.deleteBookmark(bookmark)
-        }
-    }
-
     @ViewBuilder
     private func section(for collection: AyahBookmarkCollection) -> some View {
-        let highlightColor = HighlightColor(collectionName: collection.collection.name)
+        let highlightColor = collection.kind.highlightColor
 
         NoorEditableCollapsibleSection(
             title: highlightColor?.localizedName ?? collection.collection.name,
@@ -88,7 +70,9 @@ struct AyahBookmarkCollectionsContent: View {
         ) { bookmark in
             bookmarkItem(bookmark, iconColor: highlightColor?.color)
         }
-        .onDelete(action: deleteBookmarkAction)
+        .onDelete { bookmark in
+            await viewModel.deleteBookmark(bookmark)
+        }
     }
 
     private func bookmarkItem(_ bookmark: AyahCollectionBookmark, iconColor: Color?) -> some View {

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
@@ -14,15 +14,9 @@ final class AyahBookmarkCollectionsViewController: UIHostingController<AyahBookm
 
     init(
         viewModel: AyahBookmarkCollectionsViewModel,
-        title: String = l("bookmarks.collections"),
-        allowsBookmarkDeletion: Bool = true
+        title: String = l("bookmarks.collections")
     ) {
-        super.init(
-            rootView: AyahBookmarkCollectionsView(
-                viewModel: viewModel,
-                allowsBookmarkDeletion: allowsBookmarkDeletion
-            )
-        )
+        super.init(rootView: AyahBookmarkCollectionsView(viewModel: viewModel))
         self.title = title
     }
 

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
@@ -49,17 +49,7 @@ private struct BookmarkCollectionsContent: View {
             }
 
             NoorBasicSection(title: l("bookmarks.collections.mine")) {
-                if let collection = viewModel.oldPageBookmarksCollection {
-                    collectionRow(
-                        title: l("bookmarks.old-page-bookmarks"),
-                        image: .book,
-                        imageColor: .secondaryLabel,
-                        collection: collection
-                    )
-                    .deleteDisabled(true)
-                }
-
-                if userCollections.isEmpty, viewModel.oldPageBookmarksCollection == nil {
+                if viewModel.deletableCollections.isEmpty {
                     NoorListEmptyState(
                         title: l("bookmarks.collections.no-data.title"),
                         text: l("bookmarks.collections.no-data.text"),
@@ -67,16 +57,16 @@ private struct BookmarkCollectionsContent: View {
                     )
                 }
 
-                ForEach(userCollections) { collection in
+                ForEach(viewModel.deletableCollections) { collection in
                     collectionRow(
-                        title: collection.collection.name,
-                        image: .folder,
-                        imageColor: .appIdentity,
+                        title: collectionTitle(collection),
+                        image: collectionImage(collection),
+                        imageColor: collectionImageColor(collection),
                         collection: collection
                     )
                 }
                 .onDelete { offsets in
-                    let collections = offsets.map { userCollections[$0] }
+                    let collections = offsets.map { viewModel.deletableCollections[$0] }
                     Task {
                         for collection in collections {
                             await viewModel.deleteCollection(collection)
@@ -99,16 +89,23 @@ private struct BookmarkCollectionsContent: View {
         .environment(\.editMode, $viewModel.editMode)
     }
 
-    private var userCollections: [AyahBookmarkCollection] {
-        viewModel.collections.filter {
-            $0.collection.name != AyahBookmarkCollectionName.oldPageBookmarks &&
-                HighlightColor(collectionName: $0.collection.name) == nil
-        }
+    private func collectionTitle(_ collection: AyahBookmarkCollection) -> String {
+        collection.kind.isOldPageBookmarks
+            ? l("bookmarks.old-page-bookmarks")
+            : collection.collection.name
+    }
+
+    private func collectionImage(_ collection: AyahBookmarkCollection) -> NoorSystemImage {
+        collection.kind.isOldPageBookmarks ? .book : .folder
+    }
+
+    private func collectionImageColor(_ collection: AyahBookmarkCollection) -> Color {
+        collection.kind.isOldPageBookmarks ? .secondaryLabel : .appIdentity
     }
 
     private func highlightCollection(for color: HighlightColor) -> AyahBookmarkCollection? {
         viewModel.collections.first {
-            $0.collection.name == color.collectionName
+            $0.kind == .colored(color)
         }
     }
 

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewController.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewController.swift
@@ -33,9 +33,19 @@ private final class BookmarkCollectionsMenuController {
         self.viewController = viewController
         self.viewModel = viewModel
 
-        updateMenuButton(editMode: viewModel.editMode)
-        viewModel.$editMode
-            .sink { [weak self] editMode in self?.updateMenuButton(editMode: editMode) }
+        updateMenuButton(
+            editMode: viewModel.editMode,
+            hasDeletableCollections: viewModel.hasDeletableCollections
+        )
+        Publishers.CombineLatest(viewModel.$editMode, viewModel.$collections)
+            .sink { [weak self] editMode, collections in
+                self?.updateMenuButton(
+                    editMode: editMode,
+                    hasDeletableCollections: !BookmarkCollectionsViewModel
+                        .deletableCollections(from: collections)
+                        .isEmpty
+                )
+            }
             .store(in: &cancellables)
     }
 
@@ -43,7 +53,7 @@ private final class BookmarkCollectionsMenuController {
     private let viewModel: BookmarkCollectionsViewModel
     private var cancellables: Set<AnyCancellable> = []
 
-    private func updateMenuButton(editMode: EditMode) {
+    private func updateMenuButton(editMode: EditMode, hasDeletableCollections: Bool) {
         guard let viewController else {
             return
         }
@@ -66,7 +76,7 @@ private final class BookmarkCollectionsMenuController {
             )
             doneButton.tintColor = .appIdentity
             viewController.navigationItem.leftBarButtonItem = doneButton
-        } else {
+        } else if hasDeletableCollections {
             let editButton = UIBarButtonItem(
                 title: l("bookmarks.collections.edit.action"),
                 primaryAction: UIAction { [weak self] _ in
@@ -75,6 +85,8 @@ private final class BookmarkCollectionsMenuController {
             )
             editButton.tintColor = .appIdentity
             viewController.navigationItem.leftBarButtonItem = editButton
+        } else {
+            viewController.navigationItem.leftBarButtonItem = nil
         }
     }
 }

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -44,8 +44,16 @@ final class BookmarkCollectionsViewModel: ObservableObject {
 
     var oldPageBookmarksCollection: AyahBookmarkCollection? {
         collections.first {
-            $0.collection.name == AyahBookmarkCollectionName.oldPageBookmarks
+            $0.kind.isOldPageBookmarks
         }
+    }
+
+    var deletableCollections: [AyahBookmarkCollection] {
+        Self.deletableCollections(from: collections)
+    }
+
+    var hasDeletableCollections: Bool {
+        !deletableCollections.isEmpty
     }
 
     static func sorted(_ collections: [AyahBookmarkCollection]) -> [AyahBookmarkCollection] {
@@ -61,6 +69,14 @@ final class BookmarkCollectionsViewModel: ObservableObject {
                 return lhs.collection.name.localizedCaseInsensitiveCompare(rhs.collection.name) == .orderedAscending
             }
         }
+    }
+
+    static func deletableCollections(from collections: [AyahBookmarkCollection]) -> [AyahBookmarkCollection] {
+        let oldPageBookmarks = collections.filter(\.kind.isOldPageBookmarks)
+        let userCollections = collections.filter {
+            $0.kind == .user
+        }
+        return oldPageBookmarks + userCollections
     }
 
     func start() async {
@@ -130,7 +146,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     private weak var navigationController: UINavigationController?
 
     private static func highlightSortIndex(_ collection: AyahBookmarkCollection) -> Int? {
-        guard let color = HighlightColor(collectionName: collection.collection.name) else {
+        guard let color = collection.kind.highlightColor else {
             return nil
         }
         return HighlightColor.sortedColors.firstIndex(of: color)
@@ -139,7 +155,11 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     private func observeCollections() async {
         do {
             for try await collections in ayahBookmarkCollectionService.collectionsSequence() {
-                self.collections = Self.sorted(collections)
+                let collections = Self.sorted(collections)
+                self.collections = collections
+                if Self.deletableCollections(from: collections).isEmpty {
+                    editMode = .inactive
+                }
             }
         } catch {
             self.error = error

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
@@ -9,6 +9,7 @@ import XCTest
 @MainActor
 final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
     private let database = MobileSyncTestDatabase.shared
+    private let oldPageBookmarksCollectionName = "Old Page Bookmarks"
 
     override func setUp() async throws {
         try await super.setUp()
@@ -41,6 +42,32 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
         XCTAssertNil(sut.error)
         task.cancel()
         observation.cancel()
+    }
+
+    func test_deleteBookmark_removesOldPageBookmarkFromMobileSyncDatabase() async throws {
+        let service = makeService()
+        try await service.createCollection(named: oldPageBookmarksCollectionName)
+        var stored = try await storedCollections()
+        let storedCollection = try XCTUnwrap(stored.first)
+        try await service.addAyahBookmarkToCollection(
+            collectionLocalId: storedCollection.collection.localId,
+            ayah: AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
+        )
+        stored = try await storedCollections()
+        let collection = try XCTUnwrap(
+            AyahBookmarkCollectionService
+                .collections(from: stored, quran: .hafsMadani1405)
+                .first
+        )
+        let bookmark = try XCTUnwrap(collection.bookmarks.first)
+        let sut = makeSUT(collectionLocalID: collection.collection.localId, service: service)
+
+        await sut.deleteBookmark(bookmark)
+
+        stored = try await storedCollections()
+        let updatedCollection = try XCTUnwrap(stored.first)
+        XCTAssertTrue(updatedCollection.bookmarks.isEmpty)
+        XCTAssertNil(sut.error)
     }
 
     private func makeSUT(

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -12,6 +12,7 @@ import XCTest
 @MainActor
 final class BookmarkCollectionsViewModelTests: XCTestCase {
     private let database = MobileSyncTestDatabase.shared
+    private let oldPageBookmarksCollectionName = "Old Page Bookmarks"
 
     override func setUp() async throws {
         try await super.setUp()
@@ -39,6 +40,47 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
             "A Collection",
             "Z Collection",
         ])
+    }
+
+    func test_deletableCollections_includesOldPageBookmarksAndUserCollections() {
+        let collections = BookmarkCollectionsViewModel.deletableCollections(from: [
+            collection(name: "red"),
+            collection(name: "Favorites"),
+            collection(name: oldPageBookmarksCollectionName),
+        ])
+
+        XCTAssertEqual(collections.map(\.collection.name), [
+            oldPageBookmarksCollectionName,
+            "Favorites",
+        ])
+    }
+
+    func test_collectionKind_classifiesOldColoredAndUserCollections() {
+        XCTAssertEqual(
+            collection(name: oldPageBookmarksCollectionName).kind,
+            .oldPageBookmarks
+        )
+        XCTAssertEqual(collection(name: "red").kind, .colored(.red))
+        XCTAssertEqual(collection(name: "Favorites").kind, .user)
+    }
+
+    func test_collectionsViewController_hidesEditButtonWithoutDeletableCollections() {
+        let viewController = BookmarkCollectionsViewController(viewModel: makeSUT())
+
+        XCTAssertNil(viewController.navigationItem.leftBarButtonItem)
+    }
+
+    func test_collectionsViewController_showsEditButtonForOldPageBookmarks() async throws {
+        let service = makeService()
+        try await service.createCollection(named: oldPageBookmarksCollectionName)
+        let sut = makeSUT(collectionService: service)
+        let viewController = BookmarkCollectionsViewController(viewModel: sut)
+
+        let task = Task { await sut.start() }
+        await waitUntil { viewController.navigationItem.leftBarButtonItem != nil }
+
+        XCTAssertNotNil(viewController.navigationItem.leftBarButtonItem)
+        task.cancel()
     }
 
     func test_start_setsAuthenticatedState_whenRestoreSucceeds() async {
@@ -131,7 +173,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
 
     func test_start_readsOldPageBookmarkCountFromMobileSync() async throws {
         let service = makeService()
-        try await service.createCollection(named: AyahBookmarkCollectionName.oldPageBookmarks)
+        try await service.createCollection(named: oldPageBookmarksCollectionName)
         let collection = try await storedOldPageBookmarksCollection()
         try await service.addAyahBookmarkToCollection(
             collectionLocalId: collection.collection.localId,
@@ -148,7 +190,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
 
     func test_start_updatesOldPageBookmarkCount_whenMobileSyncChanges() async throws {
         let service = makeService()
-        try await service.createCollection(named: AyahBookmarkCollectionName.oldPageBookmarks)
+        try await service.createCollection(named: oldPageBookmarksCollectionName)
         let collection = try await storedOldPageBookmarksCollection()
         let sut = makeSUT(collectionService: service)
         let task = Task { await sut.start() }
@@ -209,7 +251,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         let iterator = database.quranDataService.collectionsWithBookmarksSequence().makeAsyncIterator()
         while let collections = try await iterator.next() {
             if let collection = collections.first(where: {
-                $0.collection.name == AyahBookmarkCollectionName.oldPageBookmarks
+                $0.collection.name == oldPageBookmarksCollectionName
             }) {
                 return collection
             }


### PR DESCRIPTION
## Summary

- allow deleting bookmarks from the legacy Old Page Bookmarks collection
- treat old-page and user collections as deletable while keeping colored collections protected
- hide Edit when My Collections has nothing deletable
- centralize collection classification around the MobileSync collection model
- keep legacy collection-name details private

## Why

The collection detail builder explicitly disabled bookmark deletion for Old Page Bookmarks. That restriction is unnecessary and made migrated bookmarks impossible to remove from the collection screen.

## Impact

Users can remove migrated old-page bookmarks and delete the legacy collection. Colored highlight collections remain non-deletable. The Edit button only appears when a deletable collection exists.

## Validation

- `make format-lint`
- `make build-sync TARGET=BookmarksFeature`
- `make test-sync`
- `make build-no-sync TARGET=BookmarksFeature`

Stacked on #875.