### PR TITLE
Centralize bookmark collection classification

### DIFF
--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -245,10 +245,13 @@ final class AyahMenuViewModel {
         HighlightPreferences.shared.lastUsedHighlightColor = color
 
         let collections = deps.highlightCollections.filter {
-            HighlightColor(collectionName: $0.collection.name) != nil
+            if case .colored = $0.kind {
+                return true
+            }
+            return false
         }
         guard let targetCollection = collections.first(where: {
-            $0.collection.name == color.collectionName
+            $0.kind == .colored(color)
         }) else {
             throw AyahMenuError.highlightCollectionUnavailable
         }

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -25,11 +25,11 @@ final class AyahMenuViewModelTests: XCTestCase {
 
     func test_updateHighlight_movesAyahBetweenCollectionsInMobileSyncDatabase() async throws {
         let service = AyahBookmarkCollectionService(quranDataService: database.quranDataService)
-        try await service.createCollection(named: HighlightColor.red.collectionName)
-        try await service.createCollection(named: HighlightColor.blue.collectionName)
+        try await service.createCollection(named: HighlightColor.red.collectionName.uppercased())
+        try await service.createCollection(named: HighlightColor.blue.collectionName.uppercased())
         let collections = try await storedCollections()
         let mapped = AyahBookmarkCollectionService.collections(from: collections, quran: .hafsMadani1405)
-        let red = try XCTUnwrap(mapped.first { $0.collection.name == HighlightColor.red.collectionName })
+        let red = try XCTUnwrap(mapped.first { $0.kind == .colored(.red) })
         try await service.addAyahBookmarkToCollection(
             collectionLocalId: red.collection.localId,
             ayah: ayah
@@ -56,8 +56,12 @@ final class AyahMenuViewModelTests: XCTestCase {
         await sut.updateHighlight(color: .blue)
 
         let updated = try await storedCollections()
-        let redBookmarks = updated.first { $0.collection.name == HighlightColor.red.collectionName }?.bookmarks
-        let blueBookmarks = updated.first { $0.collection.name == HighlightColor.blue.collectionName }?.bookmarks
+        let redBookmarks = updated.first {
+            $0.collection.name == HighlightColor.red.collectionName.uppercased()
+        }?.bookmarks
+        let blueBookmarks = updated.first {
+            $0.collection.name == HighlightColor.blue.collectionName.uppercased()
+        }?.bookmarks
         XCTAssertTrue(redBookmarks?.isEmpty == true)
         XCTAssertEqual(blueBookmarks?.count, 1)
         XCTAssertEqual(blueBookmarks?.first?.sura, 1)

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
@@ -25,13 +25,27 @@ private enum AyahBookmarkCollectionName {
     static let oldPageBookmarks = "Old Page Bookmarks"
 }
 
-enum AyahBookmarkCollectionKind: Equatable {
+private extension HighlightColor {
+    init?(collectionName: String) {
+        switch collectionName.lowercased() {
+        case "red": self = .red
+        case "green": self = .green
+        case "blue": self = .blue
+        case "yellow": self = .yellow
+        case "purple": self = .purple
+        default: return nil
+        }
+    }
+}
+
+public enum AyahBookmarkCollectionKind: Equatable {
     case oldPageBookmarks
     case colored(HighlightColor)
     case user
 
     fileprivate init(collection: Collection_) {
-        if collection.name == AyahBookmarkCollectionName.oldPageBookmarks {
+        let normalizedName = collection.name.lowercased()
+        if normalizedName == AyahBookmarkCollectionName.oldPageBookmarks.lowercased() {
             self = .oldPageBookmarks
         } else if let color = HighlightColor(collectionName: collection.name) {
             self = .colored(color)
@@ -53,7 +67,7 @@ enum AyahBookmarkCollectionKind: Equatable {
 }
 
 extension AyahBookmarkCollection {
-    var kind: AyahBookmarkCollectionKind {
+    public var kind: AyahBookmarkCollectionKind {
         AyahBookmarkCollectionKind(collection: collection)
     }
 }

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -4,6 +4,7 @@ import AuthenticationClientFake
 import Combine
 import MobileSync
 import MobileSyncTestSupport
+import QuranAnnotations
 import QuranKit
 import UIKit
 import XCTest
@@ -55,12 +56,17 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         ])
     }
 
-    func test_collectionKind_classifiesOldColoredAndUserCollections() {
+    func test_collectionKind_classifiesCollectionNamesCaseInsensitively() {
         XCTAssertEqual(
-            collection(name: oldPageBookmarksCollectionName).kind,
+            collection(name: oldPageBookmarksCollectionName.uppercased()).kind,
             .oldPageBookmarks
         )
-        XCTAssertEqual(collection(name: "red").kind, .colored(.red))
+        for color in HighlightColor.allCases {
+            XCTAssertEqual(
+                collection(name: color.collectionName.uppercased()).kind,
+                .colored(color)
+            )
+        }
         XCTAssertEqual(collection(name: "Favorites").kind, .user)
     }
 

--- a/Features/BookmarksFeature/Tests/HighlightCollectionsSyncTests.swift
+++ b/Features/BookmarksFeature/Tests/HighlightCollectionsSyncTests.swift
@@ -3,16 +3,6 @@ import QuranAnnotations
 import XCTest
 
 final class HighlightCollectionsSyncTests: XCTestCase {
-    func test_highlightColor_matchesFixedCollectionNames() {
-        XCTAssertEqual(HighlightColor(collectionName: "red"), .red)
-        XCTAssertEqual(HighlightColor(collectionName: "green"), .green)
-        XCTAssertEqual(HighlightColor(collectionName: "blue"), .blue)
-        XCTAssertEqual(HighlightColor(collectionName: "yellow"), .yellow)
-        XCTAssertEqual(HighlightColor(collectionName: "purple"), .purple)
-        XCTAssertNil(HighlightColor(collectionName: "Red"))
-        XCTAssertNil(HighlightColor(collectionName: "bookmarks"))
-    }
-
     func test_collectionName_matchesFixedRawValue() {
         XCTAssertEqual(HighlightColor.red.collectionName, "red")
         XCTAssertEqual(HighlightColor.green.collectionName, "green")

--- a/Features/QuranViewFeature/QuranSyncedHighlightsObserver.swift
+++ b/Features/QuranViewFeature/QuranSyncedHighlightsObserver.swift
@@ -52,7 +52,7 @@ final class QuranSyncedHighlightsObserver {
     private func highlightedAyahs(from collections: [AyahBookmarkCollection]) -> [AyahNumber: HighlightColor] {
         var highlights: [AyahNumber: HighlightColor] = [:]
         for collection in collections {
-            guard let color = HighlightColor(collectionName: collection.collection.name) else {
+            guard case .colored(let color) = collection.kind else {
                 continue
             }
             for bookmark in collection.bookmarks {

--- a/Features/QuranViewFeature/Tests/QuranSyncedHighlightsObserverTests.swift
+++ b/Features/QuranViewFeature/Tests/QuranSyncedHighlightsObserverTests.swift
@@ -25,7 +25,7 @@ final class QuranSyncedHighlightsObserverTests: XCTestCase {
 
     func test_start_appliesPersistedMobileSyncBookmarksToHighlights() async throws {
         let collectionService = AyahBookmarkCollectionService(quranDataService: database.quranDataService)
-        try await collectionService.createCollection(named: HighlightColor.green.collectionName)
+        try await collectionService.createCollection(named: HighlightColor.green.collectionName.uppercased())
         let stored = try await storedCollections()
         let collection = try XCTUnwrap(
             AyahBookmarkCollectionService.collections(

--- a/Model/QuranAnnotations/HighlightColor.swift
+++ b/Model/QuranAnnotations/HighlightColor.swift
@@ -11,17 +11,6 @@ public enum HighlightColor: Int, CaseIterable, Equatable, Hashable {
     case yellow = 3
     case purple = 4
 
-    public init?(collectionName: String) {
-        switch collectionName {
-        case "red": self = .red
-        case "green": self = .green
-        case "blue": self = .blue
-        case "yellow": self = .yellow
-        case "purple": self = .purple
-        default: return nil
-        }
-    }
-
     public var collectionName: String {
         switch self {
         case .red: return "red"


### PR DESCRIPTION
## Summary

- classify old-page, colored, and user collections through `AyahBookmarkCollectionKind`
- make collection-name checks case-insensitive
- keep `HighlightColor(collectionName:)` private to the bookmark collection service
- reuse collection kinds in Ayah menu highlight updates and synced highlight observation
- cover mixed-case legacy and colored collection names

## Why

Raw collection-name checks were duplicated across features and were case-sensitive. That allowed classification behavior to drift and exposed persistence-specific parsing through `QuranAnnotations`.

## Impact

Legacy and colored collections are recognized consistently regardless of name casing. Consumers no longer parse persistence names directly.

## Validation

- `make format-lint`
- `make test-sync`
- `make build-no-sync TARGET=BookmarksFeature`
- exact tree preserved while rebasing onto the newly merged `main`