### PR TITLE
Reflect ayah highlight state in save menu

### DIFF
--- a/Core/Localization/Resources/ar.lproj/Localizable.stringsdict
+++ b/Core/Localization/Resources/ar.lproj/Localizable.stringsdict
@@ -37,17 +37,17 @@
             <key>NSStringFormatValueTypeKey</key>
             <string>d</string>
             <key>zero</key>
-            <string>إضافة إشارات مرجعية للآيات</string>
+            <string>حفظ الآيات...</string>
             <key>one</key>
-            <string>إضافة إشارة مرجعية لآية</string>
+            <string>حفظ آية...</string>
             <key>two</key>
-            <string>إضافة إشارة مرجعية لآيتين</string>
+            <string>حفظ آيتين...</string>
             <key>few</key>
-            <string>إضافة إشارات مرجعية إلى %d آيات</string>
+            <string>حفظ الآيات...</string>
             <key>many</key>
-            <string>إضافة إشارات مرجعية إلى %d آية</string>
+            <string>حفظ الآيات...</string>
             <key>other</key>
-            <string>إضافة إشارات مرجعية إلى %d آية</string>
+            <string>حفظ الآيات...</string>
         </dict>
     </dict>
 </dict>

--- a/Core/Localization/Resources/en.lproj/Localizable.stringsdict
+++ b/Core/Localization/Resources/en.lproj/Localizable.stringsdict
@@ -29,9 +29,9 @@
             <key>NSStringFormatValueTypeKey</key>
             <string>d</string>
             <key>one</key>
-            <string>Bookmark Ayah</string>
+            <string>Save Ayah...</string>
             <key>other</key>
-            <string>Bookmark %d Ayahs</string>
+            <string>Save Ayahs...</string>
         </dict>
     </dict>
 </dict>

--- a/Features/AyahMenuFeature/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/AyahMenuBuilder.swift
@@ -19,12 +19,14 @@ public struct AyahMenuInput {
         sourceView: UIView,
         pointInView: CGPoint,
         verses: [AyahNumber],
-        notes: [QuranAnnotations.Note]
+        notes: [QuranAnnotations.Note],
+        highlightVerses: [AyahNumber: HighlightColor] = [:]
     ) {
         self.sourceView = sourceView
         self.pointInView = pointInView
         self.verses = verses
         self.notes = notes
+        self.highlightVerses = highlightVerses
     }
 
     // MARK: Internal
@@ -33,6 +35,7 @@ public struct AyahMenuInput {
     let pointInView: CGPoint
     let verses: [AyahNumber]
     let notes: [QuranAnnotations.Note]
+    let highlightVerses: [AyahNumber: HighlightColor]
 }
 
 @MainActor
@@ -56,7 +59,8 @@ public struct AyahMenuBuilder {
             pointInView: input.pointInView,
             verses: input.verses,
             textRetriever: textRetriever,
-            notes: input.notes
+            notes: input.notes,
+            highlightVerses: input.highlightVerses
         )
         #else
         let deps = AyahMenuViewModel.Deps(
@@ -65,6 +69,7 @@ public struct AyahMenuBuilder {
             verses: input.verses,
             textRetriever: textRetriever,
             notes: input.notes,
+            highlightVerses: input.highlightVerses,
             noteService: container.noteService()
         )
         #endif

--- a/Features/AyahMenuFeature/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewController.swift
@@ -50,6 +50,7 @@ final class AyahMenuViewController: UIViewController {
             highlightingColor: highlightingColor,
             state: viewModel.noteState,
             bookmarkTitle: viewModel.bookmarkTitle,
+            bookmarkState: viewModel.bookmarkState,
             playSubtitle: viewModel.playSubtitle,
             repeatSubtitle: viewModel.repeatSubtitle,
             actions: actions,

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -41,6 +41,7 @@ final class AyahMenuViewModel {
         let verses: [AyahNumber]
         let textRetriever: ShareableVerseTextRetriever
         let notes: [QuranAnnotations.Note]
+        let highlightVerses: [AyahNumber: HighlightColor]
         #if !QURAN_SYNC
         let noteService: NoteService
         #endif
@@ -83,6 +84,17 @@ final class AyahMenuViewModel {
 
     var bookmarkTitle: String {
         lFormat("bookmarks.editor.title", deps.verses.count)
+    }
+
+    var bookmarkState: AyahMenuUI.BookmarkState {
+        let colors = deps.verses.compactMap { deps.highlightVerses[$0] }
+        guard !colors.isEmpty else {
+            return .unhighlighted
+        }
+        guard colors.count == deps.verses.count, Set(colors).count == 1, let color = colors.first else {
+            return .partiallyHighlighted
+        }
+        return .highlighted(color)
     }
 
     var repeatSubtitle: String {

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -1,4 +1,5 @@
 #if QURAN_SYNC
+import Localization
 import QuranAnnotations
 import QuranKit
 import QuranTextKit
@@ -8,13 +9,57 @@ import XCTest
 
 @MainActor
 final class AyahMenuViewModelTests: XCTestCase {
-    func test_bookmark_requestsEditorForCrossSuraSelection() throws {
-        let verses = [
-            try XCTUnwrap(AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 7)),
-            try XCTUnwrap(AyahNumber(quran: .hafsMadani1405, sura: 2, ayah: 1)),
+    func test_bookmark_requestsEditorForCrossSuraSelection() {
+        let sut = makeSUT()
+        let listener = BookmarkListenerSpy()
+        sut.listener = listener
+
+        sut.bookmark()
+
+        XCTAssertEqual(listener.bookmarkedVerses, verses)
+    }
+
+    func test_bookmarkState_isUnhighlightedWhenNoSelectedAyahIsHighlighted() {
+        let sut = makeSUT()
+
+        XCTAssertEqual(sut.bookmarkState, .unhighlighted)
+    }
+
+    func test_bookmarkState_usesHighlightColorWhenEverySelectedAyahHasTheSameColor() {
+        let sut = makeSUT(highlightVerses: Dictionary(uniqueKeysWithValues: verses.map { ($0, .green) }))
+
+        XCTAssertEqual(sut.bookmarkState, .highlighted(.green))
+    }
+
+    func test_bookmarkState_isPartialWhenOnlySomeSelectedAyahsAreHighlighted() {
+        let sut = makeSUT(highlightVerses: [verses[0]: .red])
+
+        XCTAssertEqual(sut.bookmarkState, .partiallyHighlighted)
+    }
+
+    func test_bookmarkState_isPartialWhenSelectedAyahsHaveDifferentHighlightColors() {
+        let sut = makeSUT(highlightVerses: [verses[0]: .red, verses[1]: .green])
+
+        XCTAssertEqual(sut.bookmarkState, .partiallyHighlighted)
+    }
+
+    func test_bookmarkTitle_usesSaveAyahSingularAndPluralCopy() {
+        XCTAssertEqual(lFormat("bookmarks.editor.title", language: .english, 1), "Save Ayah...")
+        XCTAssertEqual(lFormat("bookmarks.editor.title", language: .english, 2), "Save Ayahs...")
+    }
+
+    private var verses: [AyahNumber] {
+        [
+            AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 7)!,
+            AyahNumber(quran: .hafsMadani1405, sura: 2, ayah: 1)!,
         ]
+    }
+
+    private func makeSUT(
+        highlightVerses: [AyahNumber: HighlightColor] = [:]
+    ) -> AyahMenuViewModel {
         let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-quran-database")
-        let sut = AyahMenuViewModel(deps: .init(
+        return AyahMenuViewModel(deps: .init(
             sourceView: UIView(),
             pointInView: .zero,
             verses: verses,
@@ -22,14 +67,9 @@ final class AyahMenuViewModelTests: XCTestCase {
                 databasesURL: unavailableDatabase,
                 quranFileURL: unavailableDatabase
             ),
-            notes: []
+            notes: [],
+            highlightVerses: highlightVerses
         ))
-        let listener = BookmarkListenerSpy()
-        sut.listener = listener
-
-        sut.bookmark()
-
-        XCTAssertEqual(listener.bookmarkedVerses, verses)
     }
 }
 

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -301,11 +301,17 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
     func presentAyahMenu(in sourceView: UIView, at point: CGPoint, verses: [AyahNumber]) {
         logger.info("Quran: present ayah menu, verses: \(verses)")
+        #if QURAN_SYNC
+        let highlightVerses = deps.highlightsService.highlights.highlightVerses
+        #else
+        let highlightVerses = deps.highlightsService.highlights.noteVerses.mapValues(\.color)
+        #endif
         let input = AyahMenuInput(
             sourceView: sourceView,
             pointInView: point,
             verses: verses,
-            notes: notesInteractingVerses(verses)
+            notes: notesInteractingVerses(verses),
+            highlightVerses: highlightVerses
         )
         let ayahMenuViewController = deps.ayahMenuBuilder.build(withListener: self, input: input)
         presenter?.presentAyahMenu(ayahMenuViewController, in: sourceView, at: point)

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
@@ -51,6 +51,7 @@ public enum AyahMenuUI {
             highlightingColor: HighlightColor,
             state: NoteState,
             bookmarkTitle: String,
+            bookmarkState: BookmarkState = .unhighlighted,
             playSubtitle: String,
             repeatSubtitle: String,
             actions: Actions,
@@ -60,6 +61,7 @@ public enum AyahMenuUI {
             self.highlightingColor = highlightingColor
             self.state = state
             self.bookmarkTitle = bookmarkTitle
+            self.bookmarkState = bookmarkState
             self.playSubtitle = playSubtitle
             self.repeatSubtitle = repeatSubtitle
             self.actions = actions
@@ -73,6 +75,7 @@ public enum AyahMenuUI {
         let state: NoteState
         let actions: Actions
         let bookmarkTitle: String
+        let bookmarkState: BookmarkState
         let playSubtitle: String
         let repeatSubtitle: String
         let isTranslationView: Bool
@@ -85,5 +88,11 @@ public enum AyahMenuUI {
         case noHighlight
         case highlighted
         case noted
+    }
+
+    public enum BookmarkState: Equatable {
+        case unhighlighted
+        case partiallyHighlighted
+        case highlighted(HighlightColor)
     }
 }

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
@@ -93,7 +93,7 @@ private struct AyahMenuViewList: View {
             MenuGroup {
                 Divider()
                 Row(title: dataObject.bookmarkTitle, action: dataObject.actions.bookmark) {
-                    NoorSystemImage.bookmark.image
+                    bookmarkIcon
                 }
                 Divider()
                     .padding(.leading)
@@ -139,6 +139,18 @@ private struct AyahMenuViewList: View {
     }
 
     // MARK: Private
+
+    @ViewBuilder private var bookmarkIcon: some View {
+        switch dataObject.bookmarkState {
+        case .unhighlighted:
+            NoorSystemImage.bookmarkOutline.image
+        case .partiallyHighlighted:
+            NoorSystemImage.bookmark.image
+        case .highlighted(let color):
+            NoorSystemImage.bookmark.image
+                .foregroundColor(color.color)
+        }
+    }
 
     private func noteIcon(legacySystemName: String) -> some View {
         Group {
@@ -261,7 +273,8 @@ struct AyahMenuView_Previews: PreviewProvider {
                 AyahMenuView(dataObject: AyahMenuUI.DataObject(
                     highlightingColor: .green,
                     state: .noted,
-                    bookmarkTitle: "Bookmark Ayah",
+                    bookmarkTitle: "Save Ayah...",
+                    bookmarkState: .highlighted(.green),
                     playSubtitle: "To the end of Juz'",
                     repeatSubtitle: "selected verses",
                     actions: actions,
@@ -276,7 +289,8 @@ struct AyahMenuView_Previews: PreviewProvider {
                 AyahMenuView(dataObject: AyahMenuUI.DataObject(
                     highlightingColor: .red,
                     state: .highlighted,
-                    bookmarkTitle: "Bookmark 3 Ayahs",
+                    bookmarkTitle: "Save Ayahs...",
+                    bookmarkState: .partiallyHighlighted,
                     playSubtitle: "To the end of Juz'",
                     repeatSubtitle: "selected verses",
                     actions: actions,
@@ -292,7 +306,8 @@ struct AyahMenuView_Previews: PreviewProvider {
                 AyahMenuView(dataObject: AyahMenuUI.DataObject(
                     highlightingColor: .green,
                     state: .noHighlight,
-                    bookmarkTitle: "Bookmark Ayah",
+                    bookmarkTitle: "Save Ayah...",
+                    bookmarkState: .unhighlighted,
                     playSubtitle: "To the end of Juz'",
                     repeatSubtitle: "selected verses",
                     actions: actions,

--- a/UI/NoorUI/Images/NoorSystemImage.swift
+++ b/UI/NoorUI/Images/NoorSystemImage.swift
@@ -21,6 +21,7 @@ public enum NoorSystemImage: String {
     case checkmark_unchecked = "circle"
     case checkmark_indeterminate = "minus.circle.fill"
     case checkmark
+    case bookmarkOutline = "bookmark"
     case bookmark = "bookmark.fill"
     case book
     case folder = "folder.fill"


### PR DESCRIPTION
## What changed

- rename the Ayah bookmark action and editor title to “Save Ayah...” / “Save Ayahs...”
- show an outline bookmark when the selection has no highlights
- show a filled bookmark tinted with the shared highlight color when all selected ayahs use one color
- show a neutral filled bookmark for partial or mixed-color selections
- add regression coverage for every icon state and localized copy

## Why

The menu always showed a filled bookmark and used “Bookmark” copy, so it did not communicate whether the selected ayahs were unhighlighted, consistently highlighted, or partially highlighted.

## Impact

The menu now matches the highlight state already rendered on the Quran page, and the sheet uses the same Save Ayah wording.

## Validation

- `make format-lint`
- `make test-sync`
- `make test-no-sync`


## Screenshots

<img width="306" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-18 at 17 02 57" src="https://github.com/user-attachments/assets/85ad511a-c5ac-40f4-a116-773a65560dc0" />
<img width="306" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-18 at 17 03 13" src="https://github.com/user-attachments/assets/2ae444c1-a050-4272-9be6-fe22f77a4e61" />
<img width="306" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-18 at 17 03 22" src="https://github.com/user-attachments/assets/81d8947c-eebc-4bc7-a803-99e3c32e08e5" />
