### PR TITLE
Indicate partially highlighted ayahs

### DIFF
--- a/Features/BookmarksFeature/Sources/BookmarkAyahsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsView.swift
@@ -18,6 +18,7 @@ struct BookmarkAyahsView: View {
                 #if QURAN_SYNC
                 HighlightColorPicker(
                     selectedColor: viewModel.selectedHighlightColor,
+                    partiallySelectedColors: viewModel.partiallySelectedHighlightColors,
                     onSelect: { await viewModel.selectHighlight($0) },
                     onRemove: viewModel.highlightSelection == .none
                         ? nil

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsViewModel.swift
@@ -16,7 +16,7 @@ import VLogging
 final class BookmarkAyahsViewModel: ObservableObject {
     enum HighlightSelection: Equatable {
         case none
-        case mixed
+        case mixed(Set<HighlightColor>)
         case color(HighlightColor)
     }
 
@@ -62,6 +62,13 @@ final class BookmarkAyahsViewModel: ObservableObject {
             return nil
         }
         return color
+    }
+
+    var partiallySelectedHighlightColors: Set<HighlightColor> {
+        guard case .mixed(let colors) = highlightSelection else {
+            return []
+        }
+        return colors
     }
 
     func start() async {
@@ -205,7 +212,7 @@ final class BookmarkAyahsViewModel: ObservableObject {
             return .none
         }
         guard colors.dropFirst().allSatisfy({ $0 == firstColor }) else {
-            return .mixed
+            return .mixed(Set(colors.compactMap { $0 }))
         }
         if let firstColor {
             return .color(firstColor)

--- a/Features/BookmarksFeature/Tests/BookmarkAyahsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkAyahsViewModelTests.swift
@@ -80,13 +80,27 @@ final class BookmarkAyahsViewModelTests: XCTestCase {
             collections: try await mappedCollections(),
             ayahBookmarkCollectionService: fixture.service
         )
-        XCTAssertEqual(sut.highlightSelection, .mixed)
+        XCTAssertEqual(sut.highlightSelection, .mixed([.red]))
+        XCTAssertEqual(sut.partiallySelectedHighlightColors, [.red])
 
         await sut.selectHighlight(nil)
 
         let stored = try await storedCollections()
         XCTAssertEqual(bookmarkedAyahs(in: stored, named: HighlightColor.red.collectionName), [])
         XCTAssertEqual(sut.highlightSelection, .none)
+    }
+
+    func test_mixedHighlightSelectionExposesEveryPartiallySelectedColor() async throws {
+        let fixture = try await makeFixture()
+        try await fixture.service.setHighlight(.green, for: [verses[1]])
+        let sut = BookmarkAyahsViewModel(
+            verses: verses,
+            collections: try await mappedCollections(),
+            ayahBookmarkCollectionService: fixture.service
+        )
+
+        XCTAssertEqual(sut.highlightSelection, .mixed([.red, .green]))
+        XCTAssertEqual(sut.partiallySelectedHighlightColors, [.red, .green])
     }
 
     private var verses: [AyahNumber] {

--- a/UI/NoorUI/Components/HighlightColorPicker.swift
+++ b/UI/NoorUI/Components/HighlightColorPicker.swift
@@ -14,10 +14,12 @@ public struct HighlightColorPicker: View {
 
     public init(
         selectedColor: HighlightColor?,
+        partiallySelectedColors: Set<HighlightColor> = [],
         onSelect: @escaping AsyncItemAction<HighlightColor>,
         onRemove: AsyncAction? = nil
     ) {
         self.selectedColor = selectedColor
+        self.partiallySelectedColors = partiallySelectedColors
         self.onSelect = onSelect
         self.onRemove = onRemove
     }
@@ -32,6 +34,7 @@ public struct HighlightColorPicker: View {
                         colorButton(
                             color: color,
                             isSelected: selectedColor == color,
+                            isPartiallySelected: partiallySelectedColors.contains(color),
                             accessibilityLabel: color.localizedName
                         )
                     }
@@ -75,12 +78,14 @@ public struct HighlightColorPicker: View {
     @ScaledMetric private var spacing = 8.0
 
     private let selectedColor: HighlightColor?
+    private let partiallySelectedColors: Set<HighlightColor>
     private let onSelect: AsyncItemAction<HighlightColor>
     private let onRemove: AsyncAction?
 
     private func colorButton(
         color: HighlightColor,
         isSelected: Bool,
+        isPartiallySelected: Bool,
         accessibilityLabel: String
     ) -> some View {
         AsyncButton {
@@ -95,12 +100,22 @@ public struct HighlightColorPicker: View {
                 if isSelected {
                     NoorSystemImage.checkmark.image
                         .font(.body.weight(.bold))
-                        .foregroundStyle(Color.label.opacity(0.72))
+                        .foregroundStyle(selectionColor)
                 }
 
                 if isSelected {
                     Circle()
-                        .stroke(Color.appIdentity, lineWidth: selectedStrokeWidth)
+                        .stroke(selectionColor, lineWidth: selectedStrokeWidth)
+                } else if isPartiallySelected {
+                    Circle()
+                        .strokeBorder(
+                            selectionColor,
+                            style: StrokeStyle(
+                                lineWidth: selectedStrokeWidth,
+                                lineCap: .round,
+                                dash: [selectedStrokeWidth * 1.5]
+                            )
+                        )
                 }
             }
             .frame(width: circleLength, height: circleLength)
@@ -109,7 +124,11 @@ public struct HighlightColorPicker: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(accessibilityLabel)
-        .accessibilityAddTraits(isSelected ? .isSelected : [])
+        .accessibilityAddTraits(isSelected || isPartiallySelected ? .isSelected : [])
+    }
+
+    private var selectionColor: Color {
+        Color.label.opacity(0.72)
     }
 }
 
@@ -118,6 +137,7 @@ struct HighlightColorPicker_Previews: PreviewProvider {
         Group {
             HighlightColorPicker(
                 selectedColor: .blue,
+                partiallySelectedColors: [.red, .green],
                 onSelect: { _ in },
                 onRemove: {}
             )


### PR DESCRIPTION
## What changed

- preserve every highlight color represented in a mixed ayah selection
- show those partially selected colors with a centered dashed border
- keep the solid border for a fully selected color
- add regression coverage for selections containing multiple highlight colors

## Why

A multi-ayah selection can contain more than one existing highlight color. Previously the bookmark sheet only reported a generic mixed state, so users could not see which colors were already applied.

## Validation

- dark-mode simulator verification with five selected ayahs and two partial colors
- `make format-lint`
- `make build-sync TARGET=NoorUI`
- `make build-no-sync TARGET=NoorUI`
- full sync/no-sync tests passed before the final visual-only centered-stroke adjustment
- post-rebase full test rerun attempted; both builds stopped because the local volume had no free space (`No space left on device`), not because of a source failure


## Screenshots

<img width="306" alt="simulator_screenshot_E7E7F5A1-C5E3-4CBC-B866-3953C5BCC49E" src="https://github.com/user-attachments/assets/f256e939-867b-4c7d-ac63-48102dc4cb24" />

<img width="306" alt="simulator_screenshot_4059CA0E-0A74-41E7-8730-3D051A60E1CE" src="https://github.com/user-attachments/assets/4e76767b-0830-47ed-8bd3-de20dca7fcaf" />


<img width="306" alt="simulator_screenshot_ABA12174-E821-4E15-BD81-D7D8733802C5" src="https://github.com/user-attachments/assets/5dd3bbf9-8bb9-40f1-8dc7-d1060e635c5d" />