### PR TITLE
build: support targeted package tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ The Makefile exposes explicit targets for each sync mode:
 - sync enabled: `make build-sync`, `make test-sync`, `make build-example-sync`, `make run-example-sync`
 - SwiftFormat: `make format-lint`
 
-Package build and test targets honor `TARGET` to select another scheme or target, such as `make build-no-sync TARGET=NoorUI`. Ambient `QURAN_SYNC` may be set or unset through `launchctl`, so always use an explicit sync-mode target.
+Package build targets honor `TARGET` as a scheme override, such as `make build-no-sync TARGET=NoorUI`. Package test targets always use the `QuranEngine-Package` scheme. Omit `TARGET` to run its full test plan, or set a production or test target to filter the run, such as `make test-sync TARGET=AyahMenuFeature` or `make test-sync TARGET=AyahMenuFeatureTests`. Keep every package test target in `QuranEngine-Package.xctestplan`. Ambient `QURAN_SYNC` may be set or unset through `launchctl`, so always use an explicit sync-mode target.
 
 Keeping these commands green locally should keep the CI workflow green as well.
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ SWIFT_FORMAT_DIR=$(BUILD_TOOLS_DIR)/SwiftFormat
 SWIFT_FORMAT_BIN=$(SWIFT_FORMAT_DIR)/.build/release/swiftformat
 SWIFT_FORMAT_VERSION_FILE=$(abspath $(SWIFT_FORMAT_DIR))/.swiftformat-version
 
-CURRENT_TARGET=$(if $(TARGET),$(TARGET),$(PACKAGE_SCHEME))
+BUILD_SCHEME=$(if $(TARGET),$(TARGET),$(PACKAGE_SCHEME))
+TEST_TARGET=$(if $(TARGET),$(if $(filter %Tests,$(TARGET)),$(TARGET),$(TARGET)Tests))
+TEST_FILTER=$(if $(TEST_TARGET),-only-testing:$(TEST_TARGET))
 WITHOUT_QURAN_SYNC=set -o pipefail; env QURAN_SYNC=
 WITH_QURAN_SYNC=set -o pipefail; env QURAN_SYNC=QURAN_SYNC
 WITHOUT_QURAN_SYNC_DERIVED_DATA=$(DERIVED_DATA_DIR)/no-sync
@@ -54,16 +56,16 @@ endef
 .PHONY: install-swiftlint build-for-analyzer swiftlint-analyzer
 
 test-no-sync:
-	$(WITHOUT_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITHOUT_QURAN_SYNC_DERIVED_DATA)" build test -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
+	$(WITHOUT_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITHOUT_QURAN_SYNC_DERIVED_DATA)" build test -scheme "$(PACKAGE_SCHEME)" $(TEST_FILTER) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
 
 test-sync:
-	$(WITH_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_QURAN_SYNC_DERIVED_DATA)" build test -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
+	$(WITH_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_QURAN_SYNC_DERIVED_DATA)" build test -scheme "$(PACKAGE_SCHEME)" $(TEST_FILTER) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
 
 build-no-sync:
-	$(WITHOUT_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITHOUT_QURAN_SYNC_DERIVED_DATA)" build -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
+	$(WITHOUT_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITHOUT_QURAN_SYNC_DERIVED_DATA)" build -scheme "$(BUILD_SCHEME)" -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
 
 build-sync:
-	$(WITH_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_QURAN_SYNC_DERIVED_DATA)" build -scheme $(CURRENT_TARGET) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
+	$(WITH_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_QURAN_SYNC_DERIVED_DATA)" build -scheme "$(BUILD_SCHEME)" -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
 
 build-example-no-sync:
 	$(WITHOUT_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITHOUT_QURAN_SYNC_DERIVED_DATA)" build -project $(EXAMPLE_PROJECT) -scheme $(EXAMPLE_SCHEME) -sdk "$(EXAMPLE_SDK)" -destination "$(EXAMPLE_DESTINATION)" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO 2>&1 | xcbeautify --renderer github-actions

--- a/QuranEngine-Package.xctestplan
+++ b/QuranEngine-Package.xctestplan
@@ -164,6 +164,76 @@
         "identifier" : "AppMigratorTests",
         "name" : "AppMigratorTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "AdvancedAudioOptionsFeatureTests",
+        "name" : "AdvancedAudioOptionsFeatureTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "AuthenticationClientTests",
+        "name" : "AuthenticationClientTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "AyahMenuFeatureTests",
+        "name" : "AyahMenuFeatureTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "BookmarksFeatureTests",
+        "name" : "BookmarksFeatureTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "LinePagePersistenceTests",
+        "name" : "LinePagePersistenceTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "NoteEditorFeatureTests",
+        "name" : "NoteEditorFeatureTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "NotesFeatureTests",
+        "name" : "NotesFeatureTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "QuranViewFeatureTests",
+        "name" : "QuranViewFeatureTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "SettingsFeatureTests",
+        "name" : "SettingsFeatureTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "SyncedPageBookmarkPersistenceTests",
+        "name" : "SyncedPageBookmarkPersistenceTests"
+      }
     }
   ],
   "version" : 1

--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ Then use one or more of the available targets as dependency. All targets are ava
 
 > :warning: Please note that we do not support CocoaPods or Carthage, and we do not plan to support these in the future.
 
+## Building and Testing
+
+Use the Makefile targets so `QURAN_SYNC` is always set explicitly:
+
+```sh
+# Build the package, or one scheme
+make build-no-sync
+make build-sync TARGET=NoorUI
+
+# Run the complete package test plan
+make test-no-sync
+make test-sync
+
+# Run one test target through the package test scheme
+make test-no-sync TARGET=AyahMenuFeature
+make test-sync TARGET=AyahMenuFeatureTests
+```
+
+For test commands, `TARGET` accepts either the production target or its `Tests` target. Both focused examples above select `AyahMenuFeatureTests`. New test targets must also be added to `QuranEngine-Package.xctestplan`.
+
 ## Repository Structure and Architecture
 
 The library consists of 6 top-level directories:
@@ -42,7 +62,7 @@ The library consists of 6 top-level directories:
 
 * **Features**: Comprises the screens making up the app. They rely on all other components to create our Quran apps. Features can encompass other features to create higher-level features. For example, `AppStructureFeature` hosts all other features to create the app.
 
-> :warning: UI and Features do not yet contain tests, and makes up around 50% of the source code. We are keen on adding tests to them in the future inshaa'Allah.
+> :warning: UI and Features still have less test coverage than the foundational layers. New behavior should include focused tests where practical.
 
 Here is a visual representation of the architecture:
 


### PR DESCRIPTION
## Summary

- Keep package tests on the canonical `QuranEngine-Package` scheme.
- Map `TARGET=Foo` and `TARGET=FooTests` to `-only-testing:FooTests` for focused runs.
- Synchronize the package test plan with every test target declared at this point in the stack.
- Document full and focused sync/no-sync test commands in `AGENTS.md` and `README.md`.

## Root cause

`TARGET` previously replaced the Xcode scheme. Commands such as `make test-sync TARGET=AyahMenuFeature` therefore selected a library scheme with no configured Test action. Falling back to the package scheme could also skip test targets absent from its checked-in test plan.

## Impact

Focused test commands now run the intended test bundle without requiring a per-feature scheme. Build commands retain their existing scheme-override behavior.

This is the second PR in a three-PR stack and depends on `afifi/standardize-package-target-layout`.

## Validation

- `make test-no-sync` — 298 passed
- `make test-sync` — 375 passed
- `make test-sync TARGET=AyahMenuFeature` — 8 passed
- `make format-lint`