### PR TITLE
Fill bookmark icon for Ayahs saved in collections

### DIFF
--- a/Features/AyahMenuFeature/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/AyahMenuBuilder.swift
@@ -20,13 +20,15 @@ public struct AyahMenuInput {
         pointInView: CGPoint,
         verses: [AyahNumber],
         notes: [QuranAnnotations.Note],
-        highlightVerses: [AyahNumber: HighlightColor] = [:]
+        highlightVerses: [AyahNumber: HighlightColor] = [:],
+        bookmarkedVerses: Set<AyahNumber> = []
     ) {
         self.sourceView = sourceView
         self.pointInView = pointInView
         self.verses = verses
         self.notes = notes
         self.highlightVerses = highlightVerses
+        self.bookmarkedVerses = bookmarkedVerses
     }
 
     // MARK: Internal
@@ -36,6 +38,7 @@ public struct AyahMenuInput {
     let verses: [AyahNumber]
     let notes: [QuranAnnotations.Note]
     let highlightVerses: [AyahNumber: HighlightColor]
+    let bookmarkedVerses: Set<AyahNumber>
 }
 
 @MainActor
@@ -60,7 +63,8 @@ public struct AyahMenuBuilder {
             verses: input.verses,
             textRetriever: textRetriever,
             notes: input.notes,
-            highlightVerses: input.highlightVerses
+            highlightVerses: input.highlightVerses,
+            bookmarkedVerses: input.bookmarkedVerses
         )
         #else
         let deps = AyahMenuViewModel.Deps(
@@ -70,6 +74,7 @@ public struct AyahMenuBuilder {
             textRetriever: textRetriever,
             notes: input.notes,
             highlightVerses: input.highlightVerses,
+            bookmarkedVerses: input.bookmarkedVerses,
             noteService: container.noteService()
         )
         #endif

--- a/Features/AyahMenuFeature/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/AyahMenuViewModel.swift
@@ -42,6 +42,7 @@ final class AyahMenuViewModel {
         let textRetriever: ShareableVerseTextRetriever
         let notes: [QuranAnnotations.Note]
         let highlightVerses: [AyahNumber: HighlightColor]
+        let bookmarkedVerses: Set<AyahNumber>
         #if !QURAN_SYNC
         let noteService: NoteService
         #endif
@@ -89,7 +90,8 @@ final class AyahMenuViewModel {
     var bookmarkState: AyahMenuUI.BookmarkState {
         let colors = deps.verses.compactMap { deps.highlightVerses[$0] }
         guard !colors.isEmpty else {
-            return .unhighlighted
+            let selectedVerses = Set(deps.verses)
+            return selectedVerses.isDisjoint(with: deps.bookmarkedVerses) ? .unhighlighted : .bookmarked
         }
         guard colors.count == deps.verses.count, Set(colors).count == 1, let color = colors.first else {
             return .partiallyHighlighted

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -25,6 +25,19 @@ final class AyahMenuViewModelTests: XCTestCase {
         XCTAssertEqual(sut.bookmarkState, .unhighlighted)
     }
 
+    func test_bookmarkState_isBookmarkedWhenAnySelectedAyahBelongsToACollection() {
+        let sut = makeSUT(bookmarkedVerses: [verses[0]])
+
+        XCTAssertEqual(sut.bookmarkState, .bookmarked)
+    }
+
+    func test_bookmarkState_isUnhighlightedWhenOnlyUnselectedAyahsBelongToACollection() {
+        let otherVerse = AyahNumber(quran: .hafsMadani1405, sura: 2, ayah: 2)!
+        let sut = makeSUT(bookmarkedVerses: [otherVerse])
+
+        XCTAssertEqual(sut.bookmarkState, .unhighlighted)
+    }
+
     func test_bookmarkState_usesHighlightColorWhenEverySelectedAyahHasTheSameColor() {
         let sut = makeSUT(highlightVerses: Dictionary(uniqueKeysWithValues: verses.map { ($0, .green) }))
 
@@ -56,7 +69,8 @@ final class AyahMenuViewModelTests: XCTestCase {
     }
 
     private func makeSUT(
-        highlightVerses: [AyahNumber: HighlightColor] = [:]
+        highlightVerses: [AyahNumber: HighlightColor] = [:],
+        bookmarkedVerses: Set<AyahNumber> = []
     ) -> AyahMenuViewModel {
         let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-quran-database")
         return AyahMenuViewModel(deps: .init(
@@ -68,7 +82,8 @@ final class AyahMenuViewModelTests: XCTestCase {
                 quranFileURL: unavailableDatabase
             ),
             notes: [],
-            highlightVerses: highlightVerses
+            highlightVerses: highlightVerses,
+            bookmarkedVerses: bookmarkedVerses
         ))
     }
 }

--- a/Features/QuranViewFeature/QuranInteractor.swift
+++ b/Features/QuranViewFeature/QuranInteractor.swift
@@ -303,15 +303,20 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         logger.info("Quran: present ayah menu, verses: \(verses)")
         #if QURAN_SYNC
         let highlightVerses = deps.highlightsService.highlights.highlightVerses
+        let bookmarkedVerses = Set(deps.syncedHighlightsObserver.collections.flatMap { collection in
+            collection.bookmarks.map(\.ayah)
+        })
         #else
         let highlightVerses = deps.highlightsService.highlights.noteVerses.mapValues(\.color)
+        let bookmarkedVerses: Set<AyahNumber> = []
         #endif
         let input = AyahMenuInput(
             sourceView: sourceView,
             pointInView: point,
             verses: verses,
             notes: notesInteractingVerses(verses),
-            highlightVerses: highlightVerses
+            highlightVerses: highlightVerses,
+            bookmarkedVerses: bookmarkedVerses
         )
         let ayahMenuViewController = deps.ayahMenuBuilder.build(withListener: self, input: input)
         presenter?.presentAyahMenu(ayahMenuViewController, in: sourceView, at: point)

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuUI.swift
@@ -92,6 +92,7 @@ public enum AyahMenuUI {
 
     public enum BookmarkState: Equatable {
         case unhighlighted
+        case bookmarked
         case partiallyHighlighted
         case highlighted(HighlightColor)
     }

--- a/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Features/AyahMenu/AyahMenuView.swift
@@ -144,7 +144,7 @@ private struct AyahMenuViewList: View {
         switch dataObject.bookmarkState {
         case .unhighlighted:
             NoorSystemImage.bookmarkOutline.image
-        case .partiallyHighlighted:
+        case .bookmarked, .partiallyHighlighted:
             NoorSystemImage.bookmark.image
         case .highlighted(let color):
             NoorSystemImage.bookmark.image


### PR DESCRIPTION
## What changed

- pass synced collection membership into the Ayah menu
- show a neutral filled bookmark when any selected Ayah belongs to a collection
- preserve the colored filled icon when every selected Ayah shares one highlight color
- preserve neutral filled behavior for partial or mixed highlights
- add regression coverage for matching and unrelated collection membership

## Why

The menu previously considered highlight collections only. Ayahs saved in regular collections still showed an outline bookmark, incorrectly suggesting they were unsaved.

## Impact

The bookmark icon now reflects any collection membership across the current selection without changing highlight color behavior.

## Validation

- `make format-lint`
- Ayah menu tests: 8 passed
- `make build-sync TARGET=QuranViewFeature`
- `make build-no-sync TARGET=QuranViewFeature`