### PR TITLE
fix: show direct edit action for collection

### DIFF
--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
@@ -69,16 +69,24 @@ private final class AyahBookmarkCollectionMenuController {
             doneButton.tintColor = .appIdentity
             viewController.navigationItem.rightBarButtonItem = doneButton
         } else {
-            let moreButton = UIBarButtonItem(
-                image: UIImage(systemName: "ellipsis.circle"),
-                menu: menu(for: collection)
-            )
-            moreButton.tintColor = .appIdentity
-            viewController.navigationItem.rightBarButtonItem = moreButton
+            let actions = actions(for: collection)
+            let button = if let singleAction = actions.first, actions.count == 1 {
+                UIBarButtonItem(
+                    title: singleAction.title,
+                    primaryAction: singleAction
+                )
+            } else {
+                UIBarButtonItem(
+                    image: UIImage(systemName: "ellipsis.circle"),
+                    menu: UIMenu(children: actions)
+                )
+            }
+            button.tintColor = .appIdentity
+            viewController.navigationItem.rightBarButtonItem = button
         }
     }
 
-    private func menu(for collection: AyahBookmarkCollection) -> UIMenu {
+    private func actions(for collection: AyahBookmarkCollection) -> [UIAction] {
         var actions = [
             UIAction(
                 title: l("bookmarks.collections.edit.action"),
@@ -114,7 +122,7 @@ private final class AyahBookmarkCollectionMenuController {
             )
         }
 
-        return UIMenu(children: actions)
+        return actions
     }
 }
 #endif

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -88,14 +88,16 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         XCTAssertTrue(user.kind.canDelete)
     }
 
-    func test_collectionDetailsMenu_onlyShowsEditForHighlightCollection() {
+    func test_collectionDetailsController_showsDirectEditButtonForHighlightCollection() {
         let collection = collection(name: "Red")
         let viewModel = makeCollectionDetailsViewModel(collection: collection)
         let viewController = AyahBookmarkCollectionsViewController(viewModel: viewModel)
 
-        let titles = viewController.navigationItem.rightBarButtonItem?.menu?.children.map(\.title)
+        let button = viewController.navigationItem.rightBarButtonItem
 
-        XCTAssertEqual(titles, [l("bookmarks.collections.edit.action")])
+        XCTAssertEqual(button?.title, l("bookmarks.collections.edit.action"))
+        XCTAssertNotNil(button?.primaryAction)
+        XCTAssertNil(button?.menu)
     }
 
     func test_collectionDetailsMenu_showsAllActionsForUserCollection() {


### PR DESCRIPTION
## Summary

- Show a direct **Edit** navigation bar button when it is the collection’s only action.
- Preserve the ellipsis menu when rename or delete actions are also available.
- Add regression coverage for highlight collections.

## Root cause

The collection details controller always wrapped its actions in an overflow menu, even when the menu contained only one Edit action.

## Validation

- `make format-lint`
- Sync-enabled `BookmarksFeatureTests`: 30 tests passed
- `make build-no-sync TARGET=BookmarksFeature`

## Screenshots

Look at the navigation bar right buttons

<img width="368" alt="Screenshot 2026-07-15 at 10 37 54 AM" src="https://github.com/user-attachments/assets/95e54049-ee88-4558-bc7d-13b5aa51323f" />

<img width="368" alt="Screenshot 2026-07-15 at 10 38 37 AM" src="https://github.com/user-attachments/assets/4e17d6b3-99c8-4025-94e1-8c23a9c4cadf" />

<img width="368" alt="Screenshot 2026-07-15 at 10 30 15 AM" src="https://github.com/user-attachments/assets/8a911675-4c79-439e-907a-d33ab68a21ff" />
