### PR TITLE
build: upgrade mobile-sync-spm to 0.1.16

### DIFF
--- a/Core/Localization/NumberFormatter+Extension.swift
+++ b/Core/Localization/NumberFormatter+Extension.swift
@@ -58,8 +58,8 @@ public extension Locale {
     func fixedLocaleNumbers() -> Locale {
         let latinSuffix = "@numbers=latn"
         if identifier.hasSuffix(latinSuffix) {
-            let localId = identifier.replacingOccurrences(of: latinSuffix, with: "")
-            return Locale(identifier: localId)
+            let localeIdentifier = identifier.replacingOccurrences(of: latinSuffix, with: "")
+            return Locale(identifier: localeIdentifier)
         } else {
             return self
         }

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -129,6 +129,7 @@
 "bookmarks.collections.mine" = "مجموعاتي";
 "bookmarks.collections.new" = "مجموعة جديدة...";
 "bookmarks.collections.new.placeholder" = "اسم المجموعة";
+"bookmarks.collections.rename" = "إعادة التسمية";
 "bookmarks.collections.no-data.title" = "لا توجد مجموعات حتى الآن";
 "bookmarks.collections.no-data.text" = "أنشئ مجموعة لتنظيم الآيات حسب الموضوع أو الدعاء أو خطة الحفظ.";
 "bookmarks.collections.ayah-count" = "%d إشارات مرجعية للآيات";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -148,6 +148,7 @@
 "bookmarks.collections.mine" = "My Collections";
 "bookmarks.collections.new" = "New Collection...";
 "bookmarks.collections.new.placeholder" = "Collection name";
+"bookmarks.collections.rename" = "Rename";
 "bookmarks.collections.no-data.title" = "No collections yet";
 "bookmarks.collections.no-data.text" = "Create a collection to organize ayahs by theme, dua, or memorization plan.";
 "bookmarks.collections.ayah-count" = "%d ayah bookmarks";

--- a/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
@@ -63,7 +63,7 @@ public struct MobileSyncLastPageService: LastPageService, @unchecked Sendable {
 
         let firstVerse = toPage.firstVerse
         let updatedSession = try await quranDataService.updateReadingSession(
-            localId: localId,
+            id: localId,
             sura: Int32(firstVerse.sura.suraNumber),
             ayah: Int32(firstVerse.ayah),
             timestamp: Date()
@@ -99,7 +99,7 @@ public struct MobileSyncLastPageService: LastPageService, @unchecked Sendable {
             page: page,
             createdOn: session.lastUpdated,
             modifiedOn: session.lastUpdated,
-            localId: session.localId
+            localId: session.id
         )
     }
 }

--- a/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
@@ -74,7 +74,7 @@ public struct MobileSyncNoteService {
 
     public func updateNote(_ note: QuranAnnotations.Note, body: String, startAyah: AyahNumber, endAyah: AyahNumber) async throws {
         try await quranDataService.updateNote(
-            localId: note.id,
+            id: note.id,
             body: body,
             startSura: Int32(startAyah.sura.suraNumber),
             startAyah: Int32(startAyah.ayah),
@@ -84,7 +84,7 @@ public struct MobileSyncNoteService {
     }
 
     public func removeNote(_ note: QuranAnnotations.Note) async throws {
-        try await quranDataService.removeNote(localId: note.id)
+        try await quranDataService.removeNote(id: note.id)
     }
 
     // MARK: Internal
@@ -103,7 +103,7 @@ public struct MobileSyncNoteService {
         }
 
         return QuranAnnotations.Note(
-            id: note.localId,
+            id: note.id,
             text: note.body,
             startAyah: start,
             endAyah: end,

--- a/Domain/AnnotationsService/Tests/MobileSyncLastPageServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncLastPageServiceTests.swift
@@ -50,7 +50,7 @@ final class MobileSyncLastPageServiceTests: XCTestCase {
         let sessions = database.quranDataService.readingSessionsSequence().makeAsyncIterator()
         let storedSessions = try await sessions.next()
         XCTAssertEqual(storedSessions?.count, 1)
-        XCTAssertEqual(storedSessions?.first?.localId, original.localId)
+        XCTAssertEqual(storedSessions?.first?.id, original.localId)
         XCTAssertEqual(storedSessions?.first?.sura, Int32(quran.pages[20].firstVerse.sura.suraNumber))
         XCTAssertEqual(storedSessions?.first?.ayah, Int32(quran.pages[20].firstVerse.ayah))
     }

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -257,7 +257,7 @@ final class AyahMenuViewModel {
         }
         let service = deps.ayahBookmarkCollectionService
         let otherCollections = collections.filter {
-            $0.collection.localId != targetCollection.collection.localId
+            $0.collection.id != targetCollection.collection.id
         }
         try await service.addAyahBookmarksIfNeeded(
             deps.verses,

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -31,7 +31,7 @@ final class AyahMenuViewModelTests: XCTestCase {
         let mapped = AyahBookmarkCollectionService.collections(from: collections, quran: .hafsMadani1405)
         let red = try XCTUnwrap(mapped.first { $0.kind == .colored(.red) })
         try await service.addAyahBookmarkToCollection(
-            collectionLocalId: red.collection.localId,
+            collectionId: red.collection.id,
             ayah: ayah
         )
         let populatedCollections = AyahBookmarkCollectionService.collections(

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
@@ -5,6 +5,7 @@
 //  Created by Ahmed Nabil on 2026-05-06.
 //
 
+import KMPNativeCoroutinesAsync
 import MobileSync
 import QuranAnnotations
 import QuranKit
@@ -66,6 +67,14 @@ public enum AyahBookmarkCollectionKind: Equatable {
 
     var isOldPageBookmarks: Bool {
         self == .oldPageBookmarks
+    }
+
+    public var canDelete: Bool {
+        highlightColor == nil && self != .defaultBookmarks
+    }
+
+    public var canRename: Bool {
+        highlightColor == nil && self != .defaultBookmarks
     }
 }
 
@@ -133,6 +142,12 @@ public struct AyahBookmarkCollectionService {
 
     public func removeCollection(id: String) async throws {
         _ = try await quranDataService.removeCollection(id: id)
+    }
+
+    public func renameCollection(id: String, to name: String) async throws {
+        _ = try await asyncFunction(
+            for: quranDataService.updateCollection(id: id, name: name)
+        )
     }
 
     public func removeBookmarkFromCollection(_ bookmark: AyahCollectionBookmark) async throws {

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
@@ -39,13 +39,16 @@ private extension HighlightColor {
 }
 
 public enum AyahBookmarkCollectionKind: Equatable {
+    case defaultBookmarks
     case oldPageBookmarks
     case colored(HighlightColor)
     case user
 
     fileprivate init(collection: Collection_) {
         let normalizedName = collection.name.lowercased()
-        if normalizedName == AyahBookmarkCollectionName.oldPageBookmarks.lowercased() {
+        if collection.isDefault {
+            self = .defaultBookmarks
+        } else if normalizedName == AyahBookmarkCollectionName.oldPageBookmarks.lowercased() {
             self = .oldPageBookmarks
         } else if let color = HighlightColor(collectionName: collection.name) {
             self = .colored(color)
@@ -117,19 +120,19 @@ public struct AyahBookmarkCollectionService {
     // MARK: Public
 
     public func createCollection(named name: String) async throws {
-        try await quranDataService.createCollection(named: name)
+        _ = try await quranDataService.createCollection(named: name)
     }
 
-    public func addAyahBookmarkToCollection(collectionLocalId: String, ayah: AyahNumber) async throws {
+    public func addAyahBookmarkToCollection(collectionId: String, ayah: AyahNumber) async throws {
         _ = try await quranDataService.addAyahBookmarkToCollection(
-            collectionLocalId: collectionLocalId,
+            collectionId: collectionId,
             sura: Int32(ayah.sura.suraNumber),
             ayah: Int32(ayah.ayah)
         )
     }
 
-    public func removeCollection(localId: String) async throws {
-        try await quranDataService.removeCollection(localId: localId)
+    public func removeCollection(id: String) async throws {
+        _ = try await quranDataService.removeCollection(id: id)
     }
 
     public func removeBookmarkFromCollection(_ bookmark: AyahCollectionBookmark) async throws {
@@ -142,7 +145,7 @@ public struct AyahBookmarkCollectionService {
     ) async throws {
         for ayah in Self.ayahsToAdd(ayahs, to: collection) {
             try await addAyahBookmarkToCollection(
-                collectionLocalId: collection.collection.localId,
+                collectionId: collection.collection.id,
                 ayah: ayah
             )
         }
@@ -253,7 +256,7 @@ private extension QuranDataService {
             for name in names {
                 group.addTask {
                     do {
-                        try await self.createCollection(named: name)
+                        _ = try await self.createCollection(named: name)
                         return nil
                     } catch {
                         logger.error("Bookmarks: failed to create highlight collection '\(name)': \(error)")

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
@@ -5,7 +5,6 @@
 //  Created by Ahmed Nabil on 2026-05-06.
 //
 
-import KMPNativeCoroutinesAsync
 import MobileSync
 import QuranAnnotations
 import QuranKit
@@ -145,9 +144,7 @@ public struct AyahBookmarkCollectionService {
     }
 
     public func renameCollection(id: String, to name: String) async throws {
-        _ = try await asyncFunction(
-            for: quranDataService.updateCollection(id: id, name: name)
-        )
+        _ = try await quranDataService.updateCollection(id: id, name: name)
     }
 
     public func removeBookmarkFromCollection(_ bookmark: AyahCollectionBookmark) async throws {

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
@@ -20,12 +20,16 @@ struct AyahBookmarkCollectionsBuilder {
         self.navigateToPage = navigateToPage
     }
 
-    func buildCollection(_ collection: AyahBookmarkCollection) -> UIViewController {
+    func buildCollection(
+        _ collection: AyahBookmarkCollection,
+        collectionDeleted: @escaping () -> Void
+    ) -> UIViewController {
         let kind = collection.kind
         let viewModel = AyahBookmarkCollectionsViewModel(
             ayahBookmarkCollectionService: ayahBookmarkCollectionService,
-            collectionID: collection.collection.id,
-            navigateToPage: navigateToPage
+            collection: collection,
+            navigateToPage: navigateToPage,
+            collectionDeleted: collectionDeleted
         )
         return AyahBookmarkCollectionsViewController(
             viewModel: viewModel,

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
@@ -24,7 +24,7 @@ struct AyahBookmarkCollectionsBuilder {
         let kind = collection.kind
         let viewModel = AyahBookmarkCollectionsViewModel(
             ayahBookmarkCollectionService: ayahBookmarkCollectionService,
-            collectionLocalID: collection.collection.localId,
+            collectionID: collection.collection.id,
             navigateToPage: navigateToPage
         )
         return AyahBookmarkCollectionsViewController(

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsModels+Identifiable.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsModels+Identifiable.swift
@@ -2,10 +2,10 @@
 import MobileSync
 
 extension AyahBookmarkCollection: Identifiable {
-    public var id: String { collection.localId }
+    public var id: String { collection.id }
 }
 
 extension AyahCollectionBookmark: Identifiable {
-    public var id: String { bookmark.localId }
+    public var id: String { bookmark.bookmarkId }
 }
 #endif

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
@@ -24,11 +24,27 @@ struct AyahBookmarkCollectionsView: View {
     @StateObject var viewModel: AyahBookmarkCollectionsViewModel
 
     var body: some View {
-        NoorList {
-            AyahBookmarkCollectionsContent(viewModel: viewModel)
+        Group {
+            if viewModel.collection?.bookmarks.isEmpty == true {
+                emptyCollection
+            } else {
+                NoorList {
+                    AyahBookmarkCollectionsContent(viewModel: viewModel)
+                }
+            }
         }
         .task { await viewModel.start() }
+        .renameCollectionAlert(viewModel: viewModel)
         .errorAlert(error: $viewModel.error)
+        .environment(\.editMode, $viewModel.editMode)
+    }
+
+    private var emptyCollection: some View {
+        DataUnavailableView(
+            title: l("bookmarks.collections.ayahs.no-data.title"),
+            text: l("bookmarks.collections.ayahs.no-data.text"),
+            image: .bookmark
+        )
     }
 }
 
@@ -83,6 +99,31 @@ struct AyahBookmarkCollectionsContent: View {
             accessory: .text(NumberFormatter.shared.format(bookmark.ayah.page.pageNumber))
         ) {
             viewModel.navigateTo(bookmark)
+        }
+    }
+}
+
+private extension View {
+    @MainActor
+    func renameCollectionAlert(viewModel: AyahBookmarkCollectionsViewModel) -> some View {
+        alert(
+            l("bookmarks.collections.rename"),
+            isPresented: Binding(
+                get: { viewModel.isPresentingRenameCollection },
+                set: { viewModel.isPresentingRenameCollection = $0 }
+            )
+        ) {
+            TextField(
+                l("bookmarks.collections.new.placeholder"),
+                text: Binding(
+                    get: { viewModel.pendingCollectionName },
+                    set: { viewModel.pendingCollectionName = $0 }
+                )
+            )
+            Button(lAndroid("cancel"), role: .cancel) {}
+            Button(l("bookmarks.collections.rename")) {
+                Task { await viewModel.renamePendingCollection() }
+            }
         }
     }
 }

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
@@ -5,7 +5,9 @@
 //  Created by Ahmed Nabil on 2026-05-05.
 //
 
+import Combine
 import Localization
+import NoorUI
 import SwiftUI
 import UIKit
 
@@ -18,12 +20,101 @@ final class AyahBookmarkCollectionsViewController: UIHostingController<AyahBookm
     ) {
         super.init(rootView: AyahBookmarkCollectionsView(viewModel: viewModel))
         self.title = title
+        menuController = AyahBookmarkCollectionMenuController(
+            viewController: self,
+            viewModel: viewModel
+        )
     }
 
     @available(*, unavailable)
     @MainActor
     dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private var menuController: AyahBookmarkCollectionMenuController?
+}
+
+@MainActor
+private final class AyahBookmarkCollectionMenuController {
+    init(viewController: UIViewController, viewModel: AyahBookmarkCollectionsViewModel) {
+        self.viewController = viewController
+        self.viewModel = viewModel
+
+        updateNavigationItem(editMode: viewModel.editMode, collection: viewModel.collection)
+        Publishers.CombineLatest(viewModel.$editMode, viewModel.$collection)
+            .sink { [weak self] editMode, collection in
+                self?.updateNavigationItem(editMode: editMode, collection: collection)
+            }
+            .store(in: &cancellables)
+    }
+
+    private weak var viewController: UIViewController?
+    private let viewModel: AyahBookmarkCollectionsViewModel
+    private var cancellables: Set<AnyCancellable> = []
+
+    private func updateNavigationItem(editMode: EditMode, collection: AyahBookmarkCollection?) {
+        guard let viewController, let collection else {
+            return
+        }
+
+        viewController.title = collection.kind.highlightColor?.localizedName ?? collection.collection.name
+        if editMode.isEditing {
+            let doneButton = UIBarButtonItem(
+                title: l("button.done"),
+                primaryAction: UIAction { [weak self] _ in
+                    self?.viewModel.editMode = .inactive
+                }
+            )
+            doneButton.tintColor = .appIdentity
+            viewController.navigationItem.rightBarButtonItem = doneButton
+        } else {
+            let moreButton = UIBarButtonItem(
+                image: UIImage(systemName: "ellipsis.circle"),
+                menu: menu(for: collection)
+            )
+            moreButton.tintColor = .appIdentity
+            viewController.navigationItem.rightBarButtonItem = moreButton
+        }
+    }
+
+    private func menu(for collection: AyahBookmarkCollection) -> UIMenu {
+        var actions = [
+            UIAction(
+                title: l("bookmarks.collections.edit.action"),
+                image: UIImage(systemName: "pencil")
+            ) { [weak self] _ in
+                self?.viewModel.editMode = .active
+            },
+        ]
+
+        if collection.kind.canRename {
+            actions.append(
+                UIAction(
+                    title: l("bookmarks.collections.rename"),
+                    image: UIImage(systemName: "pencil.line")
+                ) { [weak self] _ in
+                    self?.viewModel.presentRenameCollection()
+                }
+            )
+        }
+
+        if collection.kind.canDelete {
+            actions.append(
+                UIAction(
+                    title: l("button.delete"),
+                    image: UIImage(systemName: "trash"),
+                    attributes: .destructive
+                ) { [weak self] _ in
+                    guard let self else {
+                        return
+                    }
+                    Task { await self.viewModel.deleteCollection() }
+                }
+            )
+        }
+
+        return UIMenu(children: actions)
     }
 }
 #endif

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
@@ -8,6 +8,7 @@
 import Combine
 import QuranAnnotations
 import QuranKit
+import SwiftUI
 import VLogging
 
 @MainActor
@@ -16,18 +17,24 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
 
     init(
         ayahBookmarkCollectionService: AyahBookmarkCollectionService,
-        collectionID: String,
-        navigateToPage: @escaping (Page) -> Void
+        collection: AyahBookmarkCollection,
+        navigateToPage: @escaping (Page) -> Void,
+        collectionDeleted: @escaping () -> Void
     ) {
         self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
-        self.collectionID = collectionID
+        self.collection = collection
+        collectionID = collection.collection.id
         self.navigateToPage = navigateToPage
+        self.collectionDeleted = collectionDeleted
     }
 
     // MARK: Internal
 
     @Published private(set) var collection: AyahBookmarkCollection?
+    @Published var editMode: EditMode = .inactive
     @Published var error: Error?
+    @Published var isPresentingRenameCollection = false
+    @Published var pendingCollectionName = ""
 
     func start() async {
         do {
@@ -55,10 +62,53 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
         }
     }
 
+    func presentRenameCollection() {
+        guard let collection, collection.kind.canRename else {
+            return
+        }
+        pendingCollectionName = collection.collection.name
+        isPresentingRenameCollection = true
+    }
+
+    func renamePendingCollection() async {
+        guard let collection, collection.kind.canRename else {
+            return
+        }
+        let name = pendingCollectionName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            return
+        }
+
+        do {
+            try await ayahBookmarkCollectionService.renameCollection(
+                id: collection.collection.id,
+                to: name
+            )
+        } catch {
+            self.error = error
+        }
+    }
+
+    func deleteCollection() async {
+        guard let collection, collection.kind.canDelete else {
+            return
+        }
+
+        do {
+            try await ayahBookmarkCollectionService.removeCollection(
+                id: collection.collection.id
+            )
+            collectionDeleted()
+        } catch {
+            self.error = error
+        }
+    }
+
     // MARK: Private
 
     private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
     private let collectionID: String
     private let navigateToPage: (Page) -> Void
+    private let collectionDeleted: () -> Void
 }
 #endif

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
@@ -16,11 +16,11 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
 
     init(
         ayahBookmarkCollectionService: AyahBookmarkCollectionService,
-        collectionLocalID: String,
+        collectionID: String,
         navigateToPage: @escaping (Page) -> Void
     ) {
         self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
-        self.collectionLocalID = collectionLocalID
+        self.collectionID = collectionID
         self.navigateToPage = navigateToPage
     }
 
@@ -34,7 +34,7 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
             let sequence = ayahBookmarkCollectionService.collectionsSequence()
             for try await collections in sequence {
                 collection = collections.first {
-                    $0.collection.localId == collectionLocalID
+                    $0.collection.id == collectionID
                 }
             }
         } catch {
@@ -58,7 +58,7 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
     // MARK: Private
 
     private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
-    private let collectionLocalID: String
+    private let collectionID: String
     private let navigateToPage: (Page) -> Void
 }
 #endif

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -124,7 +124,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
 
     func deleteCollection(_ collection: AyahBookmarkCollection) async {
         do {
-            try await ayahBookmarkCollectionService.removeCollection(localId: collection.collection.localId)
+            try await ayahBookmarkCollectionService.removeCollection(id: collection.collection.id)
         } catch {
             self.error = error
         }

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -72,11 +72,10 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     }
 
     static func deletableCollections(from collections: [AyahBookmarkCollection]) -> [AyahBookmarkCollection] {
-        let oldPageBookmarks = collections.filter(\.kind.isOldPageBookmarks)
-        let userCollections = collections.filter {
-            $0.kind == .user
-        }
-        return oldPageBookmarks + userCollections
+        let deletableCollections = collections.filter(\.kind.canDelete)
+        let oldPageBookmarks = deletableCollections.filter(\.kind.isOldPageBookmarks)
+        let remainingCollections = deletableCollections.filter { !$0.kind.isOldPageBookmarks }
+        return oldPageBookmarks + remainingCollections
     }
 
     func start() async {
@@ -123,6 +122,9 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     }
 
     func deleteCollection(_ collection: AyahBookmarkCollection) async {
+        guard collection.kind.canDelete else {
+            return
+        }
         do {
             try await ayahBookmarkCollectionService.removeCollection(id: collection.collection.id)
         } catch {
@@ -132,7 +134,12 @@ final class BookmarkCollectionsViewModel: ObservableObject {
 
     func showCollection(_ collection: AyahBookmarkCollection) {
         navigationController?.pushViewController(
-            collectionsBuilder.buildCollection(collection),
+            collectionsBuilder.buildCollection(
+                collection,
+                collectionDeleted: { [weak navigationController] in
+                    navigationController?.popViewController(animated: true)
+                }
+            ),
             animated: true
         )
     }

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionServiceTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionServiceTests.swift
@@ -28,17 +28,19 @@ final class AyahBookmarkCollectionServiceTests: XCTestCase {
         let collections = try await storedCollections { collections in
             collections.contains { $0.collection.name == "Favorites" }
         }
-        XCTAssertEqual(collections.map(\.collection.name), ["Favorites"])
+        XCTAssertEqual(collections.map(\.collection.name), ["Default", "Favorites"])
     }
 
     func test_removeCollection_deletesPersistedCollection() async throws {
         try await service.createCollection(named: "Favorites")
         let collection = try await storedCollection(named: "Favorites")
 
-        try await service.removeCollection(localId: collection.collection.localId)
+        try await service.removeCollection(id: collection.collection.id)
 
-        let collections = try await storedCollections { $0.isEmpty }
-        XCTAssertTrue(collections.isEmpty)
+        let collections = try await storedCollections {
+            $0.count == 1 && $0.first?.collection.isDefault == true
+        }
+        XCTAssertEqual(collections.map(\.collection.name), ["Default"])
     }
 
     func test_addAndRemoveAyahBookmark_persistsCollectionMembership() async throws {
@@ -46,7 +48,7 @@ final class AyahBookmarkCollectionServiceTests: XCTestCase {
         let collection = try await storedCollection(named: "Favorites")
 
         try await service.addAyahBookmarkToCollection(
-            collectionLocalId: collection.collection.localId,
+            collectionId: collection.collection.id,
             ayah: ayah(1)
         )
 
@@ -86,6 +88,7 @@ final class AyahBookmarkCollectionServiceTests: XCTestCase {
         }
 
         XCTAssertTrue(expectedNames.isSubset(of: Set(collections.map(\.collection.name))))
+        XCTAssertTrue(collections.first?.collection.isDefault == true)
     }
 
     private func storedCollection(

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
@@ -24,11 +24,14 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
     func test_start_observesCollectionsFromMobileSyncDatabase() async throws {
         let service = makeService()
         try await service.createCollection(named: "Favorites")
-        let stored = try await storedCollections()
+        let stored = try await storedCollections {
+            $0.contains { !$0.collection.isDefault }
+        }
         let collection = try XCTUnwrap(
-            AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405).first
+            AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405)
+                .first { !$0.collection.isDefault }
         )
-        let sut = makeSUT(collectionLocalID: collection.collection.localId, service: service)
+        let sut = makeSUT(collectionID: collection.collection.id, service: service)
         let observed = expectation(description: "Observes persisted collection")
         let observation = sut.$collection.sink { collection in
             if collection?.collection.name == "Favorites" {
@@ -48,35 +51,43 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
         let service = makeService()
         try await service.createCollection(named: oldPageBookmarksCollectionName)
         var stored = try await storedCollections()
-        let storedCollection = try XCTUnwrap(stored.first)
+        let storedCollection = try XCTUnwrap(
+            stored.first { $0.collection.name == oldPageBookmarksCollectionName }
+        )
         try await service.addAyahBookmarkToCollection(
-            collectionLocalId: storedCollection.collection.localId,
+            collectionId: storedCollection.collection.id,
             ayah: AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
         )
-        stored = try await storedCollections()
+        stored = try await storedCollections {
+            $0.first { $0.collection.name == oldPageBookmarksCollectionName }?.bookmarks.count == 1
+        }
         let collection = try XCTUnwrap(
             AyahBookmarkCollectionService
                 .collections(from: stored, quran: .hafsMadani1405)
-                .first
+                .first { $0.collection.name == oldPageBookmarksCollectionName }
         )
         let bookmark = try XCTUnwrap(collection.bookmarks.first)
-        let sut = makeSUT(collectionLocalID: collection.collection.localId, service: service)
+        let sut = makeSUT(collectionID: collection.collection.id, service: service)
 
         await sut.deleteBookmark(bookmark)
 
-        stored = try await storedCollections()
-        let updatedCollection = try XCTUnwrap(stored.first)
+        stored = try await storedCollections {
+            $0.first { $0.collection.name == oldPageBookmarksCollectionName }?.bookmarks.isEmpty == true
+        }
+        let updatedCollection = try XCTUnwrap(
+            stored.first { $0.collection.name == oldPageBookmarksCollectionName }
+        )
         XCTAssertTrue(updatedCollection.bookmarks.isEmpty)
         XCTAssertNil(sut.error)
     }
 
     private func makeSUT(
-        collectionLocalID: String,
+        collectionID: String,
         service: AyahBookmarkCollectionService? = nil
     ) -> AyahBookmarkCollectionsViewModel {
         AyahBookmarkCollectionsViewModel(
             ayahBookmarkCollectionService: service ?? makeService(),
-            collectionLocalID: collectionLocalID,
+            collectionID: collectionID,
             navigateToPage: { _ in }
         )
     }
@@ -85,9 +96,20 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
         AyahBookmarkCollectionService(quranDataService: database.quranDataService)
     }
 
-    private func storedCollections() async throws -> [CollectionWithAyahBookmarks] {
+    private func storedCollections(
+        where predicate: ([CollectionWithAyahBookmarks]) -> Bool = { _ in true }
+    ) async throws -> [CollectionWithAyahBookmarks] {
         let iterator = database.quranDataService.collectionsWithBookmarksSequence().makeAsyncIterator()
-        return try await iterator.next() ?? []
+        while let collections = try await iterator.next() {
+            if predicate(collections) {
+                return collections
+            }
+        }
+        throw TestError.expectedDatabaseStateNotObserved
     }
+}
+
+private enum TestError: Error {
+    case expectedDatabaseStateNotObserved
 }
 #endif

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
@@ -31,13 +31,12 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
             AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405)
                 .first { !$0.collection.isDefault }
         )
-        let sut = makeSUT(collectionID: collection.collection.id, service: service)
+        let sut = makeSUT(collection: collection, service: service)
         let observed = expectation(description: "Observes persisted collection")
-        let observation = sut.$collection.sink { collection in
-            if collection?.collection.name == "Favorites" {
-                observed.fulfill()
-            }
-        }
+        let observation = sut.$collection
+            .filter { $0?.collection.name == "Favorites" }
+            .prefix(1)
+            .sink { _ in observed.fulfill() }
 
         let task = Task { await sut.start() }
         await fulfillment(of: [observed], timeout: 2)
@@ -67,7 +66,7 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
                 .first { $0.collection.name == oldPageBookmarksCollectionName }
         )
         let bookmark = try XCTUnwrap(collection.bookmarks.first)
-        let sut = makeSUT(collectionID: collection.collection.id, service: service)
+        let sut = makeSUT(collection: collection, service: service)
 
         await sut.deleteBookmark(bookmark)
 
@@ -81,14 +80,73 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
         XCTAssertNil(sut.error)
     }
 
+    func test_renamePendingCollection_updatesRealMobileSyncDatabase() async throws {
+        let service = makeService()
+        try await service.createCollection(named: "Favorites")
+        let collection = try await firstCollection()
+        let sut = makeSUT(collection: collection, service: service)
+        sut.pendingCollectionName = " Duas "
+
+        await sut.renamePendingCollection()
+
+        let renamedCollection = try await firstCollection()
+        XCTAssertEqual(renamedCollection.collection.name, "Duas")
+        XCTAssertNil(sut.error)
+    }
+
+    func test_deleteCollection_removesCollectionAndNotifiesListener() async throws {
+        let service = makeService()
+        try await service.createCollection(named: "Favorites")
+        let collection = try await firstCollection()
+        var didDeleteCollection = false
+        let sut = makeSUT(
+            collection: collection,
+            service: service,
+            collectionDeleted: { didDeleteCollection = true }
+        )
+
+        await sut.deleteCollection()
+
+        let stored = try await storedCollections {
+            $0.count == 1 && $0[0].collection.isDefault
+        }
+        XCTAssertEqual(stored.map(\.collection.name), ["Default"])
+        XCTAssertTrue(stored[0].collection.isDefault)
+        XCTAssertTrue(didDeleteCollection)
+        XCTAssertNil(sut.error)
+    }
+
+    func test_highlightCollectionCannotBeRenamedOrDeleted() async throws {
+        let service = makeService()
+        try await service.createCollection(named: "Red")
+        let collection = try await firstCollection()
+        var didDeleteCollection = false
+        let sut = makeSUT(
+            collection: collection,
+            service: service,
+            collectionDeleted: { didDeleteCollection = true }
+        )
+        sut.pendingCollectionName = "Renamed"
+
+        await sut.renamePendingCollection()
+        await sut.deleteCollection()
+
+        let storedCollection = try await firstCollection()
+        XCTAssertEqual(storedCollection.collection.name, "Red")
+        XCTAssertFalse(didDeleteCollection)
+        XCTAssertNil(sut.error)
+    }
+
     private func makeSUT(
-        collectionID: String,
-        service: AyahBookmarkCollectionService? = nil
+        collection: AyahBookmarkCollection,
+        service: AyahBookmarkCollectionService? = nil,
+        collectionDeleted: @escaping () -> Void = {}
     ) -> AyahBookmarkCollectionsViewModel {
         AyahBookmarkCollectionsViewModel(
             ayahBookmarkCollectionService: service ?? makeService(),
-            collectionID: collectionID,
-            navigateToPage: { _ in }
+            collection: collection,
+            navigateToPage: { _ in },
+            collectionDeleted: collectionDeleted
         )
     }
 
@@ -106,6 +164,16 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
             }
         }
         throw TestError.expectedDatabaseStateNotObserved
+    }
+
+    private func firstCollection() async throws -> AyahBookmarkCollection {
+        let stored = try await storedCollections {
+            $0.contains { !$0.collection.isDefault }
+        }
+        return try XCTUnwrap(
+            AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405)
+                .first { !$0.collection.isDefault }
+        )
     }
 }
 

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -67,6 +67,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
                 .colored(color)
             )
         }
+        XCTAssertEqual(collection(name: "Default", id: "__default__").kind, .defaultBookmarks)
         XCTAssertEqual(collection(name: "Favorites").kind, .user)
     }
 
@@ -156,8 +157,10 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
 
         await sut.createPendingCollection()
 
-        let collections = try await storedCollections()
-        XCTAssertEqual(collections.map(\.collection.name), ["Favorites"])
+        let collections = try await storedCollections {
+            $0.contains { $0.collection.name == "Favorites" }
+        }
+        XCTAssertEqual(collections.map(\.collection.name), ["Default", "Favorites"])
         XCTAssertNil(sut.error)
     }
 
@@ -166,14 +169,18 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         try await service.createCollection(named: "Favorites")
         let stored = try await storedCollections()
         let collection = try XCTUnwrap(
-            AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405).first
+            AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405)
+                .first { !$0.collection.isDefault }
         )
         let sut = makeSUT(collectionService: service)
 
         await sut.deleteCollection(collection)
 
-        let collections = try await storedCollections()
-        XCTAssertTrue(collections.isEmpty)
+        let collections = try await storedCollections {
+            $0.count == 1 && $0[0].collection.isDefault
+        }
+        XCTAssertEqual(collections.map(\.collection.name), ["Default"])
+        XCTAssertTrue(collections[0].collection.isDefault)
         XCTAssertNil(sut.error)
     }
 
@@ -182,7 +189,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         try await service.createCollection(named: oldPageBookmarksCollectionName)
         let collection = try await storedOldPageBookmarksCollection()
         try await service.addAyahBookmarkToCollection(
-            collectionLocalId: collection.collection.localId,
+            collectionId: collection.collection.id,
             ayah: AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
         )
         let sut = makeSUT(collectionService: service)
@@ -202,7 +209,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         let task = Task { await sut.start() }
 
         try await service.addAyahBookmarkToCollection(
-            collectionLocalId: collection.collection.localId,
+            collectionId: collection.collection.id,
             ayah: AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
         )
         await waitUntil { sut.oldPageBookmarksCollection?.bookmarks.count == 1 }
@@ -216,7 +223,8 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         try await service.createCollection(named: "Favorites")
         let stored = try await storedCollections()
         let collection = try XCTUnwrap(
-            AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405).first
+            AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405)
+                .first { !$0.collection.isDefault }
         )
         let navigationController = UINavigationController()
         let sut = makeSUT(
@@ -265,17 +273,24 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         throw TestError.collectionNotFound
     }
 
-    private func storedCollections() async throws -> [CollectionWithAyahBookmarks] {
+    private func storedCollections(
+        where predicate: ([CollectionWithAyahBookmarks]) -> Bool = { _ in true }
+    ) async throws -> [CollectionWithAyahBookmarks] {
         let iterator = database.quranDataService.collectionsWithBookmarksSequence().makeAsyncIterator()
-        return try await iterator.next() ?? []
+        while let collections = try await iterator.next() {
+            if predicate(collections) {
+                return collections
+            }
+        }
+        throw TestError.collectionNotFound
     }
 
-    private func collection(name: String) -> AyahBookmarkCollection {
+    private func collection(name: String, id: String? = nil) -> AyahBookmarkCollection {
         AyahBookmarkCollection(
             collection: Collection_(
                 name: name,
                 lastUpdated: .distantPast,
-                localId: name
+                id: id ?? name
             ),
             bookmarks: []
         )

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -2,6 +2,7 @@
 import AuthenticationClient
 import AuthenticationClientFake
 import Combine
+import Localization
 import MobileSync
 import MobileSyncTestSupport
 import QuranAnnotations
@@ -69,6 +70,56 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         }
         XCTAssertEqual(collection(name: "Default", id: "__default__").kind, .defaultBookmarks)
         XCTAssertEqual(collection(name: "Favorites").kind, .user)
+    }
+
+    func test_collectionCapabilities_protectSystemCollections() {
+        let defaultBookmarks = collection(name: "Default", id: "__default__")
+        let highlight = collection(name: "Red")
+        let oldPageBookmarks = collection(name: oldPageBookmarksCollectionName)
+        let user = collection(name: "Favorites")
+
+        XCTAssertFalse(defaultBookmarks.kind.canRename)
+        XCTAssertFalse(defaultBookmarks.kind.canDelete)
+        XCTAssertFalse(highlight.kind.canRename)
+        XCTAssertFalse(highlight.kind.canDelete)
+        XCTAssertTrue(oldPageBookmarks.kind.canRename)
+        XCTAssertTrue(oldPageBookmarks.kind.canDelete)
+        XCTAssertTrue(user.kind.canRename)
+        XCTAssertTrue(user.kind.canDelete)
+    }
+
+    func test_collectionDetailsMenu_onlyShowsEditForHighlightCollection() {
+        let collection = collection(name: "Red")
+        let viewModel = makeCollectionDetailsViewModel(collection: collection)
+        let viewController = AyahBookmarkCollectionsViewController(viewModel: viewModel)
+
+        let titles = viewController.navigationItem.rightBarButtonItem?.menu?.children.map(\.title)
+
+        XCTAssertEqual(titles, [l("bookmarks.collections.edit.action")])
+    }
+
+    func test_collectionDetailsMenu_showsAllActionsForUserCollection() {
+        let collection = collection(name: "Favorites")
+        let viewModel = makeCollectionDetailsViewModel(collection: collection)
+        let viewController = AyahBookmarkCollectionsViewController(viewModel: viewModel)
+
+        let titles = viewController.navigationItem.rightBarButtonItem?.menu?.children.map(\.title)
+
+        XCTAssertEqual(titles, [
+            l("bookmarks.collections.edit.action"),
+            l("bookmarks.collections.rename"),
+            l("button.delete"),
+        ])
+    }
+
+    func test_collectionDetailsController_showsDoneButtonInEditMode() {
+        let collection = collection(name: "Favorites")
+        let viewModel = makeCollectionDetailsViewModel(collection: collection)
+        let viewController = AyahBookmarkCollectionsViewController(viewModel: viewModel)
+
+        viewModel.editMode = .active
+
+        XCTAssertEqual(viewController.navigationItem.rightBarButtonItem?.title, l("button.done"))
     }
 
     func test_collectionsViewController_hidesEditButtonWithoutDeletableCollections() {
@@ -259,6 +310,17 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
 
     private func makeService() -> AyahBookmarkCollectionService {
         AyahBookmarkCollectionService(quranDataService: database.quranDataService)
+    }
+
+    private func makeCollectionDetailsViewModel(
+        collection: AyahBookmarkCollection
+    ) -> AyahBookmarkCollectionsViewModel {
+        AyahBookmarkCollectionsViewModel(
+            ayahBookmarkCollectionService: makeService(),
+            collection: collection,
+            navigateToPage: { _ in },
+            collectionDeleted: {}
+        )
     }
 
     private func storedOldPageBookmarksCollection() async throws -> CollectionWithAyahBookmarks {

--- a/Features/QuranViewFeature/Tests/QuranSyncedHighlightsObserverTests.swift
+++ b/Features/QuranViewFeature/Tests/QuranSyncedHighlightsObserverTests.swift
@@ -31,10 +31,10 @@ final class QuranSyncedHighlightsObserverTests: XCTestCase {
             AyahBookmarkCollectionService.collections(
                 from: stored,
                 quran: .hafsMadani1405
-            ).first
+            ).first { $0.kind == .colored(.green) }
         )
         try await collectionService.addAyahBookmarkToCollection(
-            collectionLocalId: collection.collection.localId,
+            collectionId: collection.collection.id,
             ayah: ayah
         )
         let highlightsService = QuranHighlightsService()
@@ -53,7 +53,10 @@ final class QuranSyncedHighlightsObserverTests: XCTestCase {
         await fulfillment(of: [applied], timeout: 2)
 
         XCTAssertEqual(highlightsService.highlights.highlightVerses[ayah], .green)
-        XCTAssertEqual(observer.collections.first?.bookmarks.first?.ayah, ayah)
+        XCTAssertEqual(
+            observer.collections.first { $0.kind == .colored(.green) }?.bookmarks.first?.ayah,
+            ayah
+        )
         observation.cancel()
         withExtendedLifetime(observer) {}
     }

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endef
 .PHONY: build-no-sync build-sync
 .PHONY: build-example-no-sync build-example-sync
 .PHONY: run-example-no-sync run-example-sync
-.PHONY: clone-swiftformat build-swiftformat force-build-swiftformat clean-swiftformat format-lint format-autocorrect
+.PHONY: clone-swiftformat build-swiftformat force-build-swiftformat clean-swiftformat format-lint format-autocorrect lint-no-kotlin-interop
 .PHONY: install-swiftlint build-for-analyzer swiftlint-analyzer
 
 test-no-sync:
@@ -107,7 +107,16 @@ force-build-swiftformat: clone-swiftformat
 clean-swiftformat:
 	@rm -rf $(SWIFT_FORMAT_DIR)/.build
 
-format-lint: $(SWIFT_FORMAT_BIN)
+lint-no-kotlin-interop:
+	@matches="$$(git grep --line-number --extended-regexp '(^|[[:space:]])import[[:space:]]+KMPNativeCoroutines|(^|[^[:alnum:]_])(asyncFunction|asyncSequence)[[:space:]]*\(' -- '*.swift' || true)"; \
+	if [ -n "$$matches" ]; then \
+		echo "$$matches"; \
+		echo "error: Direct Kotlin coroutine interop is forbidden in QuranEngine Swift sources." >&2; \
+		echo "Use the Swift-native async APIs exposed by MobileSync; add missing wrappers upstream." >&2; \
+		exit 1; \
+	fi
+
+format-lint: lint-no-kotlin-interop $(SWIFT_FORMAT_BIN)
 	$(SWIFT_FORMAT_BIN) --lint .
 
 format-autocorrect: $(SWIFT_FORMAT_BIN)

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quran/mobile-sync-spm.git",
       "state" : {
-        "revision" : "07e40ac37ea546f24ab5f467788d577438f5ea53",
-        "version" : "0.1.12"
+        "revision" : "ee71119cb7e1acb8f16357735aba29a132c3ae5e",
+        "version" : "0.1.14"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quran/mobile-sync-spm.git",
       "state" : {
-        "revision" : "ee71119cb7e1acb8f16357735aba29a132c3ae5e",
-        "version" : "0.1.14"
+        "revision" : "26cbfcf41abb9d900bb1e38dbf9f8a2e58238a70",
+        "version" : "0.1.15"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quran/mobile-sync-spm.git",
       "state" : {
-        "revision" : "26cbfcf41abb9d900bb1e38dbf9f8a2e58238a70",
-        "version" : "0.1.15"
+        "revision" : "8878e1e121db7f07b87cabe65d7484d96a8841f0",
+        "version" : "0.1.16"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
 
         // Sync
-        .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.15"),
+        .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.16"),
 
     ], targets: validated(targets) + [testTargetLinkingAllPackageTargets(targets)]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
 
         // Sync
-        .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.12"),
+        .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.14"),
 
     ], targets: validated(targets) + [testTargetLinkingAllPackageTargets(targets)]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/combine-schedulers", from: "1.0.0"),
 
         // Sync
-        .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.14"),
+        .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.15"),
 
     ], targets: validated(targets) + [testTargetLinkingAllPackageTargets(targets)]
 )


### PR DESCRIPTION
## What
- upgrade mobile-sync-spm to 0.1.16
- migrate to the unified identifier API and handle the virtual default collection
- rename the locale identifier helper for clarity
- adopt the package-owned Swift async sequence boundary

## Stack
Base PR for #880 and #879.

## Checks
- make format-lint
- make test-sync
- make test-no-sync
- make build-example-sync
- make build-example-no-sync