### PR TITLE
refactor: simplify last page mapping

### DIFF
--- a/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
@@ -64,22 +64,10 @@ public struct MobileSyncLastPageService: LastPageService, @unchecked Sendable {
     private let quranDataService: QuranDataService
 
     private func lastPage(for session: ReadingSession, quran: Quran) -> LastPage? {
-        guard let sourceAyah = AyahNumber(quran: quran, sura: Int(session.sura), ayah: Int(session.ayah)) else {
+        guard let ayah = AyahNumber(quran: quran, sura: Int(session.sura), ayah: Int(session.ayah)) else {
             return nil
         }
-
-        let page: Page
-        if sourceAyah.quran === quran {
-            page = sourceAyah.page
-        } else {
-            let mapper = QuranPageMapper(destination: quran)
-            guard let mappedAyah = mapper.mapAyah(sourceAyah) else {
-                return nil
-            }
-            page = mappedAyah.page
-        }
-
-        return lastPage(page: page, for: session)
+        return lastPage(page: ayah.page, for: session)
     }
 
     private func lastPage(page: Page, for session: ReadingSession) -> LastPage {

--- a/Domain/AnnotationsService/Tests/MobileSyncLastPageServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncLastPageServiceTests.swift
@@ -175,6 +175,41 @@ final class MobileSyncLastPageServiceTests: XCTestCase {
         XCTAssertEqual(Set(lastPages?.map(\.id) ?? []), Set([first.id, second.id]))
     }
 
+    func test_lastPagesMapsCoordinatesInRequestedQuran() async throws {
+        let sura: Int32 = 2
+        let ayah: Int32 = 255
+        let session = try await database.quranDataService.addReadingSession(
+            sura: sura,
+            ayah: ayah,
+            timestamp: Date(timeIntervalSince1970: 1)
+        )
+
+        for quran in [Quran.hafsMadani1405, .hafsMadani1440, .hafsNaskh] {
+            var iterator = service.lastPages(quran: quran).makeAsyncIterator()
+
+            let lastPages = try await iterator.next()
+            let expectedAyah = try XCTUnwrap(
+                AyahNumber(quran: quran, sura: Int(sura), ayah: Int(ayah))
+            )
+
+            XCTAssertEqual(lastPages?.map(\.id), [session.id])
+            XCTAssertEqual(lastPages?.map(\.page), [expectedAyah.page])
+        }
+    }
+
+    func test_lastPagesFiltersInvalidCoordinates() async throws {
+        _ = try await database.quranDataService.addReadingSession(
+            sura: 999,
+            ayah: 999,
+            timestamp: Date(timeIntervalSince1970: 1)
+        )
+        var iterator = service.lastPages(quran: .hafsMadani1405).makeAsyncIterator()
+
+        let lastPages = try await iterator.next()
+
+        XCTAssertEqual(lastPages, [])
+    }
+
     func test_lastPagesSortsByModificationTimeThenIdentityAndLimitsToThree() async throws {
         let quran = Quran.hafsMadani1405
         let pages = [10, 20, 30, 40].map { quran.pages[$0] }


### PR DESCRIPTION
## Summary

- map reading-session coordinates directly into the requested Quran
- remove the intermediate canonical-page mapping path
- ignore invalid stored coordinates
- cover supported readings and invalid coordinates

## Why

Reading sessions already store sura and ayah coordinates, so direct mapping is simpler and avoids unnecessary page conversion.

## Validation

- `make format-lint`
- `make test-no-sync`
- `make test-sync`

Stack: 5/7. Base: `afifi/last-page-sync-identity`.