### PR TITLE
refactor: observe last pages asynchronously

### DIFF
--- a/Domain/AnnotationsService/Sources/LastPageService.swift
+++ b/Domain/AnnotationsService/Sources/LastPageService.swift
@@ -6,12 +6,42 @@
 //  Copyright © 2023 Quran.com. All rights reserved.
 //
 
-import Combine
 import QuranAnnotations
 import QuranKit
 
+public struct LastPagesSequence: AsyncSequence {
+    public typealias Element = [LastPage]
+
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
+            var iterator = sequence.makeAsyncIterator()
+            nextValue = {
+                try await iterator.next()
+            }
+        }
+
+        public mutating func next() async throws -> Element? {
+            try await nextValue()
+        }
+
+        private let nextValue: () async throws -> Element?
+    }
+
+    public init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
+        makeIterator = {
+            AsyncIterator(sequence)
+        }
+    }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        makeIterator()
+    }
+
+    private let makeIterator: () -> AsyncIterator
+}
+
 public protocol LastPageService {
-    func lastPages(quran: Quran) -> AnyPublisher<[LastPage], Never>
+    func lastPages(quran: Quran) -> LastPagesSequence
 
     func add(page: Page) async throws -> LastPage
 

--- a/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
@@ -7,7 +7,6 @@
 //
 
 #if QURAN_SYNC
-import Combine
 import Foundation
 @preconcurrency import MobileSync
 import QuranAnnotations
@@ -22,28 +21,16 @@ public struct MobileSyncLastPageService: LastPageService, @unchecked Sendable {
 
     // MARK: Public
 
-    public func lastPages(quran: Quran) -> AnyPublisher<[LastPage], Never> {
-        let subject = CurrentValueSubject<[LastPage], Never>([])
-        let task = Task {
-            do {
-                for try await sessions in quranDataService.readingSessionsSequence() {
-                    if Task.isCancelled {
-                        break
-                    }
-                    let mapped = sessions.compactMap { session in
-                        lastPage(for: session, quran: quran)
-                    }
-
-                    let sorted = mapped.sorted { $0.createdOn > $1.createdOn }
-                    subject.send(Array(sorted.prefix(3)))
+    public func lastPages(quran: Quran) -> LastPagesSequence {
+        let sequence = quranDataService.readingSessionsSequence()
+            .map { sessions in
+                let mapped = sessions.compactMap { session in
+                    lastPage(for: session, quran: quran)
                 }
-            } catch {
-                // ignore errors
+                let sorted = mapped.sorted { $0.createdOn > $1.createdOn }
+                return Array(sorted.prefix(3))
             }
-        }
-        return subject
-            .handleEvents(receiveCancel: { task.cancel() })
-            .eraseToAnyPublisher()
+        return LastPagesSequence(sequence)
     }
 
     public func add(page: Page) async throws -> LastPage {

--- a/Domain/AnnotationsService/Sources/PersistenceLastPageService.swift
+++ b/Domain/AnnotationsService/Sources/PersistenceLastPageService.swift
@@ -21,9 +21,9 @@ public struct PersistenceLastPageService: LastPageService {
 
     // MARK: Public
 
-    public func lastPages(quran: Quran) -> AnyPublisher<[LastPage], Never> {
+    public func lastPages(quran: Quran) -> LastPagesSequence {
         let mapper = QuranPageMapper(destination: quran)
-        return persistence.lastPages()
+        let sequence = persistence.lastPages()
             .map { lastPages in
                 lastPages.compactMap { lastPage in
                     Page(quran: storedPageQuran, pageNumber: lastPage.page)
@@ -33,7 +33,8 @@ public struct PersistenceLastPageService: LastPageService {
                         }
                 }
             }
-            .eraseToAnyPublisher()
+            .values()
+        return LastPagesSequence(sequence)
     }
 
     public func add(page: Page) async throws -> LastPage {

--- a/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
+++ b/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
@@ -189,8 +189,8 @@ private actor ControllableLastPageService: LastPageService {
     private(set) var updateCalls: [UpdateCall] = []
     private(set) var cancellationCount = 0
 
-    nonisolated func lastPages(quran _: Quran) -> AnyPublisher<[LastPage], Never> {
-        Just([]).eraseToAnyPublisher()
+    nonisolated func lastPages(quran _: Quran) -> LastPagesSequence {
+        LastPagesSequence(Just<[LastPage]>([]).values)
     }
 
     func add(page: Page) async throws -> LastPage {
@@ -258,8 +258,8 @@ private final class LastPageServiceSpy: LastPageService {
     private(set) var addPages: [Page] = []
     private(set) var updateCalls: [UpdateCall] = []
 
-    func lastPages(quran _: Quran) -> AnyPublisher<[LastPage], Never> {
-        Just([]).eraseToAnyPublisher()
+    func lastPages(quran _: Quran) -> LastPagesSequence {
+        LastPagesSequence(Just<[LastPage]>([]).values)
     }
 
     func add(page: Page) async throws -> LastPage {

--- a/Domain/AnnotationsService/Tests/LastPagesSequenceTests.swift
+++ b/Domain/AnnotationsService/Tests/LastPagesSequenceTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import AnnotationsService
+@testable import QuranAnnotations
+
+final class LastPagesSequenceTests: XCTestCase {
+    func test_forwardsValuesAndCompletion() async throws {
+        let source = AsyncStream<[LastPage]> { continuation in
+            continuation.yield([])
+            continuation.finish()
+        }
+        let sequence = LastPagesSequence(source)
+        var iterator = sequence.makeAsyncIterator()
+
+        let value = try await iterator.next()
+        let completion = try await iterator.next()
+
+        XCTAssertEqual(value, [])
+        XCTAssertNil(completion)
+    }
+
+    func test_forwardsErrors() async {
+        let source = AsyncThrowingStream<[LastPage], Error> { continuation in
+            continuation.finish(throwing: TestError.expected)
+        }
+        let sequence = LastPagesSequence(source)
+        var iterator = sequence.makeAsyncIterator()
+
+        do {
+            _ = try await iterator.next()
+            XCTFail("Expected the source error")
+        } catch {
+            XCTAssertEqual(error as? TestError, .expected)
+        }
+    }
+
+    func test_forwardsCancellation() async {
+        let cancelled = expectation(description: "Source receives cancellation")
+        let source = AsyncThrowingStream<[LastPage], Error> { continuation in
+            continuation.onTermination = { termination in
+                guard case .cancelled = termination else { return }
+                cancelled.fulfill()
+            }
+        }
+        let sequence = LastPagesSequence(source)
+        let observation = Task {
+            var iterator = sequence.makeAsyncIterator()
+            _ = try await iterator.next()
+        }
+
+        await Task.yield()
+        observation.cancel()
+
+        await fulfillment(of: [cancelled], timeout: 1)
+        _ = await observation.result
+    }
+
+    func test_iteratorsOwnIndependentSourceIterators() async throws {
+        let sequence = LastPagesSequence(SingleValueSequence())
+        var first = sequence.makeAsyncIterator()
+        var second = sequence.makeAsyncIterator()
+
+        let firstValue = try await first.next()
+        let secondValue = try await second.next()
+        let firstCompletion = try await first.next()
+        let secondCompletion = try await second.next()
+
+        XCTAssertEqual(firstValue, [])
+        XCTAssertEqual(secondValue, [])
+        XCTAssertNil(firstCompletion)
+        XCTAssertNil(secondCompletion)
+    }
+}
+
+private enum TestError: Error {
+    case expected
+}
+
+private struct SingleValueSequence: AsyncSequence {
+    struct AsyncIterator: AsyncIteratorProtocol {
+        var hasValue = true
+
+        mutating func next() async -> [LastPage]? {
+            guard hasValue else { return nil }
+            hasValue = false
+            return []
+        }
+    }
+
+    func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator()
+    }
+}

--- a/Domain/AnnotationsService/Tests/MobileSyncLastPageServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncLastPageServiceTests.swift
@@ -1,5 +1,4 @@
 #if QURAN_SYNC
-import Combine
 import MobileSyncTestSupport
 import QuranKit
 import XCTest
@@ -25,18 +24,25 @@ final class MobileSyncLastPageServiceTests: XCTestCase {
         let quran = Quran.hafsMadani1405
         let page = quran.pages[10]
         let published = expectation(description: "Publishes the persisted last page")
-        let cancellable = service.lastPages(quran: quran).sink { lastPages in
-            if lastPages.first?.page == page {
-                published.fulfill()
+        let observation = Task {
+            do {
+                for try await lastPages in service.lastPages(quran: quran) where lastPages.first?.page == page {
+                    published.fulfill()
+                    return
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                XCTFail("Unexpected observation error: \(error)")
             }
         }
+        defer { observation.cancel() }
 
         let lastPage = try await service.add(page: page)
 
         XCTAssertEqual(lastPage.page, page)
         XCTAssertNotNil(lastPage.localId)
         await fulfillment(of: [published], timeout: 2)
-        cancellable.cancel()
     }
 
     func test_update_persistsNewPageOnExistingReadingSession() async throws {
@@ -73,6 +79,60 @@ final class MobileSyncLastPageServiceTests: XCTestCase {
         let value = try await iterator.next()
         let storedSessions = try XCTUnwrap(value)
         XCTAssertEqual(Set(storedSessions.map(\.id)), Set([sourceID, destinationID]))
+    }
+
+    func test_lastPagesObserversCancelIndependently() async throws {
+        let quran = Quran.hafsMadani1405
+        let firstPage = quran.pages[10]
+        let secondPage = quran.pages[20]
+        let firstObserverPublished = expectation(description: "First observer publishes")
+        let secondObserverPublishedFirstPage = expectation(description: "Second observer publishes first page")
+        let secondObserverPublishedSecondPage = expectation(description: "Second observer remains active")
+        let firstObservation = Task {
+            var published = false
+            do {
+                for try await lastPages in service.lastPages(quran: quran) {
+                    if !published, lastPages.contains(where: { $0.page == firstPage }) {
+                        published = true
+                        firstObserverPublished.fulfill()
+                    }
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                XCTFail("Unexpected first-observer error: \(error)")
+            }
+        }
+        let secondObservation = Task {
+            var publishedFirstPage = false
+            do {
+                for try await lastPages in service.lastPages(quran: quran) {
+                    if !publishedFirstPage, lastPages.contains(where: { $0.page == firstPage }) {
+                        publishedFirstPage = true
+                        secondObserverPublishedFirstPage.fulfill()
+                    }
+                    if lastPages.contains(where: { $0.page == secondPage }) {
+                        secondObserverPublishedSecondPage.fulfill()
+                        return
+                    }
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                XCTFail("Unexpected second-observer error: \(error)")
+            }
+        }
+        defer {
+            firstObservation.cancel()
+            secondObservation.cancel()
+        }
+
+        _ = try await service.add(page: firstPage)
+        await fulfillment(of: [firstObserverPublished, secondObserverPublishedFirstPage], timeout: 2)
+        firstObservation.cancel()
+        _ = try await service.add(page: secondPage)
+
+        await fulfillment(of: [secondObserverPublishedSecondPage], timeout: 2)
     }
 }
 #endif

--- a/Domain/AnnotationsService/Tests/PageMappingServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/PageMappingServiceTests.swift
@@ -87,13 +87,15 @@ final class PageMappingServiceTests: XCTestCase {
         XCTAssertEqual(bookmarks.map(\.page.pageNumber), [2])
     }
 
-    func testLastPagesMapStoredCanonicalPagesToRequestedQuran() {
+    func testLastPagesMapStoredCanonicalPagesToRequestedQuran() async throws {
         let persistence = LastPagePersistenceFake(lastPages: [
             LastPagePersistenceModel(page: 1, createdOn: date, modifiedOn: laterDate),
         ])
         let service = PersistenceLastPageService(persistence: persistence)
 
-        let lastPages = value(from: service.lastPages(quran: skippedPageQuran()))
+        var iterator = service.lastPages(quran: skippedPageQuran()).makeAsyncIterator()
+        let nextLastPages = try await iterator.next()
+        let lastPages = try XCTUnwrap(nextLastPages)
 
         XCTAssertEqual(lastPages.map(\.page.pageNumber), [2])
         XCTAssertEqual(lastPages.map(\.createdOn), [date])

--- a/Features/HomeFeature/HomeViewModel.swift
+++ b/Features/HomeFeature/HomeViewModel.swift
@@ -109,16 +109,28 @@ final class HomeViewModel: ObservableObject {
     private let readingPreferences = ReadingPreferences.shared
 
     private func loadLastPages() async {
-        let lastPagesSequence = readingPreferences.$reading
+        let readings = readingPreferences.$reading
             .prepend(readingPreferences.reading)
-            .map { [lastPageService] reading in
-                lastPageService.lastPages(quran: reading.quran)
-            }
-            .switchToLatest()
             .values()
+        var observationTask: Task<Void, Never>?
+        defer { observationTask?.cancel() }
 
-        for await lastPages in lastPagesSequence {
-            self.lastPages = lastPages
+        for await reading in readings {
+            observationTask?.cancel()
+            let sequence = lastPageService.lastPages(quran: reading.quran)
+            observationTask = Task { [weak self] in
+                do {
+                    for try await lastPages in sequence {
+                        guard !Task.isCancelled else { return }
+                        self?.lastPages = lastPages
+                    }
+                } catch is CancellationError {
+                    return
+                } catch {
+                    guard !Task.isCancelled else { return }
+                    crasher.recordError(error, reason: "Failed to load last pages")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- expose last-page observations as a typed async sequence
- migrate persistence, MobileSync, and Home observation to async iteration
- preserve independent iterator cancellation and error forwarding
- add async-sequence and observer coverage

## Why

A structured async observation boundary simplifies consumption and makes cancellation ownership explicit.

## Validation

- `make format-lint`
- `make test-no-sync`
- `make test-sync`

Stack: 3/7. Base: `afifi/last-page-serialized-updates`.