### PR TITLE
refactor: specialize last page identity by sync mode

### DIFF
--- a/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
@@ -27,7 +27,12 @@ public struct MobileSyncLastPageService: LastPageService, @unchecked Sendable {
                 let mapped = sessions.compactMap { session in
                     lastPage(for: session, quran: quran)
                 }
-                let sorted = mapped.sorted { $0.createdOn > $1.createdOn }
+                let sorted = mapped.sorted {
+                    if $0.modifiedOn == $1.modifiedOn {
+                        return $0.id < $1.id
+                    }
+                    return $0.modifiedOn > $1.modifiedOn
+                }
                 return Array(sorted.prefix(3))
             }
         return LastPagesSequence(sequence)
@@ -44,13 +49,9 @@ public struct MobileSyncLastPageService: LastPageService, @unchecked Sendable {
     }
 
     public func update(lastPage: LastPage, toPage: Page) async throws -> LastPage {
-        guard let localId = lastPage.localId else {
-            return try await add(page: toPage)
-        }
-
         let firstVerse = toPage.firstVerse
         let updatedSession = try await quranDataService.updateReadingSession(
-            id: localId,
+            id: lastPage.id,
             sura: Int32(firstVerse.sura.suraNumber),
             ayah: Int32(firstVerse.ayah),
             timestamp: Date()
@@ -83,10 +84,9 @@ public struct MobileSyncLastPageService: LastPageService, @unchecked Sendable {
 
     private func lastPage(page: Page, for session: ReadingSession) -> LastPage {
         LastPage(
+            id: session.id,
             page: page,
-            createdOn: session.lastUpdated,
-            modifiedOn: session.lastUpdated,
-            localId: session.id
+            modifiedOn: session.lastUpdated
         )
     }
 }

--- a/Domain/AnnotationsService/Sources/PersistenceLastPageService.swift
+++ b/Domain/AnnotationsService/Sources/PersistenceLastPageService.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2023 Quran.com. All rights reserved.
 //
 
+#if !QURAN_SYNC
 import Combine
 import LastPagePersistence
 import QuranAnnotations
@@ -90,3 +91,4 @@ public struct PersistenceLastPageService: LastPageService {
         )
     }
 }
+#endif

--- a/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
+++ b/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
@@ -22,7 +22,7 @@ final class LastPageUpdaterTests: XCTestCase {
         let service = LastPageServiceSpy()
         let sut = LastPageUpdater(service: service)
 
-        let lastPage = LastPage(page: quran.pages[0], createdOn: Date(), modifiedOn: Date())
+        let lastPage = makeLastPage(page: quran.pages[0])
 
         sut.configure(initialPage: quran.pages[1], lastPage: lastPage)
 
@@ -47,6 +47,7 @@ final class LastPageUpdaterTests: XCTestCase {
         XCTAssertEqual(updateCalls.first?.toPage, quran.pages[1])
         await service.completeNextUpdate()
         await waitUntil { sut.lastPage?.page == self.quran.pages[1] }
+        assertIdentity(sut.lastPage, syncID: "created-last-page", noSyncPage: quran.pages[1])
     }
 
     func test_rapidScrolling_serializesWritesAndCoalescesLatestPage() async {
@@ -68,6 +69,7 @@ final class LastPageUpdaterTests: XCTestCase {
         XCTAssertEqual(updateCalls[1].toPage, quran.pages[3])
         await service.completeNextUpdate()
         await waitUntil { sut.lastPage?.page == self.quran.pages[3] }
+        assertIdentity(sut.lastPage, syncID: "last-page", noSyncPage: quran.pages[3])
     }
 
     func test_scrollBackToInFlightPage_doesNotCreateRedundantWrite() async {
@@ -126,9 +128,9 @@ final class LastPageUpdaterTests: XCTestCase {
         let service = ControllableLastPageService()
         let sut = LastPageUpdater(service: service)
 
-        sut.configure(initialPage: quran.pages[1], lastPage: makeLastPage(page: quran.pages[0]))
+        sut.configure(initialPage: quran.pages[1], lastPage: makeLastPage(page: quran.pages[0], id: "old-session"))
         await waitUntil { await service.updateCalls.count == 1 }
-        sut.configure(initialPage: quran.pages[11], lastPage: makeLastPage(page: quran.pages[10]))
+        sut.configure(initialPage: quran.pages[11], lastPage: makeLastPage(page: quran.pages[10], id: "new-session"))
         let callsWhileFirstUpdateIsPending = await service.updateCalls
         XCTAssertEqual(callsWhileFirstUpdateIsPending.count, 1)
 
@@ -138,8 +140,10 @@ final class LastPageUpdaterTests: XCTestCase {
         XCTAssertEqual(updateCalls[1].page, quran.pages[10])
         XCTAssertEqual(updateCalls[1].toPage, quran.pages[11])
         XCTAssertEqual(sut.lastPage?.page, quran.pages[10])
+        assertIdentity(sut.lastPage, syncID: "new-session", noSyncPage: quran.pages[10])
         await service.completeNextUpdate()
         await waitUntil { sut.lastPage?.page == self.quran.pages[11] }
+        assertIdentity(sut.lastPage, syncID: "new-session", noSyncPage: quran.pages[11])
     }
 
     func test_deinit_cancelsInFlightWrite() async {
@@ -159,8 +163,8 @@ final class LastPageUpdaterTests: XCTestCase {
 
     private let quran = Quran(raw: Madani1405QuranReadingInfoRawData())
 
-    private func makeLastPage(page: Page) -> LastPage {
-        LastPage(page: page, createdOn: Date(), modifiedOn: Date())
+    private func makeLastPage(page: Page, id: String = "last-page") -> LastPage {
+        makeTestLastPage(page: page, syncID: id)
     }
 
     private func waitUntil(
@@ -208,7 +212,7 @@ private actor ControllableLastPageService: LastPageService {
         updateCalls.append(UpdateCall(page: lastPage.page, toPage: toPage))
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                pendingUpdates.append((toPage, continuation))
+                pendingUpdates.append((lastPage, toPage, continuation))
             }
         } onCancel: {
             Task { await self.cancelPendingOperation() }
@@ -217,21 +221,26 @@ private actor ControllableLastPageService: LastPageService {
 
     func completeNextAdd() {
         let pending = pendingAdds.removeFirst()
-        pending.continuation.resume(returning: makeLastPage(page: pending.page))
+        pending.continuation.resume(returning: makeTestLastPage(page: pending.page, syncID: "created-last-page"))
     }
 
     func completeNextUpdate() {
         let pending = pendingUpdates.removeFirst()
-        pending.continuation.resume(returning: makeLastPage(page: pending.page))
+        pending.continuation.resume(returning: updatedLastPage(pending.lastPage, page: pending.page))
     }
 
-    private typealias PendingOperation = (
+    private typealias PendingAdd = (
+        page: Page,
+        continuation: CheckedContinuation<LastPage, Error>
+    )
+    private typealias PendingUpdate = (
+        lastPage: LastPage,
         page: Page,
         continuation: CheckedContinuation<LastPage, Error>
     )
 
-    private var pendingAdds: [PendingOperation] = []
-    private var pendingUpdates: [PendingOperation] = []
+    private var pendingAdds: [PendingAdd] = []
+    private var pendingUpdates: [PendingUpdate] = []
 
     private func cancelPendingOperation() {
         cancellationCount += 1
@@ -240,10 +249,6 @@ private actor ControllableLastPageService: LastPageService {
         } else if !pendingUpdates.isEmpty {
             pendingUpdates.removeFirst().continuation.resume(throwing: CancellationError())
         }
-    }
-
-    private func makeLastPage(page: Page) -> LastPage {
-        LastPage(page: page, createdOn: Date(), modifiedOn: Date())
     }
 }
 
@@ -265,12 +270,42 @@ private final class LastPageServiceSpy: LastPageService {
     func add(page: Page) async throws -> LastPage {
         addCallCount += 1
         addPages.append(page)
-        return LastPage(page: page, createdOn: Date(), modifiedOn: Date())
+        return makeTestLastPage(page: page, syncID: "created-last-page")
     }
 
     func update(lastPage: LastPage, toPage: Page) async throws -> LastPage {
         updateCallCount += 1
         updateCalls.append(UpdateCall(page: lastPage.page, toPage: toPage))
-        return LastPage(page: toPage, createdOn: Date(), modifiedOn: Date())
+        return updatedLastPage(lastPage, page: toPage)
     }
+}
+
+private func makeTestLastPage(page: Page, syncID: String) -> LastPage {
+    #if QURAN_SYNC
+    LastPage(id: syncID, page: page, modifiedOn: Date())
+    #else
+    LastPage(page: page, createdOn: Date(), modifiedOn: Date())
+    #endif
+}
+
+private func updatedLastPage(_ lastPage: LastPage, page: Page) -> LastPage {
+    #if QURAN_SYNC
+    LastPage(id: lastPage.id, page: page, modifiedOn: Date())
+    #else
+    LastPage(page: page, createdOn: lastPage.createdOn, modifiedOn: Date())
+    #endif
+}
+
+private func assertIdentity(
+    _ lastPage: LastPage?,
+    syncID: String,
+    noSyncPage: Page,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) {
+    #if QURAN_SYNC
+    XCTAssertEqual(lastPage?.id, syncID, file: file, line: line)
+    #else
+    XCTAssertEqual(lastPage?.id, noSyncPage, file: file, line: line)
+    #endif
 }

--- a/Domain/AnnotationsService/Tests/MobileSyncLastPageServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncLastPageServiceTests.swift
@@ -41,7 +41,7 @@ final class MobileSyncLastPageServiceTests: XCTestCase {
         let lastPage = try await service.add(page: page)
 
         XCTAssertEqual(lastPage.page, page)
-        XCTAssertNotNil(lastPage.localId)
+        XCTAssertFalse(lastPage.id.isEmpty)
         await fulfillment(of: [published], timeout: 2)
     }
 
@@ -51,22 +51,39 @@ final class MobileSyncLastPageServiceTests: XCTestCase {
 
         let updated = try await service.update(lastPage: original, toPage: quran.pages[20])
 
-        XCTAssertEqual(updated.localId, original.localId)
+        XCTAssertEqual(updated.id, original.id)
         XCTAssertEqual(updated.page, quran.pages[20])
         let sessions = database.quranDataService.readingSessionsSequence().makeAsyncIterator()
         let storedSessions = try await sessions.next()
         XCTAssertEqual(storedSessions?.count, 1)
-        XCTAssertEqual(storedSessions?.first?.id, original.localId)
+        XCTAssertEqual(storedSessions?.first?.id, original.id)
         XCTAssertEqual(storedSessions?.first?.sura, Int32(quran.pages[20].firstVerse.sura.suraNumber))
         XCTAssertEqual(storedSessions?.first?.ayah, Int32(quran.pages[20].firstVerse.ayah))
+    }
+
+    func test_updateAdvancesModificationTime() async throws {
+        let quran = Quran.hafsMadani1405
+        let originalPage = quran.pages[10]
+        let originalVerse = originalPage.firstVerse
+        let originalSession = try await database.quranDataService.addReadingSession(
+            sura: Int32(originalVerse.sura.suraNumber),
+            ayah: Int32(originalVerse.ayah),
+            timestamp: Date(timeIntervalSince1970: 1)
+        )
+        var iterator = service.lastPages(quran: quran).makeAsyncIterator()
+        let originalValue = try await iterator.next()
+        let original = try XCTUnwrap(originalValue?.first)
+
+        let updated = try await service.update(lastPage: original, toPage: quran.pages[20])
+
+        XCTAssertEqual(updated.id, originalSession.id)
+        XCTAssertGreaterThan(updated.modifiedOn, original.modifiedOn)
     }
 
     func test_updateCollisionPreservesBothReadingSessions() async throws {
         let quran = Quran.hafsMadani1405
         let source = try await service.add(page: quran.pages[10])
         let destination = try await service.add(page: quran.pages[20])
-        let sourceID = try XCTUnwrap(source.localId)
-        let destinationID = try XCTUnwrap(destination.localId)
 
         do {
             _ = try await service.update(lastPage: source, toPage: quran.pages[20])
@@ -78,7 +95,7 @@ final class MobileSyncLastPageServiceTests: XCTestCase {
         let iterator = database.quranDataService.readingSessionsSequence().makeAsyncIterator()
         let value = try await iterator.next()
         let storedSessions = try XCTUnwrap(value)
-        XCTAssertEqual(Set(storedSessions.map(\.id)), Set([sourceID, destinationID]))
+        XCTAssertEqual(Set(storedSessions.map(\.id)), Set([source.id, destination.id]))
     }
 
     func test_lastPagesObserversCancelIndependently() async throws {
@@ -133,6 +150,53 @@ final class MobileSyncLastPageServiceTests: XCTestCase {
         _ = try await service.add(page: secondPage)
 
         await fulfillment(of: [secondObserverPublishedSecondPage], timeout: 2)
+    }
+
+    func test_lastPagesUsesSessionIdentityForSessionsOnSamePage() async throws {
+        let quran = Quran.hafsMadani1405
+        let page = quran.pages[10]
+        let verses = page.verses
+        XCTAssertGreaterThan(verses.count, 1)
+        let first = try await database.quranDataService.addReadingSession(
+            sura: Int32(verses[0].sura.suraNumber),
+            ayah: Int32(verses[0].ayah),
+            timestamp: Date(timeIntervalSince1970: 1)
+        )
+        let second = try await database.quranDataService.addReadingSession(
+            sura: Int32(verses[1].sura.suraNumber),
+            ayah: Int32(verses[1].ayah),
+            timestamp: Date(timeIntervalSince1970: 2)
+        )
+        var iterator = service.lastPages(quran: quran).makeAsyncIterator()
+
+        let lastPages = try await iterator.next()
+
+        XCTAssertEqual(lastPages?.map(\.page), [page, page])
+        XCTAssertEqual(Set(lastPages?.map(\.id) ?? []), Set([first.id, second.id]))
+    }
+
+    func test_lastPagesSortsByModificationTimeThenIdentityAndLimitsToThree() async throws {
+        let quran = Quran.hafsMadani1405
+        let pages = [10, 20, 30, 40].map { quran.pages[$0] }
+        let timestamps = [3.0, 5.0, 5.0, 1.0].map(Date.init(timeIntervalSince1970:))
+        var sessionIds: [String] = []
+        for (page, timestamp) in zip(pages, timestamps) {
+            let verse = page.firstVerse
+            let session = try await database.quranDataService.addReadingSession(
+                sura: Int32(verse.sura.suraNumber),
+                ayah: Int32(verse.ayah),
+                timestamp: timestamp
+            )
+            sessionIds.append(session.id)
+        }
+        var iterator = service.lastPages(quran: quran).makeAsyncIterator()
+
+        let value = try await iterator.next()
+        let lastPages = try XCTUnwrap(value)
+        let tiedSessionIds = [sessionIds[1], sessionIds[2]].sorted()
+
+        XCTAssertEqual(lastPages.map(\.id), tiedSessionIds + [sessionIds[0]])
+        XCTAssertEqual(lastPages.map(\.modifiedOn), [timestamps[1], timestamps[2], timestamps[0]])
     }
 }
 #endif

--- a/Domain/AnnotationsService/Tests/PageMappingServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/PageMappingServiceTests.swift
@@ -87,16 +87,19 @@ final class PageMappingServiceTests: XCTestCase {
         XCTAssertEqual(bookmarks.map(\.page.pageNumber), [2])
     }
 
+    #if !QURAN_SYNC
     func testLastPagesMapStoredCanonicalPagesToRequestedQuran() async throws {
+        let quran = skippedPageQuran()
         let persistence = LastPagePersistenceFake(lastPages: [
             LastPagePersistenceModel(page: 1, createdOn: date, modifiedOn: laterDate),
         ])
         let service = PersistenceLastPageService(persistence: persistence)
 
-        var iterator = service.lastPages(quran: skippedPageQuran()).makeAsyncIterator()
+        var iterator = service.lastPages(quran: quran).makeAsyncIterator()
         let nextLastPages = try await iterator.next()
         let lastPages = try XCTUnwrap(nextLastPages)
 
+        XCTAssertEqual(lastPages.map(\.id), [quran.pages[0]])
         XCTAssertEqual(lastPages.map(\.page.pageNumber), [2])
         XCTAssertEqual(lastPages.map(\.createdOn), [date])
         XCTAssertEqual(lastPages.map(\.modifiedOn), [laterDate])
@@ -105,24 +108,34 @@ final class PageMappingServiceTests: XCTestCase {
     func testAddLastPageStoresCanonicalPageAndReturnsRequestedQuranPage() async throws {
         let persistence = LastPagePersistenceFake()
         let service = PersistenceLastPageService(persistence: persistence)
+        let quran = skippedPageQuran()
 
-        let lastPage = try await service.add(page: skippedPageQuran().pages[0])
+        let lastPage = try await service.add(page: quran.pages[0])
 
         XCTAssertEqual(persistence.addedPages, [1])
+        XCTAssertEqual(lastPage.id, quran.pages[0])
         XCTAssertEqual(lastPage.page.pageNumber, 2)
     }
 
     func testUpdateLastPageStoresCanonicalPagesAndReturnsRequestedQuranPage() async throws {
-        let persistence = LastPagePersistenceFake()
+        let persistence = LastPagePersistenceFake(lastPages: [
+            LastPagePersistenceModel(page: 1, createdOn: date, modifiedOn: laterDate),
+        ])
         let service = PersistenceLastPageService(persistence: persistence)
         let quran = skippedPageQuran()
 
-        let currentLastPage = LastPage(page: quran.pages[0], createdOn: date, modifiedOn: date)
+        let currentLastPage = LastPage(
+            page: quran.pages[0],
+            createdOn: date,
+            modifiedOn: date
+        )
         let lastPage = try await service.update(lastPage: currentLastPage, toPage: quran.pages[1])
 
         XCTAssertEqual(persistence.updates, [LastPagePersistenceFake.Update(page: 1, toPage: 2)])
+        XCTAssertEqual(lastPage.id, quran.pages[1])
         XCTAssertEqual(lastPage.page.pageNumber, 3)
     }
+    #endif
 
     // MARK: Private
 
@@ -171,6 +184,7 @@ private final class PageBookmarkPersistenceFake: PageBookmarkPersistence {
     }
 }
 
+#if !QURAN_SYNC
 private final class LastPagePersistenceFake: LastPagePersistence, @unchecked Sendable {
     struct Update: Equatable {
         let page: Int
@@ -219,3 +233,4 @@ private final class LastPagePersistenceFake: LastPagePersistence, @unchecked Sen
         return model
     }
 }
+#endif

--- a/Features/HomeFeature/HomeView.swift
+++ b/Features/HomeFeature/HomeView.swift
@@ -72,7 +72,7 @@ private struct HomeViewUI: View {
         return NoorListItem(
             image: .init(.lastPage, color: .secondaryLabel),
             title: "\(ayah.sura.localizedName()) \(sura: ayah.sura.arabicSuraName)",
-            subtitle: .init(text: lastPage.createdOn.timeAgo(), location: .bottom),
+            subtitle: .init(text: lastPage.modifiedOn.timeAgo(), location: .bottom),
             accessory: .text(NumberFormatter.shared.format(lastPage.page.pageNumber))
         ) {
             selectLastPage(lastPage)
@@ -150,11 +150,19 @@ struct HomeView_Previews: PreviewProvider {
         static var staticLastPages: [LastPage] {
             let pages = Quran.hafsMadani1405.pages.shuffled()
             return (0 ..< 3).map { i in
+                #if QURAN_SYNC
+                LastPage(
+                    id: "preview-\(i)",
+                    page: pages[i],
+                    modifiedOn: Date(timeIntervalSince1970: Double(i) * 60 * -3)
+                )
+                #else
                 LastPage(
                     page: pages[i],
                     createdOn: Date(timeIntervalSince1970: Double(i) * 60 * -3),
                     modifiedOn: Date(timeIntervalSince1970: Double(i) * 60 * -3)
                 )
+                #endif
             }
         }
 

--- a/Model/QuranAnnotations/LastPage.swift
+++ b/Model/QuranAnnotations/LastPage.swift
@@ -11,19 +11,29 @@ import QuranKit
 public struct LastPage: Equatable, Identifiable {
     // MARK: Lifecycle
 
-    public init(page: Page, createdOn: Date, modifiedOn: Date, localId: String? = nil) {
+    #if QURAN_SYNC
+    public init(id: String, page: Page, modifiedOn: Date) {
+        self.id = id
+        self.page = page
+        self.modifiedOn = modifiedOn
+    }
+    #else
+    public init(page: Page, createdOn: Date, modifiedOn: Date) {
         self.page = page
         self.createdOn = createdOn
         self.modifiedOn = modifiedOn
-        self.localId = localId
     }
+    #endif
 
     // MARK: Public
 
-    public var page: Page
-    public var createdOn: Date
-    public var modifiedOn: Date
-    public var localId: String?
-
+    #if QURAN_SYNC
+    public let id: String
+    #else
     public var id: Page { page }
+    public var createdOn: Date
+    #endif
+
+    public var page: Page
+    public var modifiedOn: Date
 }


### PR DESCRIPTION
## Summary

- use MobileSync session IDs as last-page identity in sync builds
- use page-derived identity in local persistence builds
- retain creation metadata only where local persistence owns it
- sort recent synced pages by modification time with a stable identity tie-break

## Why

Sync and local persistence have different identity and metadata sources; specializing the model removes invalid cross-mode assumptions.

## Validation

- `make format-lint`
- `make test-no-sync`
- `make test-sync`

Stack: 4/7. Base: `afifi/last-page-async-observation`.