### PR TITLE
ci: forbid direct Kotlin coroutine interop

### DIFF
--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -129,6 +129,7 @@
 "bookmarks.collections.mine" = "مجموعاتي";
 "bookmarks.collections.new" = "مجموعة جديدة...";
 "bookmarks.collections.new.placeholder" = "اسم المجموعة";
+"bookmarks.collections.rename" = "إعادة التسمية";
 "bookmarks.collections.no-data.title" = "لا توجد مجموعات حتى الآن";
 "bookmarks.collections.no-data.text" = "أنشئ مجموعة لتنظيم الآيات حسب الموضوع أو الدعاء أو خطة الحفظ.";
 "bookmarks.collections.ayah-count" = "%d إشارات مرجعية للآيات";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -148,6 +148,7 @@
 "bookmarks.collections.mine" = "My Collections";
 "bookmarks.collections.new" = "New Collection...";
 "bookmarks.collections.new.placeholder" = "Collection name";
+"bookmarks.collections.rename" = "Rename";
 "bookmarks.collections.no-data.title" = "No collections yet";
 "bookmarks.collections.no-data.text" = "Create a collection to organize ayahs by theme, dua, or memorization plan.";
 "bookmarks.collections.ayah-count" = "%d ayah bookmarks";

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
@@ -5,6 +5,7 @@
 //  Created by Ahmed Nabil on 2026-05-06.
 //
 
+import KMPNativeCoroutinesAsync
 import MobileSync
 import QuranAnnotations
 import QuranKit
@@ -66,6 +67,14 @@ public enum AyahBookmarkCollectionKind: Equatable {
 
     var isOldPageBookmarks: Bool {
         self == .oldPageBookmarks
+    }
+
+    public var canDelete: Bool {
+        highlightColor == nil && self != .defaultBookmarks
+    }
+
+    public var canRename: Bool {
+        highlightColor == nil && self != .defaultBookmarks
     }
 }
 
@@ -133,6 +142,12 @@ public struct AyahBookmarkCollectionService {
 
     public func removeCollection(id: String) async throws {
         _ = try await quranDataService.removeCollection(id: id)
+    }
+
+    public func renameCollection(id: String, to name: String) async throws {
+        _ = try await asyncFunction(
+            for: quranDataService.updateCollection(id: id, name: name)
+        )
     }
 
     public func removeBookmarkFromCollection(_ bookmark: AyahCollectionBookmark) async throws {

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
@@ -5,7 +5,6 @@
 //  Created by Ahmed Nabil on 2026-05-06.
 //
 
-import KMPNativeCoroutinesAsync
 import MobileSync
 import QuranAnnotations
 import QuranKit
@@ -145,9 +144,7 @@ public struct AyahBookmarkCollectionService {
     }
 
     public func renameCollection(id: String, to name: String) async throws {
-        _ = try await asyncFunction(
-            for: quranDataService.updateCollection(id: id, name: name)
-        )
+        _ = try await quranDataService.updateCollection(id: id, name: name)
     }
 
     public func removeBookmarkFromCollection(_ bookmark: AyahCollectionBookmark) async throws {

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
@@ -20,12 +20,16 @@ struct AyahBookmarkCollectionsBuilder {
         self.navigateToPage = navigateToPage
     }
 
-    func buildCollection(_ collection: AyahBookmarkCollection) -> UIViewController {
+    func buildCollection(
+        _ collection: AyahBookmarkCollection,
+        collectionDeleted: @escaping () -> Void
+    ) -> UIViewController {
         let kind = collection.kind
         let viewModel = AyahBookmarkCollectionsViewModel(
             ayahBookmarkCollectionService: ayahBookmarkCollectionService,
-            collectionID: collection.collection.id,
-            navigateToPage: navigateToPage
+            collection: collection,
+            navigateToPage: navigateToPage,
+            collectionDeleted: collectionDeleted
         )
         return AyahBookmarkCollectionsViewController(
             viewModel: viewModel,

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
@@ -24,11 +24,27 @@ struct AyahBookmarkCollectionsView: View {
     @StateObject var viewModel: AyahBookmarkCollectionsViewModel
 
     var body: some View {
-        NoorList {
-            AyahBookmarkCollectionsContent(viewModel: viewModel)
+        Group {
+            if viewModel.collection?.bookmarks.isEmpty == true {
+                emptyCollection
+            } else {
+                NoorList {
+                    AyahBookmarkCollectionsContent(viewModel: viewModel)
+                }
+            }
         }
         .task { await viewModel.start() }
+        .renameCollectionAlert(viewModel: viewModel)
         .errorAlert(error: $viewModel.error)
+        .environment(\.editMode, $viewModel.editMode)
+    }
+
+    private var emptyCollection: some View {
+        DataUnavailableView(
+            title: l("bookmarks.collections.ayahs.no-data.title"),
+            text: l("bookmarks.collections.ayahs.no-data.text"),
+            image: .bookmark
+        )
     }
 }
 
@@ -83,6 +99,31 @@ struct AyahBookmarkCollectionsContent: View {
             accessory: .text(NumberFormatter.shared.format(bookmark.ayah.page.pageNumber))
         ) {
             viewModel.navigateTo(bookmark)
+        }
+    }
+}
+
+private extension View {
+    @MainActor
+    func renameCollectionAlert(viewModel: AyahBookmarkCollectionsViewModel) -> some View {
+        alert(
+            l("bookmarks.collections.rename"),
+            isPresented: Binding(
+                get: { viewModel.isPresentingRenameCollection },
+                set: { viewModel.isPresentingRenameCollection = $0 }
+            )
+        ) {
+            TextField(
+                l("bookmarks.collections.new.placeholder"),
+                text: Binding(
+                    get: { viewModel.pendingCollectionName },
+                    set: { viewModel.pendingCollectionName = $0 }
+                )
+            )
+            Button(lAndroid("cancel"), role: .cancel) {}
+            Button(l("bookmarks.collections.rename")) {
+                Task { await viewModel.renamePendingCollection() }
+            }
         }
     }
 }

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
@@ -5,7 +5,9 @@
 //  Created by Ahmed Nabil on 2026-05-05.
 //
 
+import Combine
 import Localization
+import NoorUI
 import SwiftUI
 import UIKit
 
@@ -18,12 +20,101 @@ final class AyahBookmarkCollectionsViewController: UIHostingController<AyahBookm
     ) {
         super.init(rootView: AyahBookmarkCollectionsView(viewModel: viewModel))
         self.title = title
+        menuController = AyahBookmarkCollectionMenuController(
+            viewController: self,
+            viewModel: viewModel
+        )
     }
 
     @available(*, unavailable)
     @MainActor
     dynamic required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private var menuController: AyahBookmarkCollectionMenuController?
+}
+
+@MainActor
+private final class AyahBookmarkCollectionMenuController {
+    init(viewController: UIViewController, viewModel: AyahBookmarkCollectionsViewModel) {
+        self.viewController = viewController
+        self.viewModel = viewModel
+
+        updateNavigationItem(editMode: viewModel.editMode, collection: viewModel.collection)
+        Publishers.CombineLatest(viewModel.$editMode, viewModel.$collection)
+            .sink { [weak self] editMode, collection in
+                self?.updateNavigationItem(editMode: editMode, collection: collection)
+            }
+            .store(in: &cancellables)
+    }
+
+    private weak var viewController: UIViewController?
+    private let viewModel: AyahBookmarkCollectionsViewModel
+    private var cancellables: Set<AnyCancellable> = []
+
+    private func updateNavigationItem(editMode: EditMode, collection: AyahBookmarkCollection?) {
+        guard let viewController, let collection else {
+            return
+        }
+
+        viewController.title = collection.kind.highlightColor?.localizedName ?? collection.collection.name
+        if editMode.isEditing {
+            let doneButton = UIBarButtonItem(
+                title: l("button.done"),
+                primaryAction: UIAction { [weak self] _ in
+                    self?.viewModel.editMode = .inactive
+                }
+            )
+            doneButton.tintColor = .appIdentity
+            viewController.navigationItem.rightBarButtonItem = doneButton
+        } else {
+            let moreButton = UIBarButtonItem(
+                image: UIImage(systemName: "ellipsis.circle"),
+                menu: menu(for: collection)
+            )
+            moreButton.tintColor = .appIdentity
+            viewController.navigationItem.rightBarButtonItem = moreButton
+        }
+    }
+
+    private func menu(for collection: AyahBookmarkCollection) -> UIMenu {
+        var actions = [
+            UIAction(
+                title: l("bookmarks.collections.edit.action"),
+                image: UIImage(systemName: "pencil")
+            ) { [weak self] _ in
+                self?.viewModel.editMode = .active
+            },
+        ]
+
+        if collection.kind.canRename {
+            actions.append(
+                UIAction(
+                    title: l("bookmarks.collections.rename"),
+                    image: UIImage(systemName: "pencil.line")
+                ) { [weak self] _ in
+                    self?.viewModel.presentRenameCollection()
+                }
+            )
+        }
+
+        if collection.kind.canDelete {
+            actions.append(
+                UIAction(
+                    title: l("button.delete"),
+                    image: UIImage(systemName: "trash"),
+                    attributes: .destructive
+                ) { [weak self] _ in
+                    guard let self else {
+                        return
+                    }
+                    Task { await self.viewModel.deleteCollection() }
+                }
+            )
+        }
+
+        return UIMenu(children: actions)
     }
 }
 #endif

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
@@ -8,6 +8,7 @@
 import Combine
 import QuranAnnotations
 import QuranKit
+import SwiftUI
 import VLogging
 
 @MainActor
@@ -16,18 +17,24 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
 
     init(
         ayahBookmarkCollectionService: AyahBookmarkCollectionService,
-        collectionID: String,
-        navigateToPage: @escaping (Page) -> Void
+        collection: AyahBookmarkCollection,
+        navigateToPage: @escaping (Page) -> Void,
+        collectionDeleted: @escaping () -> Void
     ) {
         self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
-        self.collectionID = collectionID
+        self.collection = collection
+        collectionID = collection.collection.id
         self.navigateToPage = navigateToPage
+        self.collectionDeleted = collectionDeleted
     }
 
     // MARK: Internal
 
     @Published private(set) var collection: AyahBookmarkCollection?
+    @Published var editMode: EditMode = .inactive
     @Published var error: Error?
+    @Published var isPresentingRenameCollection = false
+    @Published var pendingCollectionName = ""
 
     func start() async {
         do {
@@ -55,10 +62,53 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
         }
     }
 
+    func presentRenameCollection() {
+        guard let collection, collection.kind.canRename else {
+            return
+        }
+        pendingCollectionName = collection.collection.name
+        isPresentingRenameCollection = true
+    }
+
+    func renamePendingCollection() async {
+        guard let collection, collection.kind.canRename else {
+            return
+        }
+        let name = pendingCollectionName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            return
+        }
+
+        do {
+            try await ayahBookmarkCollectionService.renameCollection(
+                id: collection.collection.id,
+                to: name
+            )
+        } catch {
+            self.error = error
+        }
+    }
+
+    func deleteCollection() async {
+        guard let collection, collection.kind.canDelete else {
+            return
+        }
+
+        do {
+            try await ayahBookmarkCollectionService.removeCollection(
+                id: collection.collection.id
+            )
+            collectionDeleted()
+        } catch {
+            self.error = error
+        }
+    }
+
     // MARK: Private
 
     private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
     private let collectionID: String
     private let navigateToPage: (Page) -> Void
+    private let collectionDeleted: () -> Void
 }
 #endif

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -72,11 +72,10 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     }
 
     static func deletableCollections(from collections: [AyahBookmarkCollection]) -> [AyahBookmarkCollection] {
-        let oldPageBookmarks = collections.filter(\.kind.isOldPageBookmarks)
-        let userCollections = collections.filter {
-            $0.kind == .user
-        }
-        return oldPageBookmarks + userCollections
+        let deletableCollections = collections.filter(\.kind.canDelete)
+        let oldPageBookmarks = deletableCollections.filter(\.kind.isOldPageBookmarks)
+        let remainingCollections = deletableCollections.filter { !$0.kind.isOldPageBookmarks }
+        return oldPageBookmarks + remainingCollections
     }
 
     func start() async {
@@ -123,6 +122,9 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     }
 
     func deleteCollection(_ collection: AyahBookmarkCollection) async {
+        guard collection.kind.canDelete else {
+            return
+        }
         do {
             try await ayahBookmarkCollectionService.removeCollection(id: collection.collection.id)
         } catch {
@@ -132,7 +134,12 @@ final class BookmarkCollectionsViewModel: ObservableObject {
 
     func showCollection(_ collection: AyahBookmarkCollection) {
         navigationController?.pushViewController(
-            collectionsBuilder.buildCollection(collection),
+            collectionsBuilder.buildCollection(
+                collection,
+                collectionDeleted: { [weak navigationController] in
+                    navigationController?.popViewController(animated: true)
+                }
+            ),
             animated: true
         )
     }

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
@@ -31,13 +31,12 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
             AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405)
                 .first { !$0.collection.isDefault }
         )
-        let sut = makeSUT(collectionID: collection.collection.id, service: service)
+        let sut = makeSUT(collection: collection, service: service)
         let observed = expectation(description: "Observes persisted collection")
-        let observation = sut.$collection.sink { collection in
-            if collection?.collection.name == "Favorites" {
-                observed.fulfill()
-            }
-        }
+        let observation = sut.$collection
+            .filter { $0?.collection.name == "Favorites" }
+            .prefix(1)
+            .sink { _ in observed.fulfill() }
 
         let task = Task { await sut.start() }
         await fulfillment(of: [observed], timeout: 2)
@@ -67,7 +66,7 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
                 .first { $0.collection.name == oldPageBookmarksCollectionName }
         )
         let bookmark = try XCTUnwrap(collection.bookmarks.first)
-        let sut = makeSUT(collectionID: collection.collection.id, service: service)
+        let sut = makeSUT(collection: collection, service: service)
 
         await sut.deleteBookmark(bookmark)
 
@@ -81,14 +80,73 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
         XCTAssertNil(sut.error)
     }
 
+    func test_renamePendingCollection_updatesRealMobileSyncDatabase() async throws {
+        let service = makeService()
+        try await service.createCollection(named: "Favorites")
+        let collection = try await firstCollection()
+        let sut = makeSUT(collection: collection, service: service)
+        sut.pendingCollectionName = " Duas "
+
+        await sut.renamePendingCollection()
+
+        let renamedCollection = try await firstCollection()
+        XCTAssertEqual(renamedCollection.collection.name, "Duas")
+        XCTAssertNil(sut.error)
+    }
+
+    func test_deleteCollection_removesCollectionAndNotifiesListener() async throws {
+        let service = makeService()
+        try await service.createCollection(named: "Favorites")
+        let collection = try await firstCollection()
+        var didDeleteCollection = false
+        let sut = makeSUT(
+            collection: collection,
+            service: service,
+            collectionDeleted: { didDeleteCollection = true }
+        )
+
+        await sut.deleteCollection()
+
+        let stored = try await storedCollections {
+            $0.count == 1 && $0[0].collection.isDefault
+        }
+        XCTAssertEqual(stored.map(\.collection.name), ["Default"])
+        XCTAssertTrue(stored[0].collection.isDefault)
+        XCTAssertTrue(didDeleteCollection)
+        XCTAssertNil(sut.error)
+    }
+
+    func test_highlightCollectionCannotBeRenamedOrDeleted() async throws {
+        let service = makeService()
+        try await service.createCollection(named: "Red")
+        let collection = try await firstCollection()
+        var didDeleteCollection = false
+        let sut = makeSUT(
+            collection: collection,
+            service: service,
+            collectionDeleted: { didDeleteCollection = true }
+        )
+        sut.pendingCollectionName = "Renamed"
+
+        await sut.renamePendingCollection()
+        await sut.deleteCollection()
+
+        let storedCollection = try await firstCollection()
+        XCTAssertEqual(storedCollection.collection.name, "Red")
+        XCTAssertFalse(didDeleteCollection)
+        XCTAssertNil(sut.error)
+    }
+
     private func makeSUT(
-        collectionID: String,
-        service: AyahBookmarkCollectionService? = nil
+        collection: AyahBookmarkCollection,
+        service: AyahBookmarkCollectionService? = nil,
+        collectionDeleted: @escaping () -> Void = {}
     ) -> AyahBookmarkCollectionsViewModel {
         AyahBookmarkCollectionsViewModel(
             ayahBookmarkCollectionService: service ?? makeService(),
-            collectionID: collectionID,
-            navigateToPage: { _ in }
+            collection: collection,
+            navigateToPage: { _ in },
+            collectionDeleted: collectionDeleted
         )
     }
 
@@ -106,6 +164,16 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
             }
         }
         throw TestError.expectedDatabaseStateNotObserved
+    }
+
+    private func firstCollection() async throws -> AyahBookmarkCollection {
+        let stored = try await storedCollections {
+            $0.contains { !$0.collection.isDefault }
+        }
+        return try XCTUnwrap(
+            AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405)
+                .first { !$0.collection.isDefault }
+        )
     }
 }
 

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -2,6 +2,7 @@
 import AuthenticationClient
 import AuthenticationClientFake
 import Combine
+import Localization
 import MobileSync
 import MobileSyncTestSupport
 import QuranAnnotations
@@ -69,6 +70,56 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         }
         XCTAssertEqual(collection(name: "Default", id: "__default__").kind, .defaultBookmarks)
         XCTAssertEqual(collection(name: "Favorites").kind, .user)
+    }
+
+    func test_collectionCapabilities_protectSystemCollections() {
+        let defaultBookmarks = collection(name: "Default", id: "__default__")
+        let highlight = collection(name: "Red")
+        let oldPageBookmarks = collection(name: oldPageBookmarksCollectionName)
+        let user = collection(name: "Favorites")
+
+        XCTAssertFalse(defaultBookmarks.kind.canRename)
+        XCTAssertFalse(defaultBookmarks.kind.canDelete)
+        XCTAssertFalse(highlight.kind.canRename)
+        XCTAssertFalse(highlight.kind.canDelete)
+        XCTAssertTrue(oldPageBookmarks.kind.canRename)
+        XCTAssertTrue(oldPageBookmarks.kind.canDelete)
+        XCTAssertTrue(user.kind.canRename)
+        XCTAssertTrue(user.kind.canDelete)
+    }
+
+    func test_collectionDetailsMenu_onlyShowsEditForHighlightCollection() {
+        let collection = collection(name: "Red")
+        let viewModel = makeCollectionDetailsViewModel(collection: collection)
+        let viewController = AyahBookmarkCollectionsViewController(viewModel: viewModel)
+
+        let titles = viewController.navigationItem.rightBarButtonItem?.menu?.children.map(\.title)
+
+        XCTAssertEqual(titles, [l("bookmarks.collections.edit.action")])
+    }
+
+    func test_collectionDetailsMenu_showsAllActionsForUserCollection() {
+        let collection = collection(name: "Favorites")
+        let viewModel = makeCollectionDetailsViewModel(collection: collection)
+        let viewController = AyahBookmarkCollectionsViewController(viewModel: viewModel)
+
+        let titles = viewController.navigationItem.rightBarButtonItem?.menu?.children.map(\.title)
+
+        XCTAssertEqual(titles, [
+            l("bookmarks.collections.edit.action"),
+            l("bookmarks.collections.rename"),
+            l("button.delete"),
+        ])
+    }
+
+    func test_collectionDetailsController_showsDoneButtonInEditMode() {
+        let collection = collection(name: "Favorites")
+        let viewModel = makeCollectionDetailsViewModel(collection: collection)
+        let viewController = AyahBookmarkCollectionsViewController(viewModel: viewModel)
+
+        viewModel.editMode = .active
+
+        XCTAssertEqual(viewController.navigationItem.rightBarButtonItem?.title, l("button.done"))
     }
 
     func test_collectionsViewController_hidesEditButtonWithoutDeletableCollections() {
@@ -259,6 +310,17 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
 
     private func makeService() -> AyahBookmarkCollectionService {
         AyahBookmarkCollectionService(quranDataService: database.quranDataService)
+    }
+
+    private func makeCollectionDetailsViewModel(
+        collection: AyahBookmarkCollection
+    ) -> AyahBookmarkCollectionsViewModel {
+        AyahBookmarkCollectionsViewModel(
+            ayahBookmarkCollectionService: makeService(),
+            collection: collection,
+            navigateToPage: { _ in },
+            collectionDeleted: {}
+        )
     }
 
     private func storedOldPageBookmarksCollection() async throws -> CollectionWithAyahBookmarks {

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endef
 .PHONY: build-no-sync build-sync
 .PHONY: build-example-no-sync build-example-sync
 .PHONY: run-example-no-sync run-example-sync
-.PHONY: clone-swiftformat build-swiftformat force-build-swiftformat clean-swiftformat format-lint format-autocorrect
+.PHONY: clone-swiftformat build-swiftformat force-build-swiftformat clean-swiftformat format-lint format-autocorrect lint-no-kotlin-interop
 .PHONY: install-swiftlint build-for-analyzer swiftlint-analyzer
 
 test-no-sync:
@@ -107,7 +107,16 @@ force-build-swiftformat: clone-swiftformat
 clean-swiftformat:
 	@rm -rf $(SWIFT_FORMAT_DIR)/.build
 
-format-lint: $(SWIFT_FORMAT_BIN)
+lint-no-kotlin-interop:
+	@matches="$$(git grep --line-number --extended-regexp '(^|[[:space:]])import[[:space:]]+KMPNativeCoroutines|(^|[^[:alnum:]_])(asyncFunction|asyncSequence)[[:space:]]*\(' -- '*.swift' || true)"; \
+	if [ -n "$$matches" ]; then \
+		echo "$$matches"; \
+		echo "error: Direct Kotlin coroutine interop is forbidden in QuranEngine Swift sources." >&2; \
+		echo "Use the Swift-native async APIs exposed by MobileSync; add missing wrappers upstream." >&2; \
+		exit 1; \
+	fi
+
+format-lint: lint-no-kotlin-interop $(SWIFT_FORMAT_BIN)
 	$(SWIFT_FORMAT_BIN) --lint .
 
 format-autocorrect: $(SWIFT_FORMAT_BIN)


### PR DESCRIPTION
## What
- fail format-lint when app Swift sources import KMPNativeCoroutines directly
- reject direct asyncFunction and asyncSequence calls
- direct contributors to Swift-native MobileSync wrappers

## Stack
Based on #878 (mobile-sync-spm 0.1.16). #879 is stacked on this PR.

## Checks
- make format-lint
- make test-sync
- make test-no-sync
- make build-example-sync
- make build-example-no-sync