### PR TITLE
Show default Favorites collection

### DIFF
--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -126,6 +126,7 @@
 "bookmarks.collections.add" = "إضافة مجموعة";
 "bookmarks.collections.edit.action" = "تحرير";
 "bookmarks.collections.colored" = "الإشارات المرجعية الملونة";
+"bookmarks.collections.favorites" = "المفضلة";
 "bookmarks.collections.mine" = "مجموعاتي";
 "bookmarks.collections.new" = "مجموعة جديدة...";
 "bookmarks.collections.new.placeholder" = "اسم المجموعة";

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -145,6 +145,7 @@
 "bookmarks.collections.add" = "Add Collection";
 "bookmarks.collections.edit.action" = "Edit";
 "bookmarks.collections.colored" = "Colored Bookmarks";
+"bookmarks.collections.favorites" = "Favorites";
 "bookmarks.collections.mine" = "My Collections";
 "bookmarks.collections.new" = "New Collection...";
 "bookmarks.collections.new.placeholder" = "Collection name";

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollection+Presentation.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollection+Presentation.swift
@@ -1,0 +1,32 @@
+#if QURAN_SYNC
+import Localization
+import NoorUI
+
+extension AyahBookmarkCollection {
+    var displayName: String {
+        switch kind {
+        case .defaultBookmarks:
+            l("bookmarks.collections.favorites")
+        case .oldPageBookmarks:
+            l("bookmarks.old-page-bookmarks")
+        case .colored(let color):
+            color.localizedName
+        case .user:
+            collection.name
+        }
+    }
+
+    var displayImage: NoorSystemImage {
+        switch kind {
+        case .defaultBookmarks:
+            .starFilled
+        case .oldPageBookmarks:
+            .book
+        case .colored:
+            .bookmark
+        case .user:
+            .folder
+        }
+    }
+}
+#endif

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
@@ -95,7 +95,7 @@ private final class AyahBookmarkCollectionMenuController {
     }
 
     private func updateTitle(for collection: AyahBookmarkCollection, in viewController: UIViewController) {
-        let title = collection.kind.highlightColor?.localizedName ?? collection.collection.name
+        let title = collection.displayName
         let subtitle = bookmarkCountText(collection.bookmarks.count)
 
         if #available(iOS 26.0, *) {

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
@@ -49,7 +49,7 @@ private struct BookmarkCollectionsContent: View {
             }
 
             NoorBasicSection(title: l("bookmarks.collections.mine")) {
-                if viewModel.deletableCollections.isEmpty {
+                if viewModel.displayedCollections.isEmpty {
                     NoorListEmptyState(
                         title: l("bookmarks.collections.no-data.title"),
                         text: l("bookmarks.collections.no-data.text"),
@@ -57,16 +57,17 @@ private struct BookmarkCollectionsContent: View {
                     )
                 }
 
-                ForEach(viewModel.deletableCollections) { collection in
+                ForEach(viewModel.displayedCollections) { collection in
                     collectionRow(
-                        title: collectionTitle(collection),
-                        image: collectionImage(collection),
+                        title: collection.displayName,
+                        image: collection.displayImage,
                         imageColor: collectionImageColor(collection),
                         collection: collection
                     )
+                    .deleteDisabled(!collection.kind.canDelete)
                 }
                 .onDelete { offsets in
-                    let collections = offsets.map { viewModel.deletableCollections[$0] }
+                    let collections = offsets.map { viewModel.displayedCollections[$0] }
                     Task {
                         for collection in collections {
                             await viewModel.deleteCollection(collection)
@@ -89,18 +90,15 @@ private struct BookmarkCollectionsContent: View {
         .environment(\.editMode, $viewModel.editMode)
     }
 
-    private func collectionTitle(_ collection: AyahBookmarkCollection) -> String {
-        collection.kind.isOldPageBookmarks
-            ? l("bookmarks.old-page-bookmarks")
-            : collection.collection.name
-    }
-
-    private func collectionImage(_ collection: AyahBookmarkCollection) -> NoorSystemImage {
-        collection.kind.isOldPageBookmarks ? .book : .folder
-    }
-
     private func collectionImageColor(_ collection: AyahBookmarkCollection) -> Color {
-        collection.kind.isOldPageBookmarks ? .secondaryLabel : .appIdentity
+        switch collection.kind {
+        case .defaultBookmarks:
+            Color(uiColor: .systemYellow)
+        case .oldPageBookmarks:
+            .secondaryLabel
+        case .colored, .user:
+            .appIdentity
+        }
     }
 
     private func highlightCollection(for color: HighlightColor) -> AyahBookmarkCollection? {

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -48,6 +48,10 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         }
     }
 
+    var displayedCollections: [AyahBookmarkCollection] {
+        Self.displayedCollections(from: collections)
+    }
+
     var deletableCollections: [AyahBookmarkCollection] {
         Self.deletableCollections(from: collections)
     }
@@ -76,6 +80,10 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         let oldPageBookmarks = deletableCollections.filter(\.kind.isOldPageBookmarks)
         let remainingCollections = deletableCollections.filter { !$0.kind.isOldPageBookmarks }
         return oldPageBookmarks + remainingCollections
+    }
+
+    static func displayedCollections(from collections: [AyahBookmarkCollection]) -> [AyahBookmarkCollection] {
+        collections.filter { $0.kind.highlightColor == nil }
     }
 
     func start() async {

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -59,6 +59,21 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         ])
     }
 
+    func test_displayedCollections_includesDefaultAndExcludesHighlights() {
+        let collections = BookmarkCollectionsViewModel.displayedCollections(from: [
+            collection(name: "Default", id: "__default__"),
+            collection(name: "red"),
+            collection(name: "Favorites"),
+            collection(name: oldPageBookmarksCollectionName),
+        ])
+
+        XCTAssertEqual(collections.map(\.collection.name), [
+            "Default",
+            "Favorites",
+            oldPageBookmarksCollectionName,
+        ])
+    }
+
     func test_collectionKind_classifiesCollectionNamesCaseInsensitively() {
         XCTAssertEqual(
             collection(name: oldPageBookmarksCollectionName.uppercased()).kind,
@@ -90,6 +105,13 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         XCTAssertTrue(user.kind.canDelete)
     }
 
+    func test_defaultCollectionPresentation_usesLocalizedFavoritesNameAndFilledStarIcon() {
+        let collection = collection(name: "Default", id: "__default__")
+
+        XCTAssertEqual(collection.displayName, l("bookmarks.collections.favorites"))
+        XCTAssertEqual(collection.displayImage, .starFilled)
+    }
+
     func test_collectionDetailsController_showsDirectEditButtonForHighlightCollection() {
         let collection = collection(name: "Red")
         let viewModel = makeCollectionDetailsViewModel(collection: collection)
@@ -102,11 +124,11 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         XCTAssertNil(button?.menu)
     }
 
-    func test_collectionDetailsController_usesNativeTitleAndSubtitle() throws {
+    func test_collectionDetailsController_usesNativeTitleAndSubtitle() {
         let collection = collection(name: "Red")
         let viewModel = makeCollectionDetailsViewModel(collection: collection)
         let viewController = AyahBookmarkCollectionsViewController(viewModel: viewModel)
-        let title = try XCTUnwrap(collection.kind.highlightColor?.localizedName)
+        let title = collection.displayName
         let subtitle = lFormat("bookmarks.collections.ayahs.count", 0)
 
         if #available(iOS 26.0, *) {

--- a/UI/NoorUI/Images/NoorSystemImage.swift
+++ b/UI/NoorUI/Images/NoorSystemImage.swift
@@ -15,6 +15,7 @@ public enum NoorSystemImage: String {
     case heart = "heart.fill"
     case share = "square.and.arrow.up"
     case star
+    case starFilled = "star.fill"
     case mail = "envelope"
     case checkmark_checked = "checkmark.circle.fill"
     case checkmark_unchecked = "circle"


### PR DESCRIPTION
## Summary

- always show the Mobile Sync default collection under My Collections
- present it as localized Favorites with a gold filled-star icon
- keep the collection non-deletable and use the same display name on its detail screen

## Why

The Collections page derived My Collections from deletable collections. Because the virtual default collection is intentionally non-deletable, it was filtered out of the UI.

## Validation

- `make format-lint`
- `make test-sync`
- `make test-no-sync`
- `make run-example-sync`
- verified the Favorites row and gold star in iOS Simulator

<img width="306"  alt="simulator_screenshot_453616DF-E82B-41A8-BB93-3AD1AF4297C6" src="https://github.com/user-attachments/assets/ad874c40-075b-41e7-bfff-c51395c0e9be" />
