### PR TITLE
feat(noorui): add multipart text localization formatter

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -171,7 +171,7 @@ private func uiTargets() -> [[Target]] {
         target(type, name: "NoorFont", hasTests: false, resources: [
             .process("Resources"),
         ]),
-        target(type, name: "NoorUI", hasTests: false, dependencies: [
+        target(type, name: "NoorUI", dependencies: [
             "UIx",
             "Crashing",
             "Localization",
@@ -185,6 +185,8 @@ private func uiTargets() -> [[Target]] {
         ], resources: [
             .process("Colors/Colors.xcassets"),
             .process("Images/Images.xcassets"),
+        ], testDependencies: [
+            "Localization",
         ]),
     ]
 }

--- a/QuranEngine-Package.xctestplan
+++ b/QuranEngine-Package.xctestplan
@@ -234,6 +234,13 @@
         "identifier" : "SyncedPageBookmarkPersistenceTests",
         "name" : "SyncedPageBookmarkPersistenceTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "NoorUITests",
+        "name" : "NoorUITests"
+      }
     }
   ],
   "version" : 1

--- a/UI/NoorUI/Sources/Components/MultipartText+Localization.swift
+++ b/UI/NoorUI/Sources/Components/MultipartText+Localization.swift
@@ -1,0 +1,48 @@
+//
+//  MultipartText+Localization.swift
+//
+//
+//  Created by Mohamed Afifi on 2026-07-19.
+//
+
+import Foundation
+import Localization
+
+extension MultipartText {
+    public static func localizedFormat(
+        _ key: String,
+        table: Table = .localizable,
+        language: Language? = nil,
+        _ arguments: MultipartText...
+    ) -> MultipartText {
+        format(l(key, table: table, language: language), arguments: arguments)
+    }
+
+    static func format(_ format: String, arguments: [MultipartText]) -> MultipartText {
+        let placeholders = arguments.indices.map { index in
+            "\u{E000}\(index)\u{E001}"
+        }
+        let formattedArguments = placeholders.map { $0 as CVarArg }
+        let formatted = String(
+            format: format,
+            locale: .fixedCurrentLocaleNumbers,
+            arguments: formattedArguments
+        )
+
+        var result: MultipartText = ""
+        var remainder = formatted[...]
+        while let nextPlaceholder = placeholders.enumerated()
+            .compactMap({ index, placeholder -> (index: Int, range: Range<String.Index>)? in
+                guard let range = remainder.range(of: placeholder) else { return nil }
+                return (index, range)
+            })
+            .min(by: { $0.range.lowerBound < $1.range.lowerBound })
+        {
+            result.append(.text(String(remainder[..<nextPlaceholder.range.lowerBound])))
+            result.append(arguments[nextPlaceholder.index])
+            remainder = remainder[nextPlaceholder.range.upperBound...]
+        }
+        result.append(.text(String(remainder)))
+        return result
+    }
+}

--- a/UI/NoorUI/Tests/MultipartTextLocalizationTests.swift
+++ b/UI/NoorUI/Tests/MultipartTextLocalizationTests.swift
@@ -1,0 +1,41 @@
+//
+//  MultipartTextLocalizationTests.swift
+//
+//
+//  Created by Mohamed Afifi on 2026-07-19.
+//
+
+import Localization
+import XCTest
+@testable import NoorUI
+
+final class MultipartTextLocalizationTests: XCTestCase {
+    func test_localizedFormat_insertsMultipartTextArguments() {
+        let start: MultipartText = "Al-Baqarah 2:255 \(sura: "البقرة")"
+        let end: MultipartText = "Al-Baqarah 2:256"
+
+        let result = MultipartText.localizedFormat(
+            "audio.playing.message",
+            language: .english,
+            start,
+            end
+        )
+
+        XCTAssertEqual(
+            result.rawValue,
+            "Playing audio from Al-Baqarah 2:255 البقرة to Al-Baqarah 2:256"
+        )
+    }
+
+    func test_format_supportsReorderedAndRepeatedArguments() {
+        let first: MultipartText = "first"
+        let second: MultipartText = "second"
+
+        let result = MultipartText.format(
+            "%2$@ / %1$@ / %2$@",
+            arguments: [first, second]
+        )
+
+        XCTAssertEqual(result.rawValue, "second / first / second")
+    }
+}


### PR DESCRIPTION
## Summary

- Add `MultipartText.localizedFormat` for applying localized format strings without flattening styled text segments.
- Support reordered and repeated object placeholders.
- Add focused NoorUI regression tests.
- Register the new `NoorUITests` target in the package test plan introduced by the preceding PR.

## Why

Plain string interpolation loses `MultipartText` segment structure, while localized format strings may reorder or repeat placeholders. The formatter uses temporary markers, applies locale-aware formatting, then reconstructs the original multipart arguments in formatted order.

## Impact

No existing call sites change. NoorUI gains a reusable localized formatter for styled text.

This is the third PR in a three-PR stack and depends on `afifi/targeted-package-tests`.

## Validation

- `make test-no-sync TARGET=NoorUI` — 2 passed
- `make test-sync TARGET=NoorUITests` — 2 passed
- Full cumulative no-sync suite — 300 passed
- Full cumulative sync suite — 389 passed
- `make format-lint`