### PR TITLE
feat: enhance bookmark collection details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,14 @@ Keeping these commands green locally should keep the CI workflow green as well.
 - Do not introduce new listener or delegate patterns unless extending an existing one; prefer closure-based callbacks for new interaction seams.
 - Views should stay mostly declarative; business logic belongs in view models/interactors/services.
 - Reuse NoorUI/UIx components before adding one-off controls.
+- Put new reusable UI components in NoorUI; avoid feature-local component duplicates.
+- Match established layouts in analogous features before introducing a new visual pattern.
+- Render Quran Arabic with NoorUI's Quran text APIs and Quran font; never use a system font.
+- Render sura names with NoorUI's locale-aware `MultipartText` sura interpolation: localized plus decorated Arabic outside Arabic locales, localized Arabic only in Arabic locales.
+- Prefer native `UINavigationItem` title, subtitle, and attributed-title APIs; use a custom `titleView` only when native APIs cannot meet the requirement. For pre-iOS 26 fallback, combine title and subtitle as `Title (Subtitle)`.
+- Inject concrete data services through builders and view models; do not wrap them in closure-based adapters.
+- Use `@ScaledMetric` for explicit UI dimensions that should scale with Dynamic Type; avoid fixed numeric layout metrics.
+- Prefer default `.padding()` spacing; specify edges or values only when the design requires custom spacing.
 - Preserve localized strings; do not hardcode user-facing text unless existing nearby code does.
 
 ## Concurrency

--- a/Core/Localization/Resources/ar.lproj/Android.strings
+++ b/Core/Localization/Resources/ar.lproj/Android.strings
@@ -38,7 +38,7 @@
 "available_translations" = "الملفات المتاحة للتحميل";
 "ayah_copied_popup" = "تم نسخ الآية";
 "bookmark_ayah" = "أضف الآية إلى المرجعيات";
-"bookmarks_list_empty" = "لا توجد أي مرجعيات";
+"bookmarks_list_empty" = "لا توجد إشارات مرجعية";
 "cancel" = "إلغاء";
 "canceling" = "جاري إلغاء اﻷمر…";
 "comma" = "\"،\"";

--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -133,8 +133,10 @@
 "bookmarks.collections.no-data.title" = "لا توجد مجموعات حتى الآن";
 "bookmarks.collections.no-data.text" = "أنشئ مجموعة لتنظيم الآيات حسب الموضوع أو الدعاء أو خطة الحفظ.";
 "bookmarks.collections.ayah-count" = "%d إشارات مرجعية للآيات";
-"bookmarks.collections.ayahs.no-data.title" = "لا توجد إشارات مرجعية في هذه المجموعة";
-"bookmarks.collections.ayahs.no-data.text" = "أضف إشارات مرجعية للآيات لرؤيتها هنا.";
+"bookmarks.collections.ayahs.delete-hint" = "اسحب الإشارة المرجعية لحذفها.";
+"bookmarks.collections.ayahs.open-hint" = "يفتح هذه الآية في القرآن.";
+"bookmarks.collections.ayahs.no-data.text" = "ستظهر هنا الآيات التي تضيف لها إشارة مرجعية أثناء القراءة.";
+"bookmarks.collections.ayahs.no-data.colored.text" = "ستظهر هنا الآيات التي تميّزها أثناء القراءة بإشارة مرجعية باللون %@.";
 "bookmarks.old-page-bookmarks" = "إشارات الصفحات المرجعية القديمة";
 
 "bookmarks.sync.title" = "زامن العلامات المرجعية";

--- a/Core/Localization/Resources/ar.lproj/Localizable.stringsdict
+++ b/Core/Localization/Resources/ar.lproj/Localizable.stringsdict
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>bookmarks.collections.ayahs.count</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@bookmarks@</string>
+        <key>bookmarks</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>zero</key>
+            <string>لا توجد إشارات مرجعية</string>
+            <key>one</key>
+            <string>إشارة مرجعية واحدة</string>
+            <key>two</key>
+            <string>إشارتان مرجعيتان</string>
+            <key>few</key>
+            <string>%d إشارات مرجعية</string>
+            <key>many</key>
+            <string>%d إشارة مرجعية</string>
+            <key>other</key>
+            <string>%d إشارة مرجعية</string>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -152,8 +152,10 @@
 "bookmarks.collections.no-data.title" = "No collections yet";
 "bookmarks.collections.no-data.text" = "Create a collection to organize ayahs by theme, dua, or memorization plan.";
 "bookmarks.collections.ayah-count" = "%d ayah bookmarks";
-"bookmarks.collections.ayahs.no-data.title" = "No bookmarks in this collection";
-"bookmarks.collections.ayahs.no-data.text" = "Add ayah bookmarks to see them here.";
+"bookmarks.collections.ayahs.delete-hint" = "Swipe a bookmark to delete it.";
+"bookmarks.collections.ayahs.open-hint" = "Opens this ayah in the Quran.";
+"bookmarks.collections.ayahs.no-data.text" = "Ayahs you bookmark while reading will appear here.";
+"bookmarks.collections.ayahs.no-data.colored.text" = "Ayahs you highlight with a %@ bookmark while reading will appear here.";
 "bookmarks.highlights" = "Highlights";
 
 // MARK: - Notes

--- a/Core/Localization/Resources/en.lproj/Localizable.stringsdict
+++ b/Core/Localization/Resources/en.lproj/Localizable.stringsdict
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>bookmarks.collections.ayahs.count</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@bookmarks@</string>
+        <key>bookmarks</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>one</key>
+            <string>%d bookmark</string>
+            <key>other</key>
+            <string>%d bookmarks</string>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
@@ -8,15 +8,18 @@
 import NoorUI
 import QuranAnnotations
 import QuranKit
+import QuranTextKit
 import UIKit
 
 @MainActor
 struct AyahBookmarkCollectionsBuilder {
     init(
         ayahBookmarkCollectionService: AyahBookmarkCollectionService,
+        quranTextDataService: QuranTextDataService,
         navigateToPage: @escaping (Page) -> Void
     ) {
         self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
+        self.quranTextDataService = quranTextDataService
         self.navigateToPage = navigateToPage
     }
 
@@ -24,20 +27,18 @@ struct AyahBookmarkCollectionsBuilder {
         _ collection: AyahBookmarkCollection,
         collectionDeleted: @escaping () -> Void
     ) -> UIViewController {
-        let kind = collection.kind
         let viewModel = AyahBookmarkCollectionsViewModel(
             ayahBookmarkCollectionService: ayahBookmarkCollectionService,
             collection: collection,
+            quranTextDataService: quranTextDataService,
             navigateToPage: navigateToPage,
             collectionDeleted: collectionDeleted
         )
-        return AyahBookmarkCollectionsViewController(
-            viewModel: viewModel,
-            title: kind.highlightColor?.localizedName ?? collection.collection.name
-        )
+        return AyahBookmarkCollectionsViewController(viewModel: viewModel)
     }
 
     private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
+    private let quranTextDataService: QuranTextDataService
     private let navigateToPage: (Page) -> Void
 }
 #endif

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
@@ -24,82 +24,96 @@ struct AyahBookmarkCollectionsView: View {
     @StateObject var viewModel: AyahBookmarkCollectionsViewModel
 
     var body: some View {
-        Group {
-            if viewModel.collection?.bookmarks.isEmpty == true {
-                emptyCollection
-            } else {
-                NoorList {
-                    AyahBookmarkCollectionsContent(viewModel: viewModel)
-                }
-            }
-        }
-        .task { await viewModel.start() }
-        .renameCollectionAlert(viewModel: viewModel)
-        .errorAlert(error: $viewModel.error)
-        .environment(\.editMode, $viewModel.editMode)
-    }
-
-    private var emptyCollection: some View {
-        DataUnavailableView(
-            title: l("bookmarks.collections.ayahs.no-data.title"),
-            text: l("bookmarks.collections.ayahs.no-data.text"),
-            image: .bookmark
-        )
+        AyahBookmarkCollectionDetails(viewModel: viewModel, collection: viewModel.collection)
+            .task { await viewModel.start() }
+            .renameCollectionAlert(viewModel: viewModel)
+            .errorAlert(error: $viewModel.error)
+            .environment(\.editMode, $viewModel.editMode)
     }
 }
 
 @MainActor
-struct AyahBookmarkCollectionsContent: View {
+private struct AyahBookmarkCollectionDetails: View {
     @ObservedObject var viewModel: AyahBookmarkCollectionsViewModel
-    @State private var isExpanded = true
+    let collection: AyahBookmarkCollection
 
     var body: some View {
-        Group {
-            if let collection = viewModel.collection {
-                section(for: collection)
+        VStack {
+            if collection.bookmarks.isEmpty {
+                emptyCollection
             } else {
-                noData
+                filledCollection
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.systemGroupedBackground)
     }
 
     // MARK: Private
 
-    private var noData: some View {
-        DataUnavailableView(
-            title: l("bookmarks.collections.no-data.title"),
-            text: l("bookmarks.collections.no-data.text"),
-            image: .bookmark
+    private var highlightColor: HighlightColor? {
+        collection.kind.highlightColor
+    }
+
+    private var filledCollection: some View {
+        NoorList {
+            Section {
+                ForEach(collection.bookmarks) { bookmark in
+                    bookmarkRow(bookmark)
+                }
+                .onDelete { offsets in
+                    let bookmarks = offsets.map { collection.bookmarks[$0] }
+                    Task {
+                        for bookmark in bookmarks {
+                            await viewModel.deleteBookmark(bookmark)
+                        }
+                    }
+                }
+            } footer: {
+                Text(l("bookmarks.collections.ayahs.delete-hint"))
+                    .font(.body)
+                    .foregroundStyle(Color.tertiaryLabel)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top)
+                    .textCase(nil)
+            }
+        }
+    }
+
+    private var emptyCollection: some View {
+        NoorListEmptyState(
+            title: lAndroid("bookmarks_list_empty"),
+            text: emptyStateText,
+            image: .bookmark,
+            style: .prominent(
+                imageColor: highlightColor?.color ?? Color.appIdentity
+            )
         )
     }
 
-    @ViewBuilder
-    private func section(for collection: AyahBookmarkCollection) -> some View {
-        let highlightColor = collection.kind.highlightColor
-
-        NoorEditableCollapsibleSection(
-            title: highlightColor?.localizedName ?? collection.collection.name,
-            isExpanded: $isExpanded,
-            collection.bookmarks,
-            showsHeaderDeleteAction: false,
-            headerDeleteAction: nil
-        ) { bookmark in
-            bookmarkItem(bookmark, iconColor: highlightColor?.color)
+    private var emptyStateText: String {
+        if let highlightColor {
+            return lFormat(
+                "bookmarks.collections.ayahs.no-data.colored.text",
+                highlightColor.localizedName.lowercased()
+            )
         }
-        .onDelete { bookmark in
-            await viewModel.deleteBookmark(bookmark)
-        }
+        return l("bookmarks.collections.ayahs.no-data.text")
     }
 
-    private func bookmarkItem(_ bookmark: AyahCollectionBookmark, iconColor: Color?) -> some View {
+    private func bookmarkRow(_ bookmark: AyahCollectionBookmark) -> some View {
         NoorListItem(
-            image: .init(.bookmark, color: iconColor ?? .red),
-            title: "\(bookmark.ayah.sura.localizedName()) \(sura: bookmark.ayah.sura.arabicSuraName)",
-            subtitle: .init(text: bookmark.ayah.localizedName, location: .bottom),
-            accessory: .text(NumberFormatter.shared.format(bookmark.ayah.page.pageNumber))
-        ) {
-            viewModel.navigateTo(bookmark)
-        }
+            rightPretitle: "\(verse: viewModel.ayahTexts[bookmark.ayah] ?? " ", color: .clear, lineLimit: 2)",
+            title: bookmarkLocation(bookmark),
+            titleColor: .secondaryLabel,
+            action: { viewModel.navigateTo(bookmark) }
+        )
+        .accessibilityHint(l("bookmarks.collections.ayahs.open-hint"))
+    }
+
+    private func bookmarkLocation(_ bookmark: AyahCollectionBookmark) -> MultipartText {
+        let ayah = bookmark.ayah
+        return "\(ayah.localizedNameWithSuraNumber) \(sura: ayah.sura.arabicSuraName) · \(ayah.page.localizedName)"
     }
 }
 

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
@@ -8,22 +8,30 @@
 import Combine
 import Localization
 import NoorUI
+import QuranAnnotations
 import SwiftUI
 import UIKit
 
 final class AyahBookmarkCollectionsViewController: UIHostingController<AyahBookmarkCollectionsView> {
     // MARK: Lifecycle
 
-    init(
-        viewModel: AyahBookmarkCollectionsViewModel,
-        title: String = l("bookmarks.collections")
-    ) {
+    init(viewModel: AyahBookmarkCollectionsViewModel) {
         super.init(rootView: AyahBookmarkCollectionsView(viewModel: viewModel))
-        self.title = title
+        navigationItem.largeTitleDisplayMode = .always
         menuController = AyahBookmarkCollectionMenuController(
             viewController: self,
             viewModel: viewModel
         )
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.navigationBar.prefersLargeTitles = true
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        navigationController?.navigationBar.sizeToFit()
     }
 
     @available(*, unavailable)
@@ -53,12 +61,12 @@ private final class AyahBookmarkCollectionMenuController {
     private let viewModel: AyahBookmarkCollectionsViewModel
     private var cancellables: Set<AnyCancellable> = []
 
-    private func updateNavigationItem(editMode: EditMode, collection: AyahBookmarkCollection?) {
-        guard let viewController, let collection else {
+    private func updateNavigationItem(editMode: EditMode, collection: AyahBookmarkCollection) {
+        guard let viewController else {
             return
         }
 
-        viewController.title = collection.kind.highlightColor?.localizedName ?? collection.collection.name
+        updateTitle(for: collection, in: viewController)
         if editMode.isEditing {
             let doneButton = UIBarButtonItem(
                 title: l("button.done"),
@@ -84,6 +92,24 @@ private final class AyahBookmarkCollectionMenuController {
             button.tintColor = .appIdentity
             viewController.navigationItem.rightBarButtonItem = button
         }
+    }
+
+    private func updateTitle(for collection: AyahBookmarkCollection, in viewController: UIViewController) {
+        let title = collection.kind.highlightColor?.localizedName ?? collection.collection.name
+        let subtitle = bookmarkCountText(collection.bookmarks.count)
+
+        if #available(iOS 26.0, *) {
+            viewController.title = title
+            viewController.navigationItem.subtitle = subtitle
+            viewController.navigationItem.largeTitle = title
+            viewController.navigationItem.largeSubtitle = subtitle
+        } else {
+            viewController.title = "\(title) (\(subtitle))"
+        }
+    }
+
+    private func bookmarkCountText(_ count: Int) -> String {
+        lFormat("bookmarks.collections.ayahs.count", count)
     }
 
     private func actions(for collection: AyahBookmarkCollection) -> [UIAction] {

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
@@ -8,6 +8,7 @@
 import Combine
 import QuranAnnotations
 import QuranKit
+import QuranTextKit
 import SwiftUI
 import VLogging
 
@@ -18,19 +19,22 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
     init(
         ayahBookmarkCollectionService: AyahBookmarkCollectionService,
         collection: AyahBookmarkCollection,
+        quranTextDataService: QuranTextDataService,
         navigateToPage: @escaping (Page) -> Void,
         collectionDeleted: @escaping () -> Void
     ) {
         self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
         self.collection = collection
         collectionID = collection.collection.id
+        self.quranTextDataService = quranTextDataService
         self.navigateToPage = navigateToPage
         self.collectionDeleted = collectionDeleted
     }
 
     // MARK: Internal
 
-    @Published private(set) var collection: AyahBookmarkCollection?
+    @Published private(set) var collection: AyahBookmarkCollection
+    @Published private(set) var ayahTexts: [AyahNumber: String] = [:]
     @Published var editMode: EditMode = .inactive
     @Published var error: Error?
     @Published var isPresentingRenameCollection = false
@@ -40,8 +44,11 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
         do {
             let sequence = ayahBookmarkCollectionService.collectionsSequence()
             for try await collections in sequence {
-                collection = collections.first {
+                if let collection = collections.first(where: {
                     $0.collection.id == collectionID
+                }) {
+                    self.collection = collection
+                    try await loadAyahTexts(for: collection)
                 }
             }
         } catch {
@@ -63,7 +70,7 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
     }
 
     func presentRenameCollection() {
-        guard let collection, collection.kind.canRename else {
+        guard collection.kind.canRename else {
             return
         }
         pendingCollectionName = collection.collection.name
@@ -71,7 +78,7 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
     }
 
     func renamePendingCollection() async {
-        guard let collection, collection.kind.canRename else {
+        guard collection.kind.canRename else {
             return
         }
         let name = pendingCollectionName.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -90,7 +97,7 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
     }
 
     func deleteCollection() async {
-        guard let collection, collection.kind.canDelete else {
+        guard collection.kind.canDelete else {
             return
         }
 
@@ -107,8 +114,24 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
     // MARK: Private
 
     private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
+    private let quranTextDataService: QuranTextDataService
     private let collectionID: String
     private let navigateToPage: (Page) -> Void
     private let collectionDeleted: () -> Void
+
+    private func loadAyahTexts(for collection: AyahBookmarkCollection?) async throws {
+        guard let collection else {
+            ayahTexts = [:]
+            return
+        }
+
+        let ayahs = collection.bookmarks.map(\.ayah)
+        guard Set(ayahTexts.keys) != Set(ayahs) else {
+            return
+        }
+        ayahTexts = try await quranTextDataService
+            .textForVerses(ayahs, translations: [])
+            .mapValues(\.arabicText)
+    }
 }
 #endif

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsBuilder.swift
@@ -19,6 +19,7 @@ struct BookmarkCollectionsBuilder {
         let collectionService = AyahBookmarkCollectionService(quranDataService: container.quranDataService)
         let collectionsBuilder = AyahBookmarkCollectionsBuilder(
             ayahBookmarkCollectionService: collectionService,
+            quranTextDataService: container.textDataService(),
             navigateToPage: { [weak listener] page in
                 listener?.navigateTo(page: page, lastPage: nil, highlightingSearchAyah: nil)
             }

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
@@ -3,6 +3,8 @@ import Combine
 import MobileSync
 import MobileSyncTestSupport
 import QuranKit
+import QuranResources
+import QuranTextKit
 import XCTest
 @testable import BookmarksFeature
 
@@ -34,13 +36,39 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
         let sut = makeSUT(collection: collection, service: service)
         let observed = expectation(description: "Observes persisted collection")
         let observation = sut.$collection
-            .filter { $0?.collection.name == "Favorites" }
+            .filter { $0.collection.name == "Favorites" }
             .prefix(1)
             .sink { _ in observed.fulfill() }
 
         let task = Task { await sut.start() }
         await fulfillment(of: [observed], timeout: 2)
 
+        XCTAssertNil(sut.error)
+        task.cancel()
+        observation.cancel()
+    }
+
+    func test_start_loadsArabicTextForCollectionBookmarks() async throws {
+        let service = makeService()
+        try await service.createCollection(named: "Favorites")
+        let storedCollection = try await firstCollection()
+        let ayah = try XCTUnwrap(AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1))
+        try await service.addAyahBookmarkToCollection(
+            collectionId: storedCollection.collection.id,
+            ayah: ayah
+        )
+        let collection = try await firstCollection()
+        let sut = makeSUT(collection: collection, service: service)
+        let retrieved = expectation(description: "Retrieves Arabic text")
+        let observation = sut.$ayahTexts
+            .filter { $0[ayah]?.isEmpty == false }
+            .prefix(1)
+            .sink { _ in retrieved.fulfill() }
+
+        let task = Task { await sut.start() }
+        await fulfillment(of: [retrieved], timeout: 2)
+
+        XCTAssertFalse(try XCTUnwrap(sut.ayahTexts[ayah]).isEmpty)
         XCTAssertNil(sut.error)
         task.cancel()
         observation.cancel()
@@ -140,11 +168,13 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
     private func makeSUT(
         collection: AyahBookmarkCollection,
         service: AyahBookmarkCollectionService? = nil,
+        quranTextDataService: QuranTextDataService? = nil,
         collectionDeleted: @escaping () -> Void = {}
     ) -> AyahBookmarkCollectionsViewModel {
         AyahBookmarkCollectionsViewModel(
             ayahBookmarkCollectionService: service ?? makeService(),
             collection: collection,
+            quranTextDataService: quranTextDataService ?? makeQuranTextDataService(),
             navigateToPage: { _ in },
             collectionDeleted: collectionDeleted
         )
@@ -152,6 +182,13 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
 
     private func makeService() -> AyahBookmarkCollectionService {
         AyahBookmarkCollectionService(quranDataService: database.quranDataService)
+    }
+
+    private func makeQuranTextDataService() -> QuranTextDataService {
+        QuranTextDataService(
+            databasesURL: URL(fileURLWithPath: "/tmp/unavailable-translations-database"),
+            quranFileURL: QuranResources.quranUthmaniV2Database
+        )
     }
 
     private func storedCollections(

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -7,6 +7,8 @@ import MobileSync
 import MobileSyncTestSupport
 import QuranAnnotations
 import QuranKit
+import QuranResources
+import QuranTextKit
 import UIKit
 import XCTest
 @testable import BookmarksFeature
@@ -98,6 +100,41 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         XCTAssertEqual(button?.title, l("bookmarks.collections.edit.action"))
         XCTAssertNotNil(button?.primaryAction)
         XCTAssertNil(button?.menu)
+    }
+
+    func test_collectionDetailsController_usesNativeTitleAndSubtitle() throws {
+        let collection = collection(name: "Red")
+        let viewModel = makeCollectionDetailsViewModel(collection: collection)
+        let viewController = AyahBookmarkCollectionsViewController(viewModel: viewModel)
+        let title = try XCTUnwrap(collection.kind.highlightColor?.localizedName)
+        let subtitle = lFormat("bookmarks.collections.ayahs.count", 0)
+
+        if #available(iOS 26.0, *) {
+            XCTAssertEqual(viewController.navigationItem.largeTitleDisplayMode, .always)
+            XCTAssertEqual(viewController.title, title)
+            XCTAssertEqual(viewController.navigationItem.subtitle, subtitle)
+            XCTAssertEqual(viewController.navigationItem.largeTitle, title)
+            XCTAssertEqual(viewController.navigationItem.largeSubtitle, subtitle)
+        } else {
+            XCTAssertEqual(viewController.title, "\(title) (\(subtitle))")
+        }
+    }
+
+    func test_bookmarkCountLocalization_usesLocalePluralRules() {
+        XCTAssertEqual(lFormat("bookmarks.collections.ayahs.count", language: .english, 0), "0 bookmarks")
+        XCTAssertEqual(lFormat("bookmarks.collections.ayahs.count", language: .english, 1), "1 bookmark")
+        XCTAssertEqual(lFormat("bookmarks.collections.ayahs.count", language: .english, 2), "2 bookmarks")
+
+        let arabicFormat = l("bookmarks.collections.ayahs.count", language: .arabic)
+        let arabicCount: (Int) -> String = {
+            String(format: arabicFormat, locale: Locale(identifier: "ar"), arguments: [$0])
+        }
+        XCTAssertEqual(arabicCount(0), "لا توجد إشارات مرجعية")
+        XCTAssertEqual(arabicCount(1), "إشارة مرجعية واحدة")
+        XCTAssertEqual(arabicCount(2), "إشارتان مرجعيتان")
+        XCTAssertEqual(arabicCount(3), "3 إشارات مرجعية")
+        XCTAssertEqual(arabicCount(11), "11 إشارة مرجعية")
+        XCTAssertEqual(arabicCount(100), "100 إشارة مرجعية")
     }
 
     func test_collectionDetailsMenu_showsAllActionsForUserCollection() {
@@ -300,6 +337,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         let navigationController = navigationController ?? UINavigationController()
         let collectionsBuilder = AyahBookmarkCollectionsBuilder(
             ayahBookmarkCollectionService: collectionService,
+            quranTextDataService: makeQuranTextDataService(),
             navigateToPage: { _ in }
         )
         return BookmarkCollectionsViewModel(
@@ -320,8 +358,16 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         AyahBookmarkCollectionsViewModel(
             ayahBookmarkCollectionService: makeService(),
             collection: collection,
+            quranTextDataService: makeQuranTextDataService(),
             navigateToPage: { _ in },
             collectionDeleted: {}
+        )
+    }
+
+    private func makeQuranTextDataService() -> QuranTextDataService {
+        QuranTextDataService(
+            databasesURL: URL(fileURLWithPath: "/tmp/unavailable-translations-database"),
+            quranFileURL: QuranResources.quranUthmaniV2Database
         )
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -631,6 +631,7 @@ private func featuresTargets() -> [[Target]] {
             "AnnotationsService",
             "NoorUI",
             "Preferences",
+            "QuranTextKit",
             "ReadingService",
         ], testDependencies: [
             "Analytics",
@@ -640,6 +641,7 @@ private func featuresTargets() -> [[Target]] {
             "MobileSyncTestSupport",
             .product(name: "MobileSync", package: "mobile-sync-spm"),
             "PageBookmarkPersistence",
+            "QuranResources",
         ]),
 
         target(type, name: "QuranPagesFeature", hasTests: false, dependencies: [

--- a/UI/NoorUI/Components/List/NoorListEmptyState.swift
+++ b/UI/NoorUI/Components/List/NoorListEmptyState.swift
@@ -6,14 +6,34 @@ import SwiftUI
 import UIx
 
 public struct NoorListEmptyState: View {
-    public init(title: String, text: String, image: NoorSystemImage) {
+    public enum Style {
+        case standard
+        case prominent(imageColor: Color)
+    }
+
+    public init(
+        title: String,
+        text: String,
+        image: NoorSystemImage,
+        style: Style = .standard
+    ) {
         self.title = title
         self.text = text
         self.image = image
+        self.style = style
     }
 
     public var body: some View {
-        VStack(spacing: 8) {
+        switch style {
+        case .standard:
+            standardContent
+        case .prominent(let imageColor):
+            prominentContent(imageColor: imageColor)
+        }
+    }
+
+    private var standardContent: some View {
+        VStack {
             image.image
                 .font(.title)
                 .accessibilityHidden(true)
@@ -27,12 +47,37 @@ public struct NoorListEmptyState: View {
         }
         .foregroundColor(.secondaryLabel)
         .frame(maxWidth: .infinity)
-        .padding(.horizontal, 24)
-        .padding(.vertical, 28)
+        .padding()
         .accessibilityElement(children: .combine)
     }
+
+    private func prominentContent(imageColor: Color) -> some View {
+        VStack {
+            image.image
+                .font(.system(size: prominentImageSize, weight: .semibold))
+                .foregroundStyle(imageColor)
+                .padding(.bottom)
+                .accessibilityHidden(true)
+
+            Text(title)
+                .font(.title2.bold())
+                .foregroundStyle(Color.primary)
+
+            Text(text)
+                .font(.body)
+                .foregroundStyle(Color.secondaryLabel)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: prominentTextMaxWidth)
+        }
+        .padding()
+        .accessibilityElement(children: .combine)
+    }
+
+    @ScaledMetric(relativeTo: .title) private var prominentImageSize: CGFloat = 42
+    @ScaledMetric(relativeTo: .body) private var prominentTextMaxWidth: CGFloat = 300
 
     private let title: String
     private let text: String
     private let image: NoorSystemImage
+    private let style: Style
 }


### PR DESCRIPTION
Stacked on #881.

## Summary

- Redesign bookmark collection details with Quran text rows, localized ayah/page labels, and prominent empty states.
- Show collection name and plural-aware bookmark count through native navigation title/subtitle APIs.
- Reuse shared Android and QuranTextKit localization; add English and Arabic plural resources and accessibility guidance.
- Extend NoorUI's reusable list empty state and document the resulting UI conventions.

## Why

Collection details repeated section chrome, omitted Quran text, and used compact metadata that did not clearly identify each ayah. The initial localization approach also duplicated existing resources and manually selected count variants, which would not handle Arabic plural categories correctly.

## Impact

Users get richer bookmark rows, clearer empty states, native navigation metadata, direction-neutral deletion guidance, and correct English/Arabic bookmark counts. Existing navigation, editing, rename, and deletion behavior remains intact.

## Validation

- `make format-lint`
- `make test-sync`
- `make test-no-sync`
- Localization plist validation and dead-key scan

## Screenshots

<img width="368" alt="Screenshot 2026-07-15 at 11 56 35 AM" src="https://github.com/user-attachments/assets/1009713d-43b3-4840-9c9b-580895017b48" />

<img width="368"  alt="Screenshot 2026-07-15 at 11 56 49 AM" src="https://github.com/user-attachments/assets/3e5be646-b0c0-4d45-80d9-c30b254a3407" />

