### PR TITLE
Sort bookmark collections alphabetically

### DIFF
--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollection+Presentation.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollection+Presentation.swift
@@ -1,6 +1,7 @@
 #if QURAN_SYNC
 import Localization
 import NoorUI
+import QuranAnnotations
 
 extension AyahBookmarkCollection {
     var displayName: String {
@@ -26,6 +27,14 @@ extension AyahBookmarkCollection {
             .bookmark
         case .user:
             .folder
+        }
+    }
+}
+
+extension HighlightColor {
+    static var alphabeticallySortedColors: [Self] {
+        allCases.sorted {
+            $0.localizedName.localizedCaseInsensitiveCompare($1.localizedName) == .orderedAscending
         }
     }
 }

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
@@ -38,7 +38,7 @@ private struct BookmarkCollectionsContent: View {
             }
 
             NoorBasicSection(title: l("bookmarks.collections.colored")) {
-                ForEach(HighlightColor.sortedColors, id: \.self) { color in
+                ForEach(HighlightColor.alphabeticallySortedColors, id: \.self) { color in
                     collectionRow(
                         title: color.localizedName,
                         image: .bookmark,

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -83,7 +83,16 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     }
 
     static func displayedCollections(from collections: [AyahBookmarkCollection]) -> [AyahBookmarkCollection] {
-        collections.filter { $0.kind.highlightColor == nil }
+        collections
+            .filter { $0.kind.highlightColor == nil }
+            .sorted { lhs, rhs in
+                let lhsIndex = displayedCollectionSortIndex(lhs)
+                let rhsIndex = displayedCollectionSortIndex(rhs)
+                if lhsIndex != rhsIndex {
+                    return lhsIndex < rhsIndex
+                }
+                return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+            }
     }
 
     func start() async {
@@ -164,7 +173,20 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         guard let color = collection.kind.highlightColor else {
             return nil
         }
-        return HighlightColor.sortedColors.firstIndex(of: color)
+        return HighlightColor.alphabeticallySortedColors.firstIndex(of: color)
+    }
+
+    private static func displayedCollectionSortIndex(_ collection: AyahBookmarkCollection) -> Int {
+        switch collection.kind {
+        case .defaultBookmarks:
+            0
+        case .oldPageBookmarks:
+            1
+        case .user:
+            2
+        case .colored:
+            3
+        }
     }
 
     private func observeCollections() async {

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -59,19 +59,33 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         ])
     }
 
-    func test_displayedCollections_includesDefaultAndExcludesHighlights() {
+    func test_displayedCollections_sortsDefaultThenOldPageBookmarksThenCustomCollections() {
         let collections = BookmarkCollectionsViewModel.displayedCollections(from: [
-            collection(name: "Default", id: "__default__"),
+            collection(name: "Z Collection"),
             collection(name: "red"),
-            collection(name: "Favorites"),
             collection(name: oldPageBookmarksCollectionName),
+            collection(name: "A Collection"),
+            collection(name: "Default", id: "__default__"),
         ])
 
         XCTAssertEqual(collections.map(\.collection.name), [
             "Default",
-            "Favorites",
             oldPageBookmarksCollectionName,
+            "A Collection",
+            "Z Collection",
         ])
+    }
+
+    func test_alphabeticallySortedColors_sortsLocalizedNames() {
+        let colors = HighlightColor.alphabeticallySortedColors
+
+        XCTAssertEqual(Set(colors), Set(HighlightColor.allCases))
+        XCTAssertEqual(
+            colors.map(\.localizedName),
+            HighlightColor.allCases.map(\.localizedName).sorted {
+                $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+            }
+        )
     }
 
     func test_collectionKind_classifiesCollectionNamesCaseInsensitively() {


### PR DESCRIPTION
## Summary

- keep Favorites first and Old Page Bookmarks second under My Collections
- sort custom collections alphabetically using locale-aware comparison
- sort colored bookmark rows alphabetically by their localized names
- add regression coverage for both ordering rules

## Why

Collection rows previously inherited Mobile Sync or fixed color ordering, so the visible lists were not consistently alphabetical. This keeps system collections predictable while making user and localized color collections easier to scan.

## Stack

- builds on #891
- base branch: `afifi/show-favorites-collection`

## Validation

- `make format-lint`
- `make test-sync`
- `make test-no-sync`
- `make run-example-sync`
- verified ordering in iOS Simulator