### PR TITLE
feat: add ayah bookmark sheet

### DIFF
--- a/Core/Localization/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Resources/ar.lproj/Localizable.strings
@@ -145,6 +145,10 @@
 "bookmarks.sync.action" = "تسجيل الدخول";
 
 "bookmarks.highlights" = "التمييزات";
+"bookmarks.editor.collection.unselected" = "غير محددة";
+"bookmarks.editor.collection.mixed" = "محددة جزئيًا";
+"bookmarks.editor.collection.selected" = "محددة";
+"bookmarks.editor.error.highlight-unavailable" = "لا تزال ألوان التمييز قيد التحميل. حاول مرة أخرى.";
 
 // MARK: - Notes
 

--- a/Core/Localization/Resources/ar.lproj/Localizable.stringsdict
+++ b/Core/Localization/Resources/ar.lproj/Localizable.stringsdict
@@ -26,5 +26,29 @@
             <string>%d إشارة مرجعية</string>
         </dict>
     </dict>
+    <key>bookmarks.editor.title</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@ayahs@</string>
+        <key>ayahs</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>zero</key>
+            <string>إضافة إشارات مرجعية للآيات</string>
+            <key>one</key>
+            <string>إضافة إشارة مرجعية لآية</string>
+            <key>two</key>
+            <string>إضافة إشارة مرجعية لآيتين</string>
+            <key>few</key>
+            <string>إضافة إشارات مرجعية إلى %d آيات</string>
+            <key>many</key>
+            <string>إضافة إشارات مرجعية إلى %d آية</string>
+            <key>other</key>
+            <string>إضافة إشارات مرجعية إلى %d آية</string>
+        </dict>
+    </dict>
 </dict>
 </plist>

--- a/Core/Localization/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Resources/en.lproj/Localizable.strings
@@ -158,6 +158,10 @@
 "bookmarks.collections.ayahs.no-data.text" = "Ayahs you bookmark while reading will appear here.";
 "bookmarks.collections.ayahs.no-data.colored.text" = "Ayahs you highlight with a %@ bookmark while reading will appear here.";
 "bookmarks.highlights" = "Highlights";
+"bookmarks.editor.collection.unselected" = "Not selected";
+"bookmarks.editor.collection.mixed" = "Partially selected";
+"bookmarks.editor.collection.selected" = "Selected";
+"bookmarks.editor.error.highlight-unavailable" = "Highlight colors are still loading. Please try again.";
 
 // MARK: - Notes
 

--- a/Core/Localization/Resources/en.lproj/Localizable.stringsdict
+++ b/Core/Localization/Resources/en.lproj/Localizable.stringsdict
@@ -18,5 +18,21 @@
             <string>%d bookmarks</string>
         </dict>
     </dict>
+    <key>bookmarks.editor.title</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@ayahs@</string>
+        <key>ayahs</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>one</key>
+            <string>Bookmark Ayah</string>
+            <key>other</key>
+            <string>Bookmark %d Ayahs</string>
+        </dict>
+    </dict>
 </dict>
 </plist>

--- a/Features/AyahMenuFeature/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/AyahMenuBuilder.swift
@@ -7,9 +7,6 @@
 //
 
 import AppDependencies
-#if QURAN_SYNC
-import BookmarksFeature
-#endif
 import QuranAnnotations
 import QuranKit
 import QuranTextKit
@@ -18,23 +15,6 @@ import UIKit
 public struct AyahMenuInput {
     // MARK: Lifecycle
 
-    #if QURAN_SYNC
-    public init(
-        sourceView: UIView,
-        pointInView: CGPoint,
-        verses: [AyahNumber],
-        notes: [QuranAnnotations.Note],
-        highlightVerses: [AyahNumber: HighlightColor],
-        highlightCollections: [AyahBookmarkCollection]
-    ) {
-        self.sourceView = sourceView
-        self.pointInView = pointInView
-        self.verses = verses
-        self.notes = notes
-        self.highlightVerses = highlightVerses
-        self.highlightCollections = highlightCollections
-    }
-    #else
     public init(
         sourceView: UIView,
         pointInView: CGPoint,
@@ -46,7 +26,6 @@ public struct AyahMenuInput {
         self.verses = verses
         self.notes = notes
     }
-    #endif
 
     // MARK: Internal
 
@@ -54,10 +33,6 @@ public struct AyahMenuInput {
     let pointInView: CGPoint
     let verses: [AyahNumber]
     let notes: [QuranAnnotations.Note]
-    #if QURAN_SYNC
-    let highlightVerses: [AyahNumber: HighlightColor]
-    let highlightCollections: [AyahBookmarkCollection]
-    #endif
 }
 
 @MainActor
@@ -81,10 +56,7 @@ public struct AyahMenuBuilder {
             pointInView: input.pointInView,
             verses: input.verses,
             textRetriever: textRetriever,
-            notes: input.notes,
-            highlightVerses: input.highlightVerses,
-            highlightCollections: input.highlightCollections,
-            ayahBookmarkCollectionService: AyahBookmarkCollectionService(quranDataService: container.quranDataService)
+            notes: input.notes
         )
         #else
         let deps = AyahMenuViewModel.Deps(

--- a/Features/AyahMenuFeature/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewController.swift
@@ -38,7 +38,7 @@ final class AyahMenuViewController: UIViewController {
         let actions = AyahMenuUI.Actions(
             play: { [weak self] in self?.viewModel.play() },
             repeatVerses: { [weak self] in self?.viewModel.repeatVerses() },
-            highlight: { [weak self] color in await self?.viewModel.updateHighlight(color: color) },
+            bookmark: { [weak self] in self?.viewModel.bookmark() },
             addNote: { [weak self] in await self?.viewModel.editNote() },
             deleteNote: { [weak self] in await self?.viewModel.deleteNotes() },
             showTranslation: { [weak self] in self?.viewModel.showTranslation() },
@@ -49,6 +49,7 @@ final class AyahMenuViewController: UIViewController {
         let dataObject = AyahMenuUI.DataObject(
             highlightingColor: highlightingColor,
             state: viewModel.noteState,
+            bookmarkTitle: viewModel.bookmarkTitle,
             playSubtitle: viewModel.playSubtitle,
             repeatSubtitle: viewModel.repeatSubtitle,
             actions: actions,

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -8,9 +8,6 @@
 
 import AnnotationsService
 import Crashing
-#if QURAN_SYNC
-import BookmarksFeature
-#endif
 import Localization
 import NoorUI
 import QuranAnnotations
@@ -29,6 +26,7 @@ public protocol AyahMenuListener: AnyObject {
 
     func shareText(_ lines: [String], in sourceView: UIView, at point: CGPoint)
     func showTranslation(_ verses: [AyahNumber])
+    func showBookmarkEditor(for verses: [AyahNumber])
     func showNoteEditor(for verses: [AyahNumber]) async
     func deleteNotes(in verses: [AyahNumber]) async
 }
@@ -43,11 +41,7 @@ final class AyahMenuViewModel {
         let verses: [AyahNumber]
         let textRetriever: ShareableVerseTextRetriever
         let notes: [QuranAnnotations.Note]
-        #if QURAN_SYNC
-        let highlightVerses: [AyahNumber: HighlightColor]
-        let highlightCollections: [AyahBookmarkCollection]
-        let ayahBookmarkCollectionService: AyahBookmarkCollectionService
-        #else
+        #if !QURAN_SYNC
         let noteService: NoteService
         #endif
         let quranContentStatePreferences = QuranContentStatePreferences.shared
@@ -69,7 +63,7 @@ final class AyahMenuViewModel {
 
     var highlightingColor: HighlightColor {
         #if QURAN_SYNC
-        return selectedHighlightColor ?? HighlightPreferences.shared.lastUsedHighlightColor
+        return HighlightPreferences.shared.lastUsedHighlightColor
         #else
         return deps.noteService.color(from: deps.notes)
         #endif
@@ -85,6 +79,10 @@ final class AyahMenuViewModel {
         case .page: return l("ayah.menu.play-end-page")
         case .quran: return l("ayah.menu.play-end-quran")
         }
+    }
+
+    var bookmarkTitle: String {
+        lFormat("bookmarks.editor.title", deps.verses.count)
     }
 
     var repeatSubtitle: String {
@@ -134,6 +132,11 @@ final class AyahMenuViewModel {
         listener?.playAudio(verses[0], to: verses.last, repeatVerses: true)
     }
 
+    func bookmark() {
+        logger.info("AyahMenu: bookmark tapped. Verses: \(deps.verses)")
+        listener?.showBookmarkEditor(for: deps.verses)
+    }
+
     func deleteNotes() async {
         logger.info("AyahMenu: delete notes. Verses: \(deps.verses)")
         listener?.dismissAyahMenu()
@@ -143,12 +146,6 @@ final class AyahMenuViewModel {
     func editNote() async {
         logger.info("AyahMenu: edit notes. Verses: \(deps.verses)")
         await listener?.showNoteEditor(for: deps.verses)
-    }
-
-    func updateHighlight(color: HighlightColor) async {
-        logger.info("AyahMenu: update verse highlights. Verses: \(deps.verses)")
-        listener?.dismissAyahMenu()
-        _ = await _updateHighlight(color: color)
     }
 
     func showTranslation() {
@@ -183,17 +180,6 @@ final class AyahMenuViewModel {
 
     private let deps: Deps
 
-    #if QURAN_SYNC
-    private var selectedHighlightColor: HighlightColor? {
-        let colors = deps.verses.compactMap { deps.highlightVerses[$0] }
-        guard colors.count == deps.verses.count else {
-            return nil
-        }
-        let uniqueColors = Set(colors)
-        return uniqueColors.count == 1 ? uniqueColors.first : nil
-    }
-    #endif
-
     // MARK: - Helper
 
     #if !QURAN_SYNC
@@ -204,75 +190,9 @@ final class AyahMenuViewModel {
     }
     #endif
 
-    private func _updateHighlight(color: HighlightColor) async -> QuranAnnotations.Note? {
-        #if QURAN_SYNC
-        do {
-            try await updateSyncedHighlight(color: color)
-            return nil
-        } catch {
-            crasher.recordError(error, reason: "Failed to update synced highlights")
-            return nil
-        }
-        #else
-        return await updateLegacyHighlight(color: color)
-        #endif
-    }
-
-    #if !QURAN_SYNC
-    private func updateLegacyHighlight(color: HighlightColor) async -> QuranAnnotations.Note? {
-        let quran = ReadingPreferences.shared.reading.quran
-        do {
-            let updatedNote = try await deps.noteService.updateHighlight(
-                verses: deps.verses, color: color, quran: quran
-            )
-            logger.info("AyahMenu: notes updated")
-            return updatedNote
-        } catch {
-            crasher.recordError(error, reason: "Failed to update highlights")
-            return nil
-        }
-    }
-    #endif
-
     private func retrieveSelectedAyahText() async throws -> [String] {
         try await crasher.recordError("Failed to update highlights") {
             try await deps.textRetriever.textForVerses(deps.verses)
         }
     }
-
-    #if QURAN_SYNC
-    private func updateSyncedHighlight(color: HighlightColor) async throws {
-        HighlightPreferences.shared.lastUsedHighlightColor = color
-
-        let collections = deps.highlightCollections.filter {
-            if case .colored = $0.kind {
-                return true
-            }
-            return false
-        }
-        guard let targetCollection = collections.first(where: {
-            $0.kind == .colored(color)
-        }) else {
-            throw AyahMenuError.highlightCollectionUnavailable
-        }
-        let service = deps.ayahBookmarkCollectionService
-        let otherCollections = collections.filter {
-            $0.collection.id != targetCollection.collection.id
-        }
-        try await service.addAyahBookmarksIfNeeded(
-            deps.verses,
-            to: targetCollection
-        )
-        try await service.removeAyahBookmarksIfNeeded(
-            deps.verses,
-            from: otherCollections
-        )
-    }
-    #endif
 }
-
-#if QURAN_SYNC
-private enum AyahMenuError: Error {
-    case highlightCollectionUnavailable
-}
-#endif

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -1,80 +1,51 @@
 #if QURAN_SYNC
-import MobileSync
-import MobileSyncTestSupport
 import QuranAnnotations
 import QuranKit
 import QuranTextKit
 import UIKit
 import XCTest
 @testable import AyahMenuFeature
-@testable import BookmarksFeature
 
 @MainActor
 final class AyahMenuViewModelTests: XCTestCase {
-    private let database = MobileSyncTestDatabase.shared
-
-    override func setUp() async throws {
-        try await super.setUp()
-        try await database.reset()
-    }
-
-    override func tearDown() async throws {
-        try await database.reset()
-        try await super.tearDown()
-    }
-
-    func test_updateHighlight_movesAyahBetweenCollectionsInMobileSyncDatabase() async throws {
-        let service = AyahBookmarkCollectionService(quranDataService: database.quranDataService)
-        try await service.createCollection(named: HighlightColor.red.collectionName.uppercased())
-        try await service.createCollection(named: HighlightColor.blue.collectionName.uppercased())
-        let collections = try await storedCollections()
-        let mapped = AyahBookmarkCollectionService.collections(from: collections, quran: .hafsMadani1405)
-        let red = try XCTUnwrap(mapped.first { $0.kind == .colored(.red) })
-        try await service.addAyahBookmarkToCollection(
-            collectionId: red.collection.id,
-            ayah: ayah
-        )
-        let populatedCollections = AyahBookmarkCollectionService.collections(
-            from: try await storedCollections(),
-            quran: .hafsMadani1405
-        )
+    func test_bookmark_requestsEditorForCrossSuraSelection() throws {
+        let verses = [
+            try XCTUnwrap(AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 7)),
+            try XCTUnwrap(AyahNumber(quran: .hafsMadani1405, sura: 2, ayah: 1)),
+        ]
         let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-quran-database")
         let sut = AyahMenuViewModel(deps: .init(
             sourceView: UIView(),
             pointInView: .zero,
-            verses: [ayah],
+            verses: verses,
             textRetriever: ShareableVerseTextRetriever(
                 databasesURL: unavailableDatabase,
                 quranFileURL: unavailableDatabase
             ),
-            notes: [],
-            highlightVerses: [ayah: .red],
-            highlightCollections: populatedCollections,
-            ayahBookmarkCollectionService: service
+            notes: []
         ))
+        let listener = BookmarkListenerSpy()
+        sut.listener = listener
 
-        await sut.updateHighlight(color: .blue)
+        sut.bookmark()
 
-        let updated = try await storedCollections()
-        let redBookmarks = updated.first {
-            $0.collection.name == HighlightColor.red.collectionName.uppercased()
-        }?.bookmarks
-        let blueBookmarks = updated.first {
-            $0.collection.name == HighlightColor.blue.collectionName.uppercased()
-        }?.bookmarks
-        XCTAssertTrue(redBookmarks?.isEmpty == true)
-        XCTAssertEqual(blueBookmarks?.count, 1)
-        XCTAssertEqual(blueBookmarks?.first?.sura, 1)
-        XCTAssertEqual(blueBookmarks?.first?.ayah, 1)
+        XCTAssertEqual(listener.bookmarkedVerses, verses)
     }
+}
 
-    private var ayah: AyahNumber {
-        AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
-    }
+@MainActor
+private final class BookmarkListenerSpy: AyahMenuListener {
+    private(set) var bookmarkedVerses: [AyahNumber]?
 
-    private func storedCollections() async throws -> [CollectionWithAyahBookmarks] {
-        let iterator = database.quranDataService.collectionsWithBookmarksSequence().makeAsyncIterator()
-        return try await iterator.next() ?? []
+    func dismissAyahMenu() {}
+    func playAudio(_ from: AyahNumber, to: AyahNumber?, repeatVerses: Bool) {}
+    func shareText(_ lines: [String], in sourceView: UIView, at point: CGPoint) {}
+    func showTranslation(_ verses: [AyahNumber]) {}
+    func showNoteEditor(for verses: [AyahNumber]) async {}
+    func deleteNotes(in verses: [AyahNumber]) async {}
+
+    func showBookmarkEditor(for verses: [AyahNumber]) {
+        bookmarkedVerses = verses
     }
 }
 #endif

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollection+Presentation.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollection+Presentation.swift
@@ -2,6 +2,7 @@
 import Localization
 import NoorUI
 import QuranAnnotations
+import SwiftUI
 
 extension AyahBookmarkCollection {
     var displayName: String {
@@ -27,6 +28,17 @@ extension AyahBookmarkCollection {
             .bookmark
         case .user:
             .folder
+        }
+    }
+
+    var displayImageColor: Color {
+        switch kind {
+        case .defaultBookmarks:
+            Color(uiColor: .systemYellow)
+        case .oldPageBookmarks:
+            .secondaryLabel
+        case .colored, .user:
+            .appIdentity
         }
     }
 }

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
@@ -5,6 +5,8 @@
 //  Created by Ahmed Nabil on 2026-05-06.
 //
 
+import Foundation
+import Localization
 import MobileSync
 import QuranAnnotations
 import QuranKit
@@ -151,28 +153,42 @@ public struct AyahBookmarkCollectionService {
         try await quranDataService.removeAyahBookmarkFromCollection(bookmark.bookmark)
     }
 
-    public func addAyahBookmarksIfNeeded(
-        _ ayahs: [AyahNumber],
-        to collection: AyahBookmarkCollection
-    ) async throws {
-        for ayah in Self.ayahsToAdd(ayahs, to: collection) {
-            try await addAyahBookmarkToCollection(
-                collectionId: collection.collection.id,
-                ayah: ayah
-            )
+    public func setHighlight(_ color: HighlightColor?, for ayahs: [AyahNumber]) async throws {
+        let collections = try await loadStoredCollections()
+        let coloredCollections = collections.filter { $0.kind.highlightColor != nil }
+
+        guard let color else {
+            try await removeAyahs(ayahs, from: coloredCollections)
+            return
         }
+
+        guard let targetCollection = coloredCollections.first(where: { $0.kind == .colored(color) }) else {
+            throw AyahBookmarkCollectionServiceError.highlightCollectionUnavailable
+        }
+
+        try await addAyahsIfNeeded(ayahs, to: targetCollection)
+        try await removeAyahs(
+            ayahs,
+            from: coloredCollections.filter { $0.collection.id != targetCollection.collection.id }
+        )
     }
 
-    public func removeAyahBookmarksIfNeeded(
-        _ ayahs: [AyahNumber],
-        from collections: [AyahBookmarkCollection]
-    ) async throws {
-        let ayahs = Set(ayahs)
-        for collection in collections {
-            for bookmark in collection.bookmarks where ayahs.contains(bookmark.ayah) {
-                try await removeBookmarkFromCollection(bookmark)
-            }
+    public func addAyahs(_ ayahs: [AyahNumber], toCollectionWithID collectionID: String) async throws {
+        let collections = try await loadStoredCollections()
+        guard let collection = collections.first(where: { $0.collection.id == collectionID }) else {
+            return
         }
+
+        try await addAyahsIfNeeded(ayahs, to: collection)
+    }
+
+    public func removeAyahs(_ ayahs: [AyahNumber], fromCollectionWithID collectionID: String) async throws {
+        let collections = try await loadStoredCollections()
+        guard let collection = collections.first(where: { $0.collection.id == collectionID }) else {
+            return
+        }
+
+        try await removeAyahs(ayahs, from: [collection])
     }
 
     public func collectionsSequence() -> AyahBookmarkCollectionsSequence {
@@ -219,6 +235,36 @@ public struct AyahBookmarkCollectionService {
     private let quranDataService: QuranDataService
     private let readingPreferences: ReadingPreferences
 
+    private func loadStoredCollections() async throws -> [AyahBookmarkCollection] {
+        let iterator = quranDataService.collectionsWithBookmarksSequence().makeAsyncIterator()
+        let collections = try await iterator.next() ?? []
+        return Self.collections(from: collections, quran: readingPreferences.reading.quran)
+    }
+
+    private func addAyahsIfNeeded(
+        _ ayahs: [AyahNumber],
+        to collection: AyahBookmarkCollection
+    ) async throws {
+        for ayah in Self.ayahsToAdd(ayahs, to: collection) {
+            try await addAyahBookmarkToCollection(
+                collectionId: collection.collection.id,
+                ayah: ayah
+            )
+        }
+    }
+
+    private func removeAyahs(
+        _ ayahs: [AyahNumber],
+        from collections: [AyahBookmarkCollection]
+    ) async throws {
+        let ayahs = Set(ayahs)
+        for collection in collections {
+            for bookmark in collection.bookmarks where ayahs.contains(bookmark.ayah) {
+                try await removeBookmarkFromCollection(bookmark)
+            }
+        }
+    }
+
     private static func bookmark(for bookmark: CollectionAyahBookmark, quran: Quran) -> AyahCollectionBookmark? {
         guard let ayah = AyahNumber(
             quran: quran,
@@ -229,6 +275,14 @@ public struct AyahBookmarkCollectionService {
         }
 
         return AyahCollectionBookmark(bookmark: bookmark, ayah: ayah)
+    }
+}
+
+private enum AyahBookmarkCollectionServiceError: LocalizedError {
+    case highlightCollectionUnavailable
+
+    var errorDescription: String? {
+        l("bookmarks.editor.error.highlight-unavailable")
     }
 }
 

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsBuilder.swift
@@ -1,0 +1,59 @@
+//
+//  BookmarkAyahsBuilder.swift
+//
+
+import AppDependencies
+import NoorUI
+import QuranAnnotations
+import QuranKit
+import UIKit
+
+@MainActor
+public struct BookmarkAyahsBuilder {
+    // MARK: Lifecycle
+
+    public init(container: AppDependencies) {
+        self.container = container
+    }
+
+    // MARK: Public
+
+    #if QURAN_SYNC
+    public func build(
+        verses: [AyahNumber],
+        collections: [AyahBookmarkCollection]
+    ) -> UIViewController {
+        let viewModel = BookmarkAyahsViewModel(
+            verses: verses,
+            collections: collections,
+            ayahBookmarkCollectionService: AyahBookmarkCollectionService(
+                quranDataService: container.quranDataService
+            )
+        )
+        return navigationController(viewModel: viewModel)
+    }
+    #else
+    public func build(
+        verses: [AyahNumber],
+        notes: [QuranAnnotations.Note]
+    ) -> UIViewController {
+        let viewModel = BookmarkAyahsViewModel(
+            verses: verses,
+            notes: notes,
+            noteService: container.noteService()
+        )
+        return navigationController(viewModel: viewModel)
+    }
+    #endif
+
+    // MARK: Private
+
+    private let container: AppDependencies
+
+    private func navigationController(viewModel: BookmarkAyahsViewModel) -> UIViewController {
+        let viewController = BookmarkAyahsViewController(viewModel: viewModel)
+        let navigationController = BaseNavigationController(rootViewController: viewController)
+        navigationController.modalPresentationStyle = .pageSheet
+        return navigationController
+    }
+}

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsView.swift
@@ -1,0 +1,124 @@
+//
+//  BookmarkAyahsView.swift
+//
+
+import Localization
+import NoorUI
+import QuranAnnotations
+import SwiftUI
+import UIx
+
+@MainActor
+struct BookmarkAyahsView: View {
+    @ObservedObject var viewModel: BookmarkAyahsViewModel
+
+    var body: some View {
+        NoorList {
+            NoorBasicSection(title: l("ayah.menu.highlight")) {
+                #if QURAN_SYNC
+                HighlightColorPicker(
+                    selectedColor: viewModel.selectedHighlightColor,
+                    onSelect: { await viewModel.selectHighlight($0) },
+                    onRemove: viewModel.highlightSelection == .none
+                        ? nil
+                        : { await viewModel.selectHighlight(nil) }
+                )
+                .disabled(viewModel.isUpdatingHighlight)
+                #else
+                HighlightColorPicker(
+                    selectedColor: viewModel.selectedHighlightColor,
+                    onSelect: { await viewModel.selectHighlight($0) }
+                )
+                .disabled(viewModel.isUpdatingHighlight)
+                #endif
+            }
+
+            #if QURAN_SYNC
+            NoorBasicSection(title: l("bookmarks.collections.mine")) {
+                ForEach(viewModel.displayedCollections, id: \.collection.id) { collection in
+                    collectionRow(collection)
+                }
+
+                NoorListItem(
+                    image: .init(.plusCircle, color: .appIdentity),
+                    title: .text(l("bookmarks.collections.new")),
+                    titleColor: .appIdentity,
+                    action: { viewModel.presentAddCollection() }
+                )
+            }
+            #endif
+        }
+        #if QURAN_SYNC
+        .task { await viewModel.start() }
+            .addBookmarkCollectionAlert(viewModel: viewModel)
+        #endif
+            .errorAlert(error: $viewModel.error)
+    }
+
+    #if QURAN_SYNC
+    private func collectionRow(_ collection: AyahBookmarkCollection) -> some View {
+        let selection = viewModel.collectionSelection(for: collection)
+        return NoorListItem(
+            image: .init(collection.displayImage, color: collection.displayImageColor),
+            title: .text(collection.displayName),
+            accessory: collectionAccessory(selection),
+            action: { await viewModel.toggleCollection(collection) }
+        )
+        .disabled(viewModel.isUpdatingCollection(collection))
+        .accessibilityValue(collectionAccessibilityValue(selection))
+    }
+
+    private func collectionAccessory(
+        _ selection: BookmarkAyahsViewModel.CollectionSelection
+    ) -> NoorListItem.Accessory {
+        switch selection {
+        case .unselected:
+            .image(.checkmark_unchecked, color: .tertiaryLabel)
+        case .mixed:
+            .image(.checkmark_indeterminate, color: .appIdentity)
+        case .selected:
+            .image(.checkmark_checked, color: .appIdentity)
+        }
+    }
+
+    private func collectionAccessibilityValue(
+        _ selection: BookmarkAyahsViewModel.CollectionSelection
+    ) -> String {
+        switch selection {
+        case .unselected:
+            l("bookmarks.editor.collection.unselected")
+        case .mixed:
+            l("bookmarks.editor.collection.mixed")
+        case .selected:
+            l("bookmarks.editor.collection.selected")
+        }
+    }
+    #endif
+}
+
+#if QURAN_SYNC
+private extension View {
+    @MainActor
+    func addBookmarkCollectionAlert(viewModel: BookmarkAyahsViewModel) -> some View {
+        alert(
+            l("bookmarks.collections.add"),
+            isPresented: Binding(
+                get: { viewModel.isPresentingAddCollection },
+                set: { viewModel.isPresentingAddCollection = $0 }
+            )
+        ) {
+            TextField(
+                l("bookmarks.collections.new.placeholder"),
+                text: Binding(
+                    get: { viewModel.newCollectionName },
+                    set: { viewModel.newCollectionName = $0 }
+                )
+            )
+            Button(lAndroid("cancel"), role: .cancel) {}
+            Button(l("bookmarks.collections.add")) {
+                Task { await viewModel.createPendingCollection() }
+            }
+        }
+    }
+}
+#endif

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsViewController.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsViewController.swift
@@ -1,0 +1,38 @@
+//
+//  BookmarkAyahsViewController.swift
+//
+
+import Localization
+import NoorUI
+import SwiftUI
+import UIKit
+
+@MainActor
+final class BookmarkAyahsViewController: UIHostingController<BookmarkAyahsView> {
+    // MARK: Lifecycle
+
+    init(viewModel: BookmarkAyahsViewModel) {
+        super.init(rootView: BookmarkAyahsView(viewModel: viewModel))
+        title = viewModel.title
+        navigationItem.largeTitleDisplayMode = .never
+        configureDoneButton()
+    }
+
+    @available(*, unavailable)
+    dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Private
+
+    private func configureDoneButton() {
+        let doneButton = UIBarButtonItem(
+            title: l("button.done"),
+            primaryAction: UIAction { [weak self] _ in
+                self?.dismiss(animated: true)
+            }
+        )
+        doneButton.tintColor = .appIdentity
+        navigationItem.rightBarButtonItem = doneButton
+    }
+}

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsViewModel.swift
@@ -1,0 +1,293 @@
+//
+//  BookmarkAyahsViewModel.swift
+//
+
+import AnnotationsService
+import Combine
+import Foundation
+import Localization
+import QuranAnnotations
+import QuranKit
+import ReadingService
+import VLogging
+
+#if QURAN_SYNC
+@MainActor
+final class BookmarkAyahsViewModel: ObservableObject {
+    enum HighlightSelection: Equatable {
+        case none
+        case mixed
+        case color(HighlightColor)
+    }
+
+    enum CollectionSelection: Equatable {
+        case unselected
+        case mixed
+        case selected
+    }
+
+    // MARK: Lifecycle
+
+    init(
+        verses: [AyahNumber],
+        collections: [AyahBookmarkCollection],
+        ayahBookmarkCollectionService: AyahBookmarkCollectionService
+    ) {
+        self.verses = Self.unique(verses)
+        self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
+        updateCollections(collections)
+    }
+
+    // MARK: Internal
+
+    @Published private(set) var collections: [AyahBookmarkCollection] = []
+    @Published private(set) var collectionSelections: [String: CollectionSelection] = [:]
+    @Published private(set) var highlightSelection: HighlightSelection = .none
+    @Published private(set) var isUpdatingHighlight = false
+    @Published private(set) var updatingCollectionIDs: Set<String> = []
+    @Published var error: Error?
+    @Published var isPresentingAddCollection = false
+    @Published var newCollectionName = ""
+
+    var title: String {
+        lFormat("bookmarks.editor.title", verses.count)
+    }
+
+    var displayedCollections: [AyahBookmarkCollection] {
+        BookmarkCollectionsViewModel.displayedCollections(from: collections)
+    }
+
+    var selectedHighlightColor: HighlightColor? {
+        guard case .color(let color) = highlightSelection else {
+            return nil
+        }
+        return color
+    }
+
+    func start() async {
+        do {
+            for try await collections in ayahBookmarkCollectionService.collectionsSequence() {
+                updateCollections(collections)
+            }
+        } catch {
+            guard !Task.isCancelled else {
+                return
+            }
+            self.error = error
+        }
+    }
+
+    func selectHighlight(_ color: HighlightColor?) async {
+        let selection = color.map(HighlightSelection.color) ?? .none
+        guard selection != highlightSelection, !isUpdatingHighlight else {
+            return
+        }
+
+        let previousSelection = highlightSelection
+        highlightSelection = selection
+        isUpdatingHighlight = true
+        defer { isUpdatingHighlight = false }
+
+        do {
+            try await ayahBookmarkCollectionService.setHighlight(color, for: verses)
+            if let color {
+                HighlightPreferences.shared.lastUsedHighlightColor = color
+            }
+        } catch is CancellationError {
+            highlightSelection = previousSelection
+        } catch {
+            logger.error("Bookmarks: failed to update highlight: \(error)")
+            highlightSelection = previousSelection
+            self.error = error
+        }
+    }
+
+    func collectionSelection(for collection: AyahBookmarkCollection) -> CollectionSelection {
+        collectionSelections[collection.collection.id] ?? .unselected
+    }
+
+    func toggleCollection(_ collection: AyahBookmarkCollection) async {
+        let id = collection.collection.id
+        guard !updatingCollectionIDs.contains(id) else {
+            return
+        }
+
+        let previousSelection = collectionSelection(for: collection)
+        let selection: CollectionSelection = switch previousSelection {
+        case .selected:
+            .unselected
+        case .mixed, .unselected:
+            .selected
+        }
+        collectionSelections[id] = selection
+        updatingCollectionIDs.insert(id)
+        defer { updatingCollectionIDs.remove(id) }
+
+        do {
+            switch selection {
+            case .mixed:
+                return
+            case .selected:
+                try await ayahBookmarkCollectionService.addAyahs(verses, toCollectionWithID: id)
+            case .unselected:
+                try await ayahBookmarkCollectionService.removeAyahs(verses, fromCollectionWithID: id)
+            }
+        } catch is CancellationError {
+            collectionSelections[id] = previousSelection
+        } catch {
+            logger.error("Bookmarks: failed to update collection: \(error)")
+            collectionSelections[id] = previousSelection
+            self.error = error
+        }
+    }
+
+    func isUpdatingCollection(_ collection: AyahBookmarkCollection) -> Bool {
+        updatingCollectionIDs.contains(collection.collection.id)
+    }
+
+    func presentAddCollection() {
+        newCollectionName = ""
+        isPresentingAddCollection = true
+    }
+
+    func createPendingCollection() async {
+        let name = newCollectionName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else {
+            return
+        }
+
+        do {
+            try await ayahBookmarkCollectionService.createCollection(named: name)
+            newCollectionName = ""
+            isPresentingAddCollection = false
+        } catch {
+            self.error = error
+        }
+    }
+
+    // MARK: Private
+
+    private let verses: [AyahNumber]
+    private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
+
+    private func updateCollections(_ collections: [AyahBookmarkCollection]) {
+        let collections = BookmarkCollectionsViewModel.sorted(collections)
+        self.collections = collections
+
+        if !isUpdatingHighlight {
+            highlightSelection = Self.highlightSelection(for: verses, in: collections)
+        }
+
+        let displayedCollections = BookmarkCollectionsViewModel.displayedCollections(from: collections)
+        let displayedCollectionIDs = Set(displayedCollections.map(\.collection.id))
+        collectionSelections = collectionSelections.filter { displayedCollectionIDs.contains($0.key) }
+
+        for collection in displayedCollections {
+            let id = collection.collection.id
+            if !updatingCollectionIDs.contains(id) {
+                collectionSelections[id] = Self.collectionSelection(for: verses, in: collection)
+            }
+        }
+    }
+
+    private static func highlightSelection(
+        for verses: [AyahNumber],
+        in collections: [AyahBookmarkCollection]
+    ) -> HighlightSelection {
+        let coloredCollections = collections.filter { $0.kind.highlightColor != nil }
+        let colors = verses.map { ayah in
+            coloredCollections.first { collection in
+                collection.bookmarks.contains { $0.ayah == ayah }
+            }?.kind.highlightColor
+        }
+
+        guard let firstColor = colors.first else {
+            return .none
+        }
+        guard colors.dropFirst().allSatisfy({ $0 == firstColor }) else {
+            return .mixed
+        }
+        if let firstColor {
+            return .color(firstColor)
+        }
+        return .none
+    }
+
+    private static func collectionSelection(
+        for verses: [AyahNumber],
+        in collection: AyahBookmarkCollection
+    ) -> CollectionSelection {
+        let selectedVerses = Set(verses)
+        let bookmarkedVerses = Set(collection.bookmarks.map(\.ayah))
+        let intersectionCount = selectedVerses.intersection(bookmarkedVerses).count
+
+        if intersectionCount == 0 {
+            return .unselected
+        }
+        if intersectionCount == selectedVerses.count {
+            return .selected
+        }
+        return .mixed
+    }
+
+    private static func unique(_ verses: [AyahNumber]) -> [AyahNumber] {
+        var seen = Set<AyahNumber>()
+        return verses.filter { seen.insert($0).inserted }
+    }
+}
+#else
+@MainActor
+final class BookmarkAyahsViewModel: ObservableObject {
+    // MARK: Lifecycle
+
+    init(
+        verses: [AyahNumber],
+        notes: [QuranAnnotations.Note],
+        noteService: NoteService
+    ) {
+        self.verses = verses
+        self.noteService = noteService
+        selectedHighlightColor = noteService.color(from: notes)
+    }
+
+    // MARK: Internal
+
+    @Published private(set) var isUpdatingHighlight = false
+    @Published var error: Error?
+    @Published private(set) var selectedHighlightColor: HighlightColor
+
+    var title: String {
+        lFormat("bookmarks.editor.title", verses.count)
+    }
+
+    func selectHighlight(_ color: HighlightColor?) async {
+        guard let color, color != selectedHighlightColor, !isUpdatingHighlight else {
+            return
+        }
+
+        let previousColor = selectedHighlightColor
+        selectedHighlightColor = color
+        isUpdatingHighlight = true
+        defer { isUpdatingHighlight = false }
+
+        do {
+            _ = try await noteService.updateHighlight(
+                verses: verses,
+                color: color,
+                quran: ReadingPreferences.shared.reading.quran
+            )
+        } catch is CancellationError {
+            selectedHighlightColor = previousColor
+        } catch {
+            logger.error("Bookmarks: failed to update highlight: \(error)")
+            selectedHighlightColor = previousColor
+            self.error = error
+        }
+    }
+
+    // MARK: Private
+
+    private let verses: [AyahNumber]
+    private let noteService: NoteService
+}
+#endif

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
@@ -61,7 +61,7 @@ private struct BookmarkCollectionsContent: View {
                     collectionRow(
                         title: collection.displayName,
                         image: collection.displayImage,
-                        imageColor: collectionImageColor(collection),
+                        imageColor: collection.displayImageColor,
                         collection: collection
                     )
                     .deleteDisabled(!collection.kind.canDelete)
@@ -88,17 +88,6 @@ private struct BookmarkCollectionsContent: View {
         .addCollectionAlert(viewModel: viewModel)
         .errorAlert(error: $viewModel.error)
         .environment(\.editMode, $viewModel.editMode)
-    }
-
-    private func collectionImageColor(_ collection: AyahBookmarkCollection) -> Color {
-        switch collection.kind {
-        case .defaultBookmarks:
-            Color(uiColor: .systemYellow)
-        case .oldPageBookmarks:
-            .secondaryLabel
-        case .colored, .user:
-            .appIdentity
-        }
     }
 
     private func highlightCollection(for color: HighlightColor) -> AyahBookmarkCollection? {

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionServiceTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionServiceTests.swift
@@ -66,17 +66,54 @@ final class AyahBookmarkCollectionServiceTests: XCTestCase {
         XCTAssertTrue(emptied.bookmarks.isEmpty)
     }
 
-    func test_addAyahBookmarksIfNeeded_persistsOnlyMissingUniqueAyahs() async throws {
+    func test_addAyahs_persistsOnlyMissingUniqueAyahs() async throws {
         try await service.createCollection(named: "Favorites")
         let stored = try await storedCollection(named: "Favorites")
-        let collection = try XCTUnwrap(
-            AyahBookmarkCollectionService.collections(from: [stored], quran: .hafsMadani1405).first
-        )
 
-        try await service.addAyahBookmarksIfNeeded([ayah(1), ayah(1), ayah(2)], to: collection)
+        try await service.addAyahs(
+            [ayah(1), ayah(1), ayah(2)],
+            toCollectionWithID: stored.collection.id
+        )
 
         let updated = try await storedCollection(named: "Favorites") { $0.bookmarks.count == 2 }
         XCTAssertEqual(Set(updated.bookmarks.map { "\($0.sura):\($0.ayah)" }), ["1:1", "1:2"])
+    }
+
+    func test_removeAyahs_removesOnlyRequestedCollectionMemberships() async throws {
+        try await service.createCollection(named: "Favorites")
+        try await service.createCollection(named: "Study")
+        let favorites = try await storedCollection(named: "Favorites")
+        let study = try await storedCollection(named: "Study")
+        for number in [1, 2] {
+            try await service.addAyahBookmarkToCollection(collectionId: favorites.collection.id, ayah: ayah(number))
+            try await service.addAyahBookmarkToCollection(collectionId: study.collection.id, ayah: ayah(number))
+        }
+
+        try await service.removeAyahs([ayah(1)], fromCollectionWithID: favorites.collection.id)
+
+        let updatedFavorites = try await storedCollection(named: "Favorites") { $0.bookmarks.count == 1 }
+        let updatedStudy = try await storedCollection(named: "Study") { $0.bookmarks.count == 2 }
+        XCTAssertEqual(updatedFavorites.bookmarks.map(\.ayah), [2])
+        XCTAssertEqual(Set(updatedStudy.bookmarks.map(\.ayah)), [1, 2])
+    }
+
+    func test_setHighlight_replacesExistingHighlightAcrossCollections() async throws {
+        try await service.createCollection(named: HighlightColor.red.collectionName)
+        try await service.createCollection(named: HighlightColor.green.collectionName)
+        let red = try await storedCollection(named: HighlightColor.red.collectionName)
+        try await service.addAyahBookmarkToCollection(collectionId: red.collection.id, ayah: ayah(1))
+        try await service.addAyahBookmarkToCollection(collectionId: red.collection.id, ayah: ayah(2))
+
+        try await service.setHighlight(.green, for: [ayah(1), ayah(2)])
+
+        let updatedRed = try await storedCollection(named: HighlightColor.red.collectionName) {
+            $0.bookmarks.isEmpty
+        }
+        let updatedGreen = try await storedCollection(named: HighlightColor.green.collectionName) {
+            $0.bookmarks.count == 2
+        }
+        XCTAssertTrue(updatedRed.bookmarks.isEmpty)
+        XCTAssertEqual(Set(updatedGreen.bookmarks.map(\.ayah)), [1, 2])
     }
 
     func test_collectionsSequence_createsAllMissingHighlightCollectionsInDatabase() async throws {

--- a/Features/BookmarksFeature/Tests/BookmarkAyahsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkAyahsViewModelTests.swift
@@ -1,0 +1,141 @@
+#if QURAN_SYNC
+import MobileSync
+import MobileSyncTestSupport
+import QuranAnnotations
+import QuranKit
+import XCTest
+@testable import BookmarksFeature
+
+@MainActor
+final class BookmarkAyahsViewModelTests: XCTestCase {
+    private let database = MobileSyncTestDatabase.shared
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+    }
+
+    override func tearDown() async throws {
+        try await database.reset()
+        try await super.tearDown()
+    }
+
+    func test_selectingHighlightImmediatelyPersistsAcrossSuras() async throws {
+        let fixture = try await makeFixture()
+        let sut = BookmarkAyahsViewModel(
+            verses: verses,
+            collections: fixture.collections,
+            ayahBookmarkCollectionService: fixture.service
+        )
+
+        await sut.selectHighlight(.green)
+
+        let stored = try await storedCollections()
+        XCTAssertEqual(bookmarkedAyahs(in: stored, named: HighlightColor.green.collectionName), ["1:7", "2:1"])
+        XCTAssertEqual(bookmarkedAyahs(in: stored, named: HighlightColor.red.collectionName), [])
+        XCTAssertEqual(sut.highlightSelection, .color(.green))
+    }
+
+    func test_togglingMixedCollectionImmediatelyAddsAllSelectedAyahs() async throws {
+        let fixture = try await makeFixture()
+        let sut = BookmarkAyahsViewModel(
+            verses: verses,
+            collections: fixture.collections,
+            ayahBookmarkCollectionService: fixture.service
+        )
+        let study = try XCTUnwrap(sut.displayedCollections.first { $0.collection.name == "Study" })
+        XCTAssertEqual(sut.collectionSelection(for: study), .mixed)
+
+        await sut.toggleCollection(study)
+
+        let stored = try await storedCollections()
+        XCTAssertEqual(bookmarkedAyahs(in: stored, named: "Study"), ["1:7", "2:1"])
+        XCTAssertEqual(sut.collectionSelection(for: study), .selected)
+    }
+
+    func test_removingHighlightImmediatelyRemovesSelectedAyahs() async throws {
+        let fixture = try await makeFixture()
+        let sut = BookmarkAyahsViewModel(
+            verses: verses,
+            collections: fixture.collections,
+            ayahBookmarkCollectionService: fixture.service
+        )
+        await sut.selectHighlight(nil)
+
+        let stored = try await storedCollections()
+        XCTAssertEqual(bookmarkedAyahs(in: stored, named: HighlightColor.red.collectionName), [])
+        XCTAssertEqual(bookmarkedAyahs(in: stored, named: HighlightColor.green.collectionName), [])
+        XCTAssertEqual(sut.highlightSelection, .none)
+    }
+
+    func test_mixedHighlightSelectionCanBeRemoved() async throws {
+        let fixture = try await makeFixture()
+        let red = try XCTUnwrap(fixture.collections.first { $0.kind == .colored(.red) })
+        try await fixture.service.removeAyahs(
+            [verses[1]],
+            fromCollectionWithID: red.collection.id
+        )
+        let sut = BookmarkAyahsViewModel(
+            verses: verses,
+            collections: try await mappedCollections(),
+            ayahBookmarkCollectionService: fixture.service
+        )
+        XCTAssertEqual(sut.highlightSelection, .mixed)
+
+        await sut.selectHighlight(nil)
+
+        let stored = try await storedCollections()
+        XCTAssertEqual(bookmarkedAyahs(in: stored, named: HighlightColor.red.collectionName), [])
+        XCTAssertEqual(sut.highlightSelection, .none)
+    }
+
+    private var verses: [AyahNumber] {
+        [
+            AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 7)!,
+            AyahNumber(quran: .hafsMadani1405, sura: 2, ayah: 1)!,
+        ]
+    }
+
+    private func makeFixture() async throws -> (
+        service: AyahBookmarkCollectionService,
+        collections: [AyahBookmarkCollection]
+    ) {
+        let service = AyahBookmarkCollectionService(quranDataService: database.quranDataService)
+        try await service.createCollection(named: HighlightColor.red.collectionName)
+        try await service.createCollection(named: HighlightColor.green.collectionName)
+        try await service.createCollection(named: "Study")
+
+        var collections = try await mappedCollections()
+        let red = try XCTUnwrap(collections.first { $0.kind == .colored(.red) })
+        let study = try XCTUnwrap(collections.first { $0.collection.name == "Study" })
+        for verse in verses {
+            try await service.addAyahBookmarkToCollection(collectionId: red.collection.id, ayah: verse)
+        }
+        try await service.addAyahBookmarkToCollection(collectionId: study.collection.id, ayah: verses[0])
+        collections = try await mappedCollections()
+        return (service, collections)
+    }
+
+    private func mappedCollections() async throws -> [AyahBookmarkCollection] {
+        AyahBookmarkCollectionService.collections(
+            from: try await storedCollections(),
+            quran: .hafsMadani1405
+        )
+    }
+
+    private func storedCollections() async throws -> [CollectionWithAyahBookmarks] {
+        let iterator = database.quranDataService.collectionsWithBookmarksSequence().makeAsyncIterator()
+        return try await iterator.next() ?? []
+    }
+
+    private func bookmarkedAyahs(
+        in collections: [CollectionWithAyahBookmarks],
+        named name: String
+    ) -> Set<String> {
+        let collection = collections.first {
+            $0.collection.name.caseInsensitiveCompare(name) == .orderedSame
+        }
+        return Set(collection?.bookmarks.map { "\($0.sura):\($0.ayah)" } ?? [])
+    }
+}
+#endif

--- a/Features/QuranViewFeature/QuranBuilder.swift
+++ b/Features/QuranViewFeature/QuranBuilder.swift
@@ -10,9 +10,7 @@ import AnnotationsService
 import AppDependencies
 import AudioBannerFeature
 import AyahMenuFeature
-#if QURAN_SYNC
 import BookmarksFeature
-#endif
 import MoreMenuFeature
 import NoteEditorFeature
 import QuranContentFeature
@@ -50,6 +48,7 @@ public struct QuranBuilder {
             pageBookmarkService: pageBookmarkService,
             highlightsService: highlightsService,
             ayahMenuBuilder: AyahMenuBuilder(container: container),
+            bookmarkAyahsBuilder: BookmarkAyahsBuilder(container: container),
             moreMenuBuilder: MoreMenuBuilder(),
             audioBannerBuilder: AudioBannerBuilder(container: container),
             wordPointerBuilder: WordPointerBuilder(container: container),
@@ -70,6 +69,7 @@ public struct QuranBuilder {
             pageBookmarkService: pageBookmarkService,
             highlightsService: highlightsService,
             ayahMenuBuilder: AyahMenuBuilder(container: container),
+            bookmarkAyahsBuilder: BookmarkAyahsBuilder(container: container),
             moreMenuBuilder: MoreMenuBuilder(),
             audioBannerBuilder: AudioBannerBuilder(container: container),
             wordPointerBuilder: WordPointerBuilder(container: container),

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -10,6 +10,7 @@ import Analytics
 import AnnotationsService
 import AudioBannerFeature
 import AyahMenuFeature
+import BookmarksFeature
 import Combine
 import Crashing
 import FeaturesSupport
@@ -44,6 +45,7 @@ protocol QuranPresentable: UIViewController {
 
     func presentMoreMenu(_ viewController: UIViewController)
     func presentAyahMenu(_ viewController: UIViewController, in sourceView: UIView, at point: CGPoint)
+    func presentBookmarkAyahs(_ viewController: UIViewController)
     func presentTranslatedVerse(_ viewController: UIViewController, didDismiss: @escaping () -> Void)
     func presentAudioBanner(_ audioBanner: UIViewController)
     func presentWordPointer(_ viewController: UIViewController)
@@ -64,6 +66,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let pageBookmarkService: PageBookmarkService
         let highlightsService: QuranHighlightsService
         let ayahMenuBuilder: AyahMenuBuilder
+        let bookmarkAyahsBuilder: BookmarkAyahsBuilder
         let moreMenuBuilder: MoreMenuBuilder
         let audioBannerBuilder: AudioBannerBuilder
         let wordPointerBuilder: WordPointerBuilder
@@ -251,6 +254,28 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         #endif
     }
 
+    func showBookmarkEditor(for verses: [AyahNumber]) {
+        logger.info("Quran: show bookmark editor. Verses: \(verses)")
+        contentViewModel?.removeAyahMenuHighlight()
+        presenter?.dismissPresentedViewController { [weak self] in
+            guard let self else {
+                return
+            }
+            #if QURAN_SYNC
+            let viewController = deps.bookmarkAyahsBuilder.build(
+                verses: verses,
+                collections: deps.syncedHighlightsObserver.collections
+            )
+            #else
+            let viewController = deps.bookmarkAyahsBuilder.build(
+                verses: verses,
+                notes: notesInteractingVerses(verses)
+            )
+            #endif
+            presenter?.presentBookmarkAyahs(viewController)
+        }
+    }
+
     func dismissNoteEditor() {
         logger.info("Quran: dismiss note editor")
         presenter?.dismiss(animated: true)
@@ -276,23 +301,12 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
     func presentAyahMenu(in sourceView: UIView, at point: CGPoint, verses: [AyahNumber]) {
         logger.info("Quran: present ayah menu, verses: \(verses)")
-        #if QURAN_SYNC
-        let input = AyahMenuInput(
-            sourceView: sourceView,
-            pointInView: point,
-            verses: verses,
-            notes: notesInteractingVerses(verses),
-            highlightVerses: deps.highlightsService.highlights.highlightVerses,
-            highlightCollections: deps.syncedHighlightsObserver.collections
-        )
-        #else
         let input = AyahMenuInput(
             sourceView: sourceView,
             pointInView: point,
             verses: verses,
             notes: notesInteractingVerses(verses)
         )
-        #endif
         let ayahMenuViewController = deps.ayahMenuBuilder.build(withListener: self, input: input)
         presenter?.presentAyahMenu(ayahMenuViewController, in: sourceView, at: point)
     }

--- a/Features/QuranViewFeature/QuranViewController.swift
+++ b/Features/QuranViewFeature/QuranViewController.swift
@@ -202,6 +202,14 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         )
     }
 
+    func presentBookmarkAyahs(_ viewController: UIViewController) {
+        if let sheet = viewController.sheetPresentationController {
+            sheet.detents = [.medium(), .large()]
+            sheet.prefersGrabberVisible = true
+        }
+        present(viewController, animated: true)
+    }
+
     func presentQuranContent(_ viewController: UIViewController) {
         addContent(viewController)
     }

--- a/Model/QuranAnnotations/HighlightColor.swift
+++ b/Model/QuranAnnotations/HighlightColor.swift
@@ -4,7 +4,7 @@
 //  Created by Ahmed Nabil on 2026-05-06.
 //
 
-public enum HighlightColor: Int, CaseIterable, Equatable, Hashable {
+public enum HighlightColor: Int, CaseIterable, Equatable, Hashable, Sendable {
     case red = 0
     case green = 1
     case blue = 2

--- a/Package.swift
+++ b/Package.swift
@@ -553,11 +553,7 @@ private func featuresTargets() -> [[Target]] {
             "AppDependencies",
             "QuranAudioKit",
             "AnnotationsService",
-            "BookmarksFeature",
             "NoorUI",
-        ], testDependencies: [
-            "MobileSyncTestSupport",
-            .product(name: "MobileSync", package: "mobile-sync-spm"),
         ]),
 
         target(type, name: "WhatsNewFeature", hasTests: false, dependencies: [

--- a/UI/NoorUI/Components/HighlightColorPicker.swift
+++ b/UI/NoorUI/Components/HighlightColorPicker.swift
@@ -1,0 +1,133 @@
+//
+//  HighlightColorPicker.swift
+//
+
+import Localization
+import QuranAnnotations
+import SwiftUI
+import UIx
+
+public struct HighlightColorPicker: View {
+    @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+
+    // MARK: Lifecycle
+
+    public init(
+        selectedColor: HighlightColor?,
+        onSelect: @escaping AsyncItemAction<HighlightColor>,
+        onRemove: AsyncAction? = nil
+    ) {
+        self.selectedColor = selectedColor
+        self.onSelect = onSelect
+        self.onRemove = onRemove
+    }
+
+    // MARK: Public
+
+    public var body: some View {
+        GeometryReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: spacing) {
+                    ForEach(HighlightColor.sortedColors, id: \.self) { color in
+                        colorButton(
+                            color: color,
+                            isSelected: selectedColor == color,
+                            accessibilityLabel: color.localizedName
+                        )
+                    }
+
+                    if let onRemove {
+                        HStack(spacing: spacing) {
+                            Capsule()
+                                .fill(Color.separator)
+                                .frame(width: 2, height: dividerHeight)
+                                .accessibilityHidden(true)
+
+                            AsyncButton(action: onRemove) {
+                                Text(lAndroid("remove_button"))
+                                    .font(.subheadline.weight(.medium))
+                                    .foregroundStyle(Color.systemRed)
+                                    .frame(minHeight: minimumTapLength)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel(l("ayah.menu.delete-highlight"))
+                        }
+                        .fixedSize()
+                        .transition(.opacity.combined(with: .move(edge: .trailing)))
+                    }
+                }
+                .frame(minWidth: proxy.size.width, alignment: .center)
+                .animation(
+                    accessibilityReduceMotion ? nil : .easeInOut(duration: 0.2),
+                    value: onRemove != nil
+                )
+            }
+        }
+        .frame(height: minimumTapLength)
+    }
+
+    // MARK: Private
+
+    @ScaledMetric private var circleLength = 36.0
+    @ScaledMetric private var minimumTapLength = 44.0
+    @ScaledMetric private var selectedStrokeWidth = 3.0
+    @ScaledMetric private var dividerHeight = 24.0
+    @ScaledMetric private var spacing = 8.0
+
+    private let selectedColor: HighlightColor?
+    private let onSelect: AsyncItemAction<HighlightColor>
+    private let onRemove: AsyncAction?
+
+    private func colorButton(
+        color: HighlightColor,
+        isSelected: Bool,
+        accessibilityLabel: String
+    ) -> some View {
+        AsyncButton {
+            await onSelect(color)
+        } label: {
+            ZStack {
+                Circle()
+                    .fill(color.color)
+                Circle()
+                    .stroke(Color.separator.opacity(0.55), lineWidth: 1)
+
+                if isSelected {
+                    NoorSystemImage.checkmark.image
+                        .font(.body.weight(.bold))
+                        .foregroundStyle(Color.label.opacity(0.72))
+                }
+
+                if isSelected {
+                    Circle()
+                        .stroke(Color.appIdentity, lineWidth: selectedStrokeWidth)
+                }
+            }
+            .frame(width: circleLength, height: circleLength)
+            .frame(minWidth: minimumTapLength, minHeight: minimumTapLength)
+            .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+struct HighlightColorPicker_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            HighlightColorPicker(
+                selectedColor: .blue,
+                onSelect: { _ in },
+                onRemove: {}
+            )
+            HighlightColorPicker(
+                selectedColor: nil,
+                onSelect: { _ in }
+            )
+            .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
@@ -15,7 +15,7 @@ public enum AyahMenuUI {
         public init(
             play: @escaping AsyncAction,
             repeatVerses: @escaping AsyncAction,
-            highlight: @Sendable @escaping (HighlightColor) async -> Void,
+            bookmark: @escaping AsyncAction,
             addNote: @escaping AsyncAction,
             deleteNote: @escaping AsyncAction,
             showTranslation: @escaping AsyncAction,
@@ -24,7 +24,7 @@ public enum AyahMenuUI {
         ) {
             self.play = play
             self.repeatVerses = repeatVerses
-            self.highlight = highlight
+            self.bookmark = bookmark
             self.addNote = addNote
             self.deleteNote = deleteNote
             self.showTranslation = showTranslation
@@ -36,7 +36,7 @@ public enum AyahMenuUI {
 
         let play: AsyncAction
         let repeatVerses: AsyncAction
-        let highlight: @Sendable (HighlightColor) async -> Void
+        let bookmark: AsyncAction
         let addNote: AsyncAction
         let deleteNote: AsyncAction
         let showTranslation: AsyncAction
@@ -50,6 +50,7 @@ public enum AyahMenuUI {
         public init(
             highlightingColor: HighlightColor,
             state: NoteState,
+            bookmarkTitle: String,
             playSubtitle: String,
             repeatSubtitle: String,
             actions: Actions,
@@ -58,6 +59,7 @@ public enum AyahMenuUI {
         ) {
             self.highlightingColor = highlightingColor
             self.state = state
+            self.bookmarkTitle = bookmarkTitle
             self.playSubtitle = playSubtitle
             self.repeatSubtitle = repeatSubtitle
             self.actions = actions
@@ -70,6 +72,7 @@ public enum AyahMenuUI {
         let highlightingColor: HighlightColor
         let state: NoteState
         let actions: Actions
+        let bookmarkTitle: String
         let playSubtitle: String
         let repeatSubtitle: String
         let isTranslationView: Bool

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
@@ -7,14 +7,8 @@
 //
 
 import Localization
-import QuranAnnotations
 import SwiftUI
 import UIx
-
-private enum MenuState {
-    case list
-    case highlights
-}
 
 public struct AyahMenuView: View {
     // MARK: Lifecycle
@@ -26,49 +20,21 @@ public struct AyahMenuView: View {
     // MARK: Public
 
     public var body: some View {
-        switch state {
-        case .list:
-            ScrollView {
-                AyahMenuViewList(dataObject: dataObject) {
-                    withAnimation {
-                        state = .highlights
-                    }
-                }
-            }
-            .preferredContentSizeMatchesScrollView()
-            .transition(.opacity)
-        case .highlights:
-            ScrollView {
-                NoteCircles(selectedColor: existingHighlightedColor, tapped: dataObject.actions.highlight)
-            }
-            .preferredContentSizeMatchesScrollView()
-            .transition(AnyTransition.scale(scale: 2.0).combined(with: .opacity))
+        ScrollView {
+            AyahMenuViewList(dataObject: dataObject)
         }
+        .preferredContentSizeMatchesScrollView()
     }
 
     // MARK: Internal
 
     let dataObject: AyahMenuUI.DataObject
-
-    // MARK: Private
-
-    @State private var state: MenuState = .list
-
-    private var existingHighlightedColor: HighlightColor? {
-        switch dataObject.state {
-        case .highlighted, .noted:
-            return dataObject.highlightingColor
-        case .noHighlight:
-            return nil
-        }
-    }
 }
 
 private struct AyahMenuViewList: View {
     // MARK: Internal
 
     let dataObject: AyahMenuUI.DataObject
-    let showHighlights: AsyncAction
 
     var noteDeleteText: String {
         switch dataObject.state {
@@ -126,27 +92,8 @@ private struct AyahMenuViewList: View {
 
             MenuGroup {
                 Divider()
-
-                if dataObject.state == .noHighlight {
-                    Row(
-                        title: l("ayah.menu.highlight"),
-                        action: {
-                            Task {
-                                await dataObject.actions.highlight(dataObject.highlightingColor)
-                            }
-                        }
-                    ) {
-                        IconCircle(color: dataObject.highlightingColor)
-                    }
-                    Divider()
-                        .padding(.leading)
-                }
-                Row(
-                    title: l("ayah.menu.highlight"),
-                    subtitle: l("ayah.menu.highlight-select-color"),
-                    action: showHighlights
-                ) {
-                    IconCircles()
+                Row(title: dataObject.bookmarkTitle, action: dataObject.actions.bookmark) {
+                    NoorSystemImage.bookmark.image
                 }
                 Divider()
                     .padding(.leading)
@@ -251,7 +198,7 @@ private struct Row<Symbol: View, Accessory: View>: View {
         AsyncButton(action: action) {
             HStack {
                 ZStack {
-                    IconCircles()
+                    HighlightPaletteIcon()
                         .hidden()
                     symbol
                         .foregroundColor(Color.label)
@@ -295,45 +242,11 @@ private struct MenuGroup<Content: View>: View {
     }
 }
 
-private struct IconCircles: View {
-    var body: some View {
-        HighlightPaletteIcon()
-    }
-}
-
-private struct IconCircle: View {
-    @ScaledMetric var minLength = 20
-
-    var color: HighlightColor
-
-    var body: some View {
-        ColoredCircle(color: color.color, selected: false, minLength: minLength)
-    }
-}
-
-private struct NoteCircles: View {
-    let selectedColor: HighlightColor?
-    let tapped: @Sendable (HighlightColor) async -> Void
-
-    var body: some View {
-        HStack {
-            ForEach(HighlightColor.sortedColors, id: \.self) { color in
-                AsyncButton(
-                    action: { await tapped(color) },
-                    label: { NoteCircle(color: color.color, selected: color == selectedColor) }
-                )
-                .shadow(color: Color.tertiarySystemGroupedBackground, radius: 1)
-            }
-        }
-        .padding()
-    }
-}
-
 struct AyahMenuView_Previews: PreviewProvider {
     static let actions = AyahMenuUI.Actions(
         play: {},
         repeatVerses: {},
-        highlight: { _ in },
+        bookmark: {},
         addNote: {},
         deleteNote: {},
         showTranslation: {},
@@ -348,6 +261,7 @@ struct AyahMenuView_Previews: PreviewProvider {
                 AyahMenuView(dataObject: AyahMenuUI.DataObject(
                     highlightingColor: .green,
                     state: .noted,
+                    bookmarkTitle: "Bookmark Ayah",
                     playSubtitle: "To the end of Juz'",
                     repeatSubtitle: "selected verses",
                     actions: actions,
@@ -362,6 +276,7 @@ struct AyahMenuView_Previews: PreviewProvider {
                 AyahMenuView(dataObject: AyahMenuUI.DataObject(
                     highlightingColor: .red,
                     state: .highlighted,
+                    bookmarkTitle: "Bookmark 3 Ayahs",
                     playSubtitle: "To the end of Juz'",
                     repeatSubtitle: "selected verses",
                     actions: actions,
@@ -377,6 +292,7 @@ struct AyahMenuView_Previews: PreviewProvider {
                 AyahMenuView(dataObject: AyahMenuUI.DataObject(
                     highlightingColor: .green,
                     state: .noHighlight,
+                    bookmarkTitle: "Bookmark Ayah",
                     playSubtitle: "To the end of Juz'",
                     repeatSubtitle: "selected verses",
                     actions: actions,

--- a/UI/NoorUI/Images/NoorSystemImage.swift
+++ b/UI/NoorUI/Images/NoorSystemImage.swift
@@ -19,6 +19,7 @@ public enum NoorSystemImage: String {
     case mail = "envelope"
     case checkmark_checked = "checkmark.circle.fill"
     case checkmark_unchecked = "circle"
+    case checkmark_indeterminate = "minus.circle.fill"
     case checkmark
     case bookmark = "bookmark.fill"
     case book


### PR DESCRIPTION
## Summary

- replace the ayah long-press highlight actions with a bookmark entry point
- add a bookmark sheet for highlights and collection membership across one or multiple ayahs, including ranges spanning suras
- apply highlight and collection changes immediately without waiting for Done
- add a reusable NoorUI highlight picker with an inline animated Remove action
- reuse collection presentation patterns, including Favorites, old page bookmarks, custom collections, and collection creation

## Why

Highlighting and collection membership were split across separate menu actions. This consolidates them into one bookmark workflow while keeping every selection immediately persisted and visible.

## Validation

- `make format-lint`
- `make test-sync DERIVED_DATA_DIR=/tmp/quran-ios-bookmark-sheet-post-rebase` — 362 passed
- `make test-no-sync DERIVED_DATA_DIR=/tmp/quran-ios-bookmark-sheet-post-rebase` — 296 passed
- simulator verification on iPhone 17 Pro: Remove appears for selected or mixed highlights and disappears immediately after highlight removal


## Screenshots

<img width="306" alt="image" src="https://github.com/user-attachments/assets/58d483f9-fd18-4162-92dd-137036862987" />

<img width="306"  alt="image" src="https://github.com/user-attachments/assets/c83882f8-bc37-4bdc-937d-9cb4c33d87a3" />
