### PR TITLE
fix: serialize last page updates

### DIFF
--- a/Domain/AnnotationsService/Sources/LastPageUpdater.swift
+++ b/Domain/AnnotationsService/Sources/LastPageUpdater.swift
@@ -24,10 +24,33 @@ import QuranKit
 
 @MainActor
 public final class LastPageUpdater {
+    private struct Request {
+        let generation: UInt
+        let page: Page
+        let shouldWriteUnchangedPage: Bool
+    }
+
+    private struct Operation {
+        let generation: UInt
+        let page: Page
+        let lastPage: LastPage?
+    }
+
     // MARK: Lifecycle
 
     public init(service: any LastPageService) {
+        let (requests, continuation) = AsyncStream.makeStream(
+            of: Request.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
         self.service = service
+        requestContinuation = continuation
+        startWorker(consuming: requests)
+    }
+
+    deinit {
+        workerTask?.cancel()
+        requestContinuation.finish()
     }
 
     // MARK: Public
@@ -35,46 +58,89 @@ public final class LastPageUpdater {
     public private(set) var lastPage: LastPage?
 
     public func configure(initialPage: Page, lastPage: LastPage?) {
+        generation &+= 1
         self.lastPage = lastPage
-
-        if let lastPage {
-            updateTo(page: initialPage, lastPage: lastPage)
-        } else {
-            create(page: initialPage)
-        }
+        enqueue(page: initialPage, shouldWriteUnchangedPage: true)
     }
 
     public func updateTo(pages: [Page]) {
         guard let page = pages.min() else {
             return
         }
-        // don't update if it's the same page
-        guard let lastPage, page != lastPage.page else { return }
-
-        updateTo(page: page, lastPage: lastPage)
+        enqueue(page: page, shouldWriteUnchangedPage: false)
     }
 
     // MARK: Private
 
     private let service: any LastPageService
+    private let requestContinuation: AsyncStream<Request>.Continuation
+    private var generation: UInt = 0
+    private var workerTask: Task<Void, Never>?
 
-    private func updateTo(page: Page, lastPage: LastPage) {
-        Task {
-            do {
-                self.lastPage = try await service.update(lastPage: lastPage, toPage: page)
-            } catch {
-                crasher.recordError(error, reason: "Failed to update last page")
+    private func enqueue(page: Page, shouldWriteUnchangedPage: Bool) {
+        let request = Request(
+            generation: generation,
+            page: page,
+            shouldWriteUnchangedPage: shouldWriteUnchangedPage
+        )
+        let result = requestContinuation.yield(request)
+        guard case .dropped(let previousRequest) = result,
+              previousRequest.generation == request.generation,
+              previousRequest.page == request.page,
+              previousRequest.shouldWriteUnchangedPage
+        else {
+            return
+        }
+
+        requestContinuation.yield(Request(
+            generation: request.generation,
+            page: request.page,
+            shouldWriteUnchangedPage: true
+        ))
+    }
+
+    private func startWorker(consuming requests: AsyncStream<Request>) {
+        let service = service
+        workerTask = Task { [weak self] in
+            for await request in requests {
+                guard !Task.isCancelled else { return }
+                guard let operation = self?.makeOperation(for: request) else { continue }
+
+                let result: Result<LastPage, Error>
+                do {
+                    if let lastPage = operation.lastPage {
+                        result = .success(try await service.update(lastPage: lastPage, toPage: operation.page))
+                    } else {
+                        result = .success(try await service.add(page: operation.page))
+                    }
+                } catch {
+                    result = .failure(error)
+                }
+
+                guard let self else { return }
+                finish(operation, with: result)
             }
         }
     }
 
-    private func create(page: Page) {
-        Task {
-            do {
-                lastPage = try await service.add(page: page)
-            } catch {
-                crasher.recordError(error, reason: "Failed to create a last page")
-            }
+    private func makeOperation(for request: Request) -> Operation? {
+        guard request.generation == generation else { return nil }
+        guard request.shouldWriteUnchangedPage || request.page != lastPage?.page else { return nil }
+        return Operation(generation: request.generation, page: request.page, lastPage: lastPage)
+    }
+
+    private func finish(_ operation: Operation, with result: Result<LastPage, Error>) {
+        guard operation.generation == generation else { return }
+
+        switch result {
+        case .success(let lastPage):
+            self.lastPage = lastPage
+        case .failure(let error):
+            guard !(error is CancellationError) else { return }
+            let reason = operation.lastPage == nil
+                ? "Failed to create a last page"
+                : "Failed to update last page"
+            crasher.recordError(error, reason: reason)
         }
     }
 }

--- a/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
+++ b/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
@@ -32,21 +32,218 @@ final class LastPageUpdaterTests: XCTestCase {
         XCTAssertEqual(service.addCallCount, 0)
     }
 
+    func test_scrollDuringCreation_updatesCreatedLastPageToLatestPage() async {
+        let service = ControllableLastPageService()
+        let sut = LastPageUpdater(service: service)
+
+        sut.configure(initialPage: quran.pages[0], lastPage: nil)
+        await waitUntil { await service.addPages == [self.quran.pages[0]] }
+        sut.updateTo(pages: [quran.pages[1]])
+
+        await service.completeNextAdd()
+        await waitUntil { await service.updateCalls.count == 1 }
+        let updateCalls = await service.updateCalls
+        XCTAssertEqual(updateCalls.first?.page, quran.pages[0])
+        XCTAssertEqual(updateCalls.first?.toPage, quran.pages[1])
+        await service.completeNextUpdate()
+        await waitUntil { sut.lastPage?.page == self.quran.pages[1] }
+    }
+
+    func test_rapidScrolling_serializesWritesAndCoalescesLatestPage() async {
+        let service = ControllableLastPageService()
+        let sut = LastPageUpdater(service: service)
+        let lastPage = makeLastPage(page: quran.pages[0])
+
+        sut.configure(initialPage: quran.pages[1], lastPage: lastPage)
+        await waitUntil { await service.updateCalls.count == 1 }
+        sut.updateTo(pages: [quran.pages[2]])
+        sut.updateTo(pages: [quran.pages[3]])
+        let callsWhileFirstUpdateIsPending = await service.updateCalls
+        XCTAssertEqual(callsWhileFirstUpdateIsPending.count, 1)
+
+        await service.completeNextUpdate()
+        await waitUntil { await service.updateCalls.count == 2 }
+        let updateCalls = await service.updateCalls
+        XCTAssertEqual(updateCalls[1].page, quran.pages[1])
+        XCTAssertEqual(updateCalls[1].toPage, quran.pages[3])
+        await service.completeNextUpdate()
+        await waitUntil { sut.lastPage?.page == self.quran.pages[3] }
+    }
+
+    func test_scrollBackToInFlightPage_doesNotCreateRedundantWrite() async {
+        let service = ControllableLastPageService()
+        let sut = LastPageUpdater(service: service)
+        let lastPage = makeLastPage(page: quran.pages[0])
+
+        sut.configure(initialPage: quran.pages[1], lastPage: lastPage)
+        await waitUntil { await service.updateCalls.count == 1 }
+        sut.updateTo(pages: [quran.pages[2]])
+        sut.updateTo(pages: [quran.pages[1]])
+
+        await service.completeNextUpdate()
+        await waitUntil { sut.lastPage?.page == self.quran.pages[1] }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        let updateCalls = await service.updateCalls
+        XCTAssertEqual(updateCalls.count, 1)
+    }
+
+    func test_updateToConfiguredPageBeforeWriteStarts_preservesConfigurationWrite() async {
+        let service = ControllableLastPageService()
+        let sut = LastPageUpdater(service: service)
+        let lastPage = makeLastPage(page: quran.pages[0])
+
+        sut.configure(initialPage: quran.pages[0], lastPage: lastPage)
+        sut.updateTo(pages: [quran.pages[0]])
+
+        await waitUntil { await service.updateCalls.count == 1 }
+        let updateCalls = await service.updateCalls
+        XCTAssertEqual(updateCalls.first?.page, quran.pages[0])
+        XCTAssertEqual(updateCalls.first?.toPage, quran.pages[0])
+    }
+
+    func test_scrollBackToCurrentPageWhileUpdateIsInFlight_updatesBackToCurrentPage() async {
+        let service = ControllableLastPageService()
+        let sut = LastPageUpdater(service: service)
+        let lastPage = makeLastPage(page: quran.pages[0])
+
+        sut.configure(initialPage: quran.pages[1], lastPage: lastPage)
+        await waitUntil { await service.updateCalls.count == 1 }
+        sut.updateTo(pages: [quran.pages[0]])
+
+        await service.completeNextUpdate()
+        await waitUntil { await service.updateCalls.count == 2 }
+        let updateCalls = await service.updateCalls
+        XCTAssertEqual(updateCalls[1].page, quran.pages[1])
+        XCTAssertEqual(updateCalls[1].toPage, quran.pages[0])
+
+        await service.completeNextUpdate()
+        await waitUntil { sut.lastPage?.page == self.quran.pages[0] }
+    }
+
+    func test_reconfigure_discardsInFlightResultBeforeStartingNewWrite() async {
+        let service = ControllableLastPageService()
+        let sut = LastPageUpdater(service: service)
+
+        sut.configure(initialPage: quran.pages[1], lastPage: makeLastPage(page: quran.pages[0]))
+        await waitUntil { await service.updateCalls.count == 1 }
+        sut.configure(initialPage: quran.pages[11], lastPage: makeLastPage(page: quran.pages[10]))
+        let callsWhileFirstUpdateIsPending = await service.updateCalls
+        XCTAssertEqual(callsWhileFirstUpdateIsPending.count, 1)
+
+        await service.completeNextUpdate()
+        await waitUntil { await service.updateCalls.count == 2 }
+        let updateCalls = await service.updateCalls
+        XCTAssertEqual(updateCalls[1].page, quran.pages[10])
+        XCTAssertEqual(updateCalls[1].toPage, quran.pages[11])
+        XCTAssertEqual(sut.lastPage?.page, quran.pages[10])
+        await service.completeNextUpdate()
+        await waitUntil { sut.lastPage?.page == self.quran.pages[11] }
+    }
+
+    func test_deinit_cancelsInFlightWrite() async {
+        let service = ControllableLastPageService()
+        weak var weakSUT: LastPageUpdater?
+
+        do {
+            let sut = LastPageUpdater(service: service)
+            weakSUT = sut
+            sut.configure(initialPage: quran.pages[0], lastPage: nil)
+            await waitUntil { await service.addPages.count == 1 }
+        }
+
+        await waitUntil { weakSUT == nil }
+        await waitUntil { await service.cancellationCount == 1 }
+    }
+
     private let quran = Quran(raw: Madani1405QuranReadingInfoRawData())
+
+    private func makeLastPage(page: Page) -> LastPage {
+        LastPage(page: page, createdOn: Date(), modifiedOn: Date())
+    }
 
     private func waitUntil(
         timeoutIterations: Int = 100,
-        condition: @escaping @MainActor () -> Bool,
+        condition: @escaping @MainActor () async -> Bool,
         file: StaticString = #filePath,
         line: UInt = #line
     ) async {
         for _ in 0 ..< timeoutIterations {
-            if condition() {
+            if await condition() {
                 return
             }
             await Task.yield()
         }
         XCTFail("Condition was not met in time", file: file, line: line)
+    }
+}
+
+private actor ControllableLastPageService: LastPageService {
+    struct UpdateCall: Equatable {
+        let page: Page
+        let toPage: Page
+    }
+
+    private(set) var addPages: [Page] = []
+    private(set) var updateCalls: [UpdateCall] = []
+    private(set) var cancellationCount = 0
+
+    nonisolated func lastPages(quran _: Quran) -> AnyPublisher<[LastPage], Never> {
+        Just([]).eraseToAnyPublisher()
+    }
+
+    func add(page: Page) async throws -> LastPage {
+        addPages.append(page)
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                pendingAdds.append((page, continuation))
+            }
+        } onCancel: {
+            Task { await self.cancelPendingOperation() }
+        }
+    }
+
+    func update(lastPage: LastPage, toPage: Page) async throws -> LastPage {
+        updateCalls.append(UpdateCall(page: lastPage.page, toPage: toPage))
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                pendingUpdates.append((toPage, continuation))
+            }
+        } onCancel: {
+            Task { await self.cancelPendingOperation() }
+        }
+    }
+
+    func completeNextAdd() {
+        let pending = pendingAdds.removeFirst()
+        pending.continuation.resume(returning: makeLastPage(page: pending.page))
+    }
+
+    func completeNextUpdate() {
+        let pending = pendingUpdates.removeFirst()
+        pending.continuation.resume(returning: makeLastPage(page: pending.page))
+    }
+
+    private typealias PendingOperation = (
+        page: Page,
+        continuation: CheckedContinuation<LastPage, Error>
+    )
+
+    private var pendingAdds: [PendingOperation] = []
+    private var pendingUpdates: [PendingOperation] = []
+
+    private func cancelPendingOperation() {
+        cancellationCount += 1
+        if !pendingAdds.isEmpty {
+            pendingAdds.removeFirst().continuation.resume(throwing: CancellationError())
+        } else if !pendingUpdates.isEmpty {
+            pendingUpdates.removeFirst().continuation.resume(throwing: CancellationError())
+        }
+    }
+
+    private func makeLastPage(page: Page) -> LastPage {
+        LastPage(page: page, createdOn: Date(), modifiedOn: Date())
     }
 }
 


### PR DESCRIPTION
## Summary

- serialize last-page persistence through a single async request stream
- coalesce rapid page changes while preserving required writes
- discard stale results after reconfiguration
- add lifecycle, ordering, and regression coverage

## Why

Overlapping writes could complete out of order, publish stale state, or perform redundant persistence work.

## Validation

- `make format-lint`
- `make test-no-sync`
- `make test-sync`

Stack: 2/7. Base: `afifi/last-page-collision-sessions`.