### PR TITLE
refactor: remove unchecked last page sendability

### DIFF
--- a/Domain/AnnotationsService/Sources/LastPageService.swift
+++ b/Domain/AnnotationsService/Sources/LastPageService.swift
@@ -40,6 +40,7 @@ public struct LastPagesSequence: AsyncSequence {
     private let makeIterator: () -> AsyncIterator
 }
 
+@MainActor
 public protocol LastPageService {
     func lastPages(quran: Quran) -> LastPagesSequence
 

--- a/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
@@ -12,7 +12,7 @@ import Foundation
 import QuranAnnotations
 import QuranKit
 
-public struct MobileSyncLastPageService: LastPageService, @unchecked Sendable {
+public struct MobileSyncLastPageService: LastPageService {
     // MARK: Lifecycle
 
     public init(quranDataService: QuranDataService) {
@@ -63,14 +63,14 @@ public struct MobileSyncLastPageService: LastPageService, @unchecked Sendable {
 
     private let quranDataService: QuranDataService
 
-    private func lastPage(for session: ReadingSession, quran: Quran) -> LastPage? {
+    private nonisolated func lastPage(for session: ReadingSession, quran: Quran) -> LastPage? {
         guard let ayah = AyahNumber(quran: quran, sura: Int(session.sura), ayah: Int(session.ayah)) else {
             return nil
         }
         return lastPage(page: ayah.page, for: session)
     }
 
-    private func lastPage(page: Page, for session: ReadingSession) -> LastPage {
+    private nonisolated func lastPage(page: Page, for session: ReadingSession) -> LastPage {
         LastPage(
             id: session.id,
             page: page,

--- a/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
+++ b/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
@@ -37,15 +37,15 @@ final class LastPageUpdaterTests: XCTestCase {
         let sut = LastPageUpdater(service: service)
 
         sut.configure(initialPage: quran.pages[0], lastPage: nil)
-        await waitUntil { await service.addPages == [self.quran.pages[0]] }
+        await waitUntil { service.addPages == [self.quran.pages[0]] }
         sut.updateTo(pages: [quran.pages[1]])
 
-        await service.completeNextAdd()
-        await waitUntil { await service.updateCalls.count == 1 }
-        let updateCalls = await service.updateCalls
+        service.completeNextAdd()
+        await waitUntil { service.updateCalls.count == 1 }
+        let updateCalls = service.updateCalls
         XCTAssertEqual(updateCalls.first?.page, quran.pages[0])
         XCTAssertEqual(updateCalls.first?.toPage, quran.pages[1])
-        await service.completeNextUpdate()
+        service.completeNextUpdate()
         await waitUntil { sut.lastPage?.page == self.quran.pages[1] }
         assertIdentity(sut.lastPage, syncID: "created-last-page", noSyncPage: quran.pages[1])
     }
@@ -56,18 +56,18 @@ final class LastPageUpdaterTests: XCTestCase {
         let lastPage = makeLastPage(page: quran.pages[0])
 
         sut.configure(initialPage: quran.pages[1], lastPage: lastPage)
-        await waitUntil { await service.updateCalls.count == 1 }
+        await waitUntil { service.updateCalls.count == 1 }
         sut.updateTo(pages: [quran.pages[2]])
         sut.updateTo(pages: [quran.pages[3]])
-        let callsWhileFirstUpdateIsPending = await service.updateCalls
+        let callsWhileFirstUpdateIsPending = service.updateCalls
         XCTAssertEqual(callsWhileFirstUpdateIsPending.count, 1)
 
-        await service.completeNextUpdate()
-        await waitUntil { await service.updateCalls.count == 2 }
-        let updateCalls = await service.updateCalls
+        service.completeNextUpdate()
+        await waitUntil { service.updateCalls.count == 2 }
+        let updateCalls = service.updateCalls
         XCTAssertEqual(updateCalls[1].page, quran.pages[1])
         XCTAssertEqual(updateCalls[1].toPage, quran.pages[3])
-        await service.completeNextUpdate()
+        service.completeNextUpdate()
         await waitUntil { sut.lastPage?.page == self.quran.pages[3] }
         assertIdentity(sut.lastPage, syncID: "last-page", noSyncPage: quran.pages[3])
     }
@@ -78,16 +78,16 @@ final class LastPageUpdaterTests: XCTestCase {
         let lastPage = makeLastPage(page: quran.pages[0])
 
         sut.configure(initialPage: quran.pages[1], lastPage: lastPage)
-        await waitUntil { await service.updateCalls.count == 1 }
+        await waitUntil { service.updateCalls.count == 1 }
         sut.updateTo(pages: [quran.pages[2]])
         sut.updateTo(pages: [quran.pages[1]])
 
-        await service.completeNextUpdate()
+        service.completeNextUpdate()
         await waitUntil { sut.lastPage?.page == self.quran.pages[1] }
         for _ in 0 ..< 10 {
             await Task.yield()
         }
-        let updateCalls = await service.updateCalls
+        let updateCalls = service.updateCalls
         XCTAssertEqual(updateCalls.count, 1)
     }
 
@@ -99,8 +99,8 @@ final class LastPageUpdaterTests: XCTestCase {
         sut.configure(initialPage: quran.pages[0], lastPage: lastPage)
         sut.updateTo(pages: [quran.pages[0]])
 
-        await waitUntil { await service.updateCalls.count == 1 }
-        let updateCalls = await service.updateCalls
+        await waitUntil { service.updateCalls.count == 1 }
+        let updateCalls = service.updateCalls
         XCTAssertEqual(updateCalls.first?.page, quran.pages[0])
         XCTAssertEqual(updateCalls.first?.toPage, quran.pages[0])
     }
@@ -111,16 +111,16 @@ final class LastPageUpdaterTests: XCTestCase {
         let lastPage = makeLastPage(page: quran.pages[0])
 
         sut.configure(initialPage: quran.pages[1], lastPage: lastPage)
-        await waitUntil { await service.updateCalls.count == 1 }
+        await waitUntil { service.updateCalls.count == 1 }
         sut.updateTo(pages: [quran.pages[0]])
 
-        await service.completeNextUpdate()
-        await waitUntil { await service.updateCalls.count == 2 }
-        let updateCalls = await service.updateCalls
+        service.completeNextUpdate()
+        await waitUntil { service.updateCalls.count == 2 }
+        let updateCalls = service.updateCalls
         XCTAssertEqual(updateCalls[1].page, quran.pages[1])
         XCTAssertEqual(updateCalls[1].toPage, quran.pages[0])
 
-        await service.completeNextUpdate()
+        service.completeNextUpdate()
         await waitUntil { sut.lastPage?.page == self.quran.pages[0] }
     }
 
@@ -129,19 +129,19 @@ final class LastPageUpdaterTests: XCTestCase {
         let sut = LastPageUpdater(service: service)
 
         sut.configure(initialPage: quran.pages[1], lastPage: makeLastPage(page: quran.pages[0], id: "old-session"))
-        await waitUntil { await service.updateCalls.count == 1 }
+        await waitUntil { service.updateCalls.count == 1 }
         sut.configure(initialPage: quran.pages[11], lastPage: makeLastPage(page: quran.pages[10], id: "new-session"))
-        let callsWhileFirstUpdateIsPending = await service.updateCalls
+        let callsWhileFirstUpdateIsPending = service.updateCalls
         XCTAssertEqual(callsWhileFirstUpdateIsPending.count, 1)
 
-        await service.completeNextUpdate()
-        await waitUntil { await service.updateCalls.count == 2 }
-        let updateCalls = await service.updateCalls
+        service.completeNextUpdate()
+        await waitUntil { service.updateCalls.count == 2 }
+        let updateCalls = service.updateCalls
         XCTAssertEqual(updateCalls[1].page, quran.pages[10])
         XCTAssertEqual(updateCalls[1].toPage, quran.pages[11])
         XCTAssertEqual(sut.lastPage?.page, quran.pages[10])
         assertIdentity(sut.lastPage, syncID: "new-session", noSyncPage: quran.pages[10])
-        await service.completeNextUpdate()
+        service.completeNextUpdate()
         await waitUntil { sut.lastPage?.page == self.quran.pages[11] }
         assertIdentity(sut.lastPage, syncID: "new-session", noSyncPage: quran.pages[11])
     }
@@ -154,11 +154,11 @@ final class LastPageUpdaterTests: XCTestCase {
             let sut = LastPageUpdater(service: service)
             weakSUT = sut
             sut.configure(initialPage: quran.pages[0], lastPage: nil)
-            await waitUntil { await service.addPages.count == 1 }
+            await waitUntil { service.addPages.count == 1 }
         }
 
         await waitUntil { weakSUT == nil }
-        await waitUntil { await service.cancellationCount == 1 }
+        await waitUntil { service.cancellationCount == 1 }
     }
 
     private let quran = Quran(raw: Madani1405QuranReadingInfoRawData())
@@ -183,7 +183,8 @@ final class LastPageUpdaterTests: XCTestCase {
     }
 }
 
-private actor ControllableLastPageService: LastPageService {
+@MainActor
+private final class ControllableLastPageService: LastPageService {
     struct UpdateCall: Equatable {
         let page: Page
         let toPage: Page
@@ -193,7 +194,7 @@ private actor ControllableLastPageService: LastPageService {
     private(set) var updateCalls: [UpdateCall] = []
     private(set) var cancellationCount = 0
 
-    nonisolated func lastPages(quran _: Quran) -> LastPagesSequence {
+    func lastPages(quran _: Quran) -> LastPagesSequence {
         LastPagesSequence(Just<[LastPage]>([]).values)
     }
 
@@ -204,7 +205,9 @@ private actor ControllableLastPageService: LastPageService {
                 pendingAdds.append((page, continuation))
             }
         } onCancel: {
-            Task { await self.cancelPendingOperation() }
+            Task { @MainActor in
+                self.cancelPendingOperation()
+            }
         }
     }
 
@@ -215,7 +218,9 @@ private actor ControllableLastPageService: LastPageService {
                 pendingUpdates.append((lastPage, toPage, continuation))
             }
         } onCancel: {
-            Task { await self.cancelPendingOperation() }
+            Task { @MainActor in
+                self.cancelPendingOperation()
+            }
         }
     }
 
@@ -252,6 +257,7 @@ private actor ControllableLastPageService: LastPageService {
     }
 }
 
+@MainActor
 private final class LastPageServiceSpy: LastPageService {
     struct UpdateCall: Equatable {
         let page: Page

--- a/Domain/AnnotationsService/Tests/LastPagesSequenceTests.swift
+++ b/Domain/AnnotationsService/Tests/LastPagesSequenceTests.swift
@@ -1,6 +1,8 @@
+import Foundation
 import XCTest
 @testable import AnnotationsService
 @testable import QuranAnnotations
+@testable import QuranKit
 
 final class LastPagesSequenceTests: XCTestCase {
     func test_forwardsValuesAndCompletion() async throws {
@@ -68,6 +70,34 @@ final class LastPagesSequenceTests: XCTestCase {
         XCTAssertEqual(secondValue, [])
         XCTAssertNil(firstCompletion)
         XCTAssertNil(secondCompletion)
+    }
+
+    func test_lastPageCanCrossTaskBoundaries() async {
+        let lastPage = makeLastPage()
+        requireSendable(lastPage)
+
+        let received = await Task.detached { lastPage }.value
+
+        XCTAssertEqual(received, lastPage)
+    }
+
+    private func requireSendable(_: some Sendable) {}
+
+    private func makeLastPage() -> LastPage {
+        let page = Quran.hafsMadani1405.pages[10]
+        #if QURAN_SYNC
+        return LastPage(
+            id: "last-page",
+            page: page,
+            modifiedOn: Date(timeIntervalSince1970: 2)
+        )
+        #else
+        return LastPage(
+            page: page,
+            createdOn: Date(timeIntervalSince1970: 1),
+            modifiedOn: Date(timeIntervalSince1970: 2)
+        )
+        #endif
     }
 }
 

--- a/Domain/AnnotationsService/Tests/MobileSyncLastPageServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncLastPageServiceTests.swift
@@ -4,6 +4,7 @@ import QuranKit
 import XCTest
 @testable import AnnotationsService
 
+@MainActor
 final class MobileSyncLastPageServiceTests: XCTestCase {
     private let database = MobileSyncTestDatabase.shared
     private var service: MobileSyncLastPageService!

--- a/Domain/AnnotationsService/Tests/PageMappingServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/PageMappingServiceTests.swift
@@ -13,6 +13,7 @@ import XCTest
 @testable import QuranAnnotations
 @testable import QuranKit
 
+@MainActor
 final class PageMappingServiceTests: XCTestCase {
     private struct SkippedFirstPageReadingInfoRawData: QuranReadingInfoRawData {
         // MARK: Internal

--- a/Features/AppDependencies/AppDependencies.swift
+++ b/Features/AppDependencies/AppDependencies.swift
@@ -50,6 +50,7 @@ public protocol AppDependencies {
 extension AppDependencies {
     public var quranUthmaniV2Database: URL { QuranResources.quranUthmaniV2Database }
 
+    @MainActor
     public func lastPageService() -> any LastPageService {
         #if QURAN_SYNC
         return MobileSyncLastPageService(quranDataService: quranDataService)

--- a/Model/QuranAnnotations/LastPage.swift
+++ b/Model/QuranAnnotations/LastPage.swift
@@ -8,7 +8,7 @@
 import Foundation
 import QuranKit
 
-public struct LastPage: Equatable, Identifiable {
+public struct LastPage: Equatable, Identifiable, Sendable {
     // MARK: Lifecycle
 
     #if QURAN_SYNC


### PR DESCRIPTION
## Summary

- isolate last-page services to the main actor
- make LastPage explicitly Sendable
- remove unchecked Sendable conformance from the MobileSync service
- adapt tests and dependency wiring to the actor boundary

## Why

Compiler-checked isolation and value sendability replace an unchecked concurrency assertion.

## Validation

- `make format-lint`
- `make test-no-sync`
- `make test-sync`

Stack: 6/7. Base: `afifi/last-page-mapping`.