### PR TITLE
Use outlined folder for bookmark collections

### DIFF
--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollection+Presentation.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollection+Presentation.swift
@@ -27,7 +27,7 @@ extension AyahBookmarkCollection {
         case .colored:
             .bookmark
         case .user:
-            .folder
+            .folderOutline
         }
     }
 
@@ -38,7 +38,7 @@ extension AyahBookmarkCollection {
         case .oldPageBookmarks:
             .secondaryLabel
         case .colored, .user:
-            .appIdentity
+            .label
         }
     }
 }


### PR DESCRIPTION
## Summary

- use the outlined folder icon for user-created bookmark collections
- render user and colored bookmark collection icons with the semantic label color

## Why

This keeps collection presentation consistent with the existing collections screen and avoids the heavier filled folder treatment.

## Validation

- `make format-lint`
- `git diff --cached --check`

The full sync and no-sync test suites were started locally, then stopped before completion at the user's request; CI will provide the complete test result.

# Screenshots

<img width="368" alt="Screenshot 2026-07-18 at 2 56 49 PM" src="https://github.com/user-attachments/assets/4092a8d8-f8d6-4bbe-8e24-a4c58c472091" />
