### PR TITLE
refactor: add AnyAsyncSequence

### DIFF
--- a/Core/Utilities/Sources/Features/AnyAsyncSequence.swift
+++ b/Core/Utilities/Sources/Features/AnyAsyncSequence.swift
@@ -1,0 +1,37 @@
+//
+//  AnyAsyncSequence.swift
+//
+
+public struct AnyAsyncSequence<Element>: AsyncSequence {
+    public struct AsyncIterator: AsyncIteratorProtocol {
+        fileprivate init<I: AsyncIteratorProtocol>(
+            _ iterator: I
+        ) where I.Element == Element {
+            var iterator = iterator
+
+            nextValue = {
+                try await iterator.next()
+            }
+        }
+
+        public mutating func next() async throws -> Element? {
+            try await nextValue()
+        }
+
+        private let nextValue: () async throws -> Element?
+    }
+
+    public init<S: AsyncSequence>(
+        _ sequence: S
+    ) where S.Element == Element {
+        makeIterator = {
+            AsyncIterator(sequence.makeAsyncIterator())
+        }
+    }
+
+    public func makeAsyncIterator() -> AsyncIterator {
+        makeIterator()
+    }
+
+    private let makeIterator: () -> AsyncIterator
+}

--- a/Core/Utilities/Tests/AnyAsyncSequenceTests.swift
+++ b/Core/Utilities/Tests/AnyAsyncSequenceTests.swift
@@ -1,30 +1,27 @@
-import Foundation
 import XCTest
-@testable import AnnotationsService
-@testable import QuranAnnotations
-@testable import QuranKit
+@testable import Utilities
 
-final class LastPagesSequenceTests: XCTestCase {
+final class AnyAsyncSequenceTests: XCTestCase {
     func test_forwardsValuesAndCompletion() async throws {
-        let source = AsyncStream<[LastPage]> { continuation in
-            continuation.yield([])
+        let source = AsyncStream<Int> { continuation in
+            continuation.yield(1)
             continuation.finish()
         }
-        let sequence = LastPagesSequence(source)
+        let sequence = AnyAsyncSequence(source)
         var iterator = sequence.makeAsyncIterator()
 
         let value = try await iterator.next()
         let completion = try await iterator.next()
 
-        XCTAssertEqual(value, [])
+        XCTAssertEqual(value, 1)
         XCTAssertNil(completion)
     }
 
     func test_forwardsErrors() async {
-        let source = AsyncThrowingStream<[LastPage], Error> { continuation in
+        let source = AsyncThrowingStream<Int, Error> { continuation in
             continuation.finish(throwing: TestError.expected)
         }
-        let sequence = LastPagesSequence(source)
+        let sequence = AnyAsyncSequence(source)
         var iterator = sequence.makeAsyncIterator()
 
         do {
@@ -37,13 +34,13 @@ final class LastPagesSequenceTests: XCTestCase {
 
     func test_forwardsCancellation() async {
         let cancelled = expectation(description: "Source receives cancellation")
-        let source = AsyncThrowingStream<[LastPage], Error> { continuation in
+        let source = AsyncThrowingStream<Int, Error> { continuation in
             continuation.onTermination = { termination in
                 guard case .cancelled = termination else { return }
                 cancelled.fulfill()
             }
         }
-        let sequence = LastPagesSequence(source)
+        let sequence = AnyAsyncSequence(source)
         let observation = Task {
             var iterator = sequence.makeAsyncIterator()
             _ = try await iterator.next()
@@ -57,7 +54,7 @@ final class LastPagesSequenceTests: XCTestCase {
     }
 
     func test_iteratorsOwnIndependentSourceIterators() async throws {
-        let sequence = LastPagesSequence(SingleValueSequence())
+        let sequence = AnyAsyncSequence(SingleValueSequence())
         var first = sequence.makeAsyncIterator()
         var second = sequence.makeAsyncIterator()
 
@@ -66,38 +63,10 @@ final class LastPagesSequenceTests: XCTestCase {
         let firstCompletion = try await first.next()
         let secondCompletion = try await second.next()
 
-        XCTAssertEqual(firstValue, [])
-        XCTAssertEqual(secondValue, [])
+        XCTAssertEqual(firstValue, 1)
+        XCTAssertEqual(secondValue, 1)
         XCTAssertNil(firstCompletion)
         XCTAssertNil(secondCompletion)
-    }
-
-    func test_lastPageCanCrossTaskBoundaries() async {
-        let lastPage = makeLastPage()
-        requireSendable(lastPage)
-
-        let received = await Task.detached { lastPage }.value
-
-        XCTAssertEqual(received, lastPage)
-    }
-
-    private func requireSendable(_: some Sendable) {}
-
-    private func makeLastPage() -> LastPage {
-        let page = Quran.hafsMadani1405.pages[10]
-        #if QURAN_SYNC
-        return LastPage(
-            id: "last-page",
-            page: page,
-            modifiedOn: Date(timeIntervalSince1970: 2)
-        )
-        #else
-        return LastPage(
-            page: page,
-            createdOn: Date(timeIntervalSince1970: 1),
-            modifiedOn: Date(timeIntervalSince1970: 2)
-        )
-        #endif
     }
 }
 
@@ -109,10 +78,10 @@ private struct SingleValueSequence: AsyncSequence {
     struct AsyncIterator: AsyncIteratorProtocol {
         var hasValue = true
 
-        mutating func next() async -> [LastPage]? {
+        mutating func next() async -> Int? {
             guard hasValue else { return nil }
             hasValue = false
-            return []
+            return 1
         }
     }
 

--- a/Domain/AnnotationsService/Sources/LastPageService.swift
+++ b/Domain/AnnotationsService/Sources/LastPageService.swift
@@ -8,41 +8,11 @@
 
 import QuranAnnotations
 import QuranKit
-
-public struct LastPagesSequence: AsyncSequence {
-    public typealias Element = [LastPage]
-
-    public struct AsyncIterator: AsyncIteratorProtocol {
-        init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
-            var iterator = sequence.makeAsyncIterator()
-            nextValue = {
-                try await iterator.next()
-            }
-        }
-
-        public mutating func next() async throws -> Element? {
-            try await nextValue()
-        }
-
-        private let nextValue: () async throws -> Element?
-    }
-
-    public init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
-        makeIterator = {
-            AsyncIterator(sequence)
-        }
-    }
-
-    public func makeAsyncIterator() -> AsyncIterator {
-        makeIterator()
-    }
-
-    private let makeIterator: () -> AsyncIterator
-}
+import Utilities
 
 @MainActor
 public protocol LastPageService {
-    func lastPages(quran: Quran) -> LastPagesSequence
+    func lastPages(quran: Quran) -> AnyAsyncSequence<[LastPage]>
 
     func add(page: Page) async throws -> LastPage
 

--- a/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncLastPageService.swift
@@ -10,6 +10,7 @@
 @preconcurrency import MobileSync
 import QuranAnnotations
 import QuranKit
+import Utilities
 
 public struct MobileSyncLastPageService: LastPageService {
     // MARK: Lifecycle
@@ -20,7 +21,7 @@ public struct MobileSyncLastPageService: LastPageService {
 
     // MARK: Public
 
-    public func lastPages(quran: Quran) -> LastPagesSequence {
+    public func lastPages(quran: Quran) -> AnyAsyncSequence<[LastPage]> {
         let sequence = quranDataService.readingSessionsSequence()
             .map { sessions in
                 let mapped = sessions.compactMap { session in
@@ -34,7 +35,7 @@ public struct MobileSyncLastPageService: LastPageService {
                 }
                 return Array(sorted.prefix(3))
             }
-        return LastPagesSequence(sequence)
+        return .init(sequence)
     }
 
     public func add(page: Page) async throws -> LastPage {

--- a/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncNoteService.swift
@@ -9,37 +9,7 @@ import Foundation
 @preconcurrency import MobileSync
 import QuranAnnotations
 import QuranKit
-
-public struct SyncedNotesSequence: AsyncSequence {
-    public typealias Element = [QuranAnnotations.Note]
-
-    public struct AsyncIterator: AsyncIteratorProtocol {
-        init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
-            var iterator = sequence.makeAsyncIterator()
-            nextValue = {
-                try await iterator.next()
-            }
-        }
-
-        public mutating func next() async throws -> Element? {
-            try await nextValue()
-        }
-
-        private let nextValue: () async throws -> Element?
-    }
-
-    init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
-        makeIterator = {
-            AsyncIterator(sequence)
-        }
-    }
-
-    public func makeAsyncIterator() -> AsyncIterator {
-        makeIterator()
-    }
-
-    private let makeIterator: () -> AsyncIterator
-}
+import Utilities
 
 public struct MobileSyncNoteService {
     // MARK: Lifecycle
@@ -50,12 +20,12 @@ public struct MobileSyncNoteService {
 
     // MARK: Public
 
-    public func notesSequence(quran: Quran) -> SyncedNotesSequence {
+    public func notesSequence(quran: Quran) -> AnyAsyncSequence<[QuranAnnotations.Note]> {
         let sequence = quranDataService.notesSequence()
             .map { notes in
                 Self.notes(from: notes, quran: quran)
             }
-        return SyncedNotesSequence(sequence)
+        return .init(sequence)
     }
 
     public func createNote(body: String, startAyah: AyahNumber, endAyah: AyahNumber) async throws {

--- a/Domain/AnnotationsService/Sources/PersistenceLastPageService.swift
+++ b/Domain/AnnotationsService/Sources/PersistenceLastPageService.swift
@@ -11,6 +11,7 @@ import Combine
 import LastPagePersistence
 import QuranAnnotations
 import QuranKit
+import Utilities
 
 public struct PersistenceLastPageService: LastPageService {
     // MARK: Lifecycle
@@ -22,7 +23,7 @@ public struct PersistenceLastPageService: LastPageService {
 
     // MARK: Public
 
-    public func lastPages(quran: Quran) -> LastPagesSequence {
+    public func lastPages(quran: Quran) -> AnyAsyncSequence<[LastPage]> {
         let mapper = QuranPageMapper(destination: quran)
         let sequence = persistence.lastPages()
             .map { lastPages in
@@ -35,7 +36,7 @@ public struct PersistenceLastPageService: LastPageService {
                 }
             }
             .values()
-        return LastPagesSequence(sequence)
+        return .init(sequence)
     }
 
     public func add(page: Page) async throws -> LastPage {

--- a/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
+++ b/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import Utilities
 import XCTest
 @testable import AnnotationsService
 @testable import QuranAnnotations
@@ -194,8 +195,8 @@ private final class ControllableLastPageService: LastPageService {
     private(set) var updateCalls: [UpdateCall] = []
     private(set) var cancellationCount = 0
 
-    func lastPages(quran _: Quran) -> LastPagesSequence {
-        LastPagesSequence(Just<[LastPage]>([]).values)
+    func lastPages(quran _: Quran) -> AnyAsyncSequence<[LastPage]> {
+        .init(Just<[LastPage]>([]).values)
     }
 
     func add(page: Page) async throws -> LastPage {
@@ -269,8 +270,8 @@ private final class LastPageServiceSpy: LastPageService {
     private(set) var addPages: [Page] = []
     private(set) var updateCalls: [UpdateCall] = []
 
-    func lastPages(quran _: Quran) -> LastPagesSequence {
-        LastPagesSequence(Just<[LastPage]>([]).values)
+    func lastPages(quran _: Quran) -> AnyAsyncSequence<[LastPage]> {
+        .init(Just<[LastPage]>([]).values)
     }
 
     func add(page: Page) async throws -> LastPage {

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionService.swift
@@ -11,6 +11,7 @@ import MobileSync
 import QuranAnnotations
 import QuranKit
 import ReadingService
+import Utilities
 import VLogging
 
 public struct AyahBookmarkCollection {
@@ -83,37 +84,6 @@ extension AyahBookmarkCollection {
     public var kind: AyahBookmarkCollectionKind {
         AyahBookmarkCollectionKind(collection: collection)
     }
-}
-
-public struct AyahBookmarkCollectionsSequence: AsyncSequence {
-    public typealias Element = [AyahBookmarkCollection]
-
-    public struct AsyncIterator: AsyncIteratorProtocol {
-        init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
-            var iterator = sequence.makeAsyncIterator()
-            nextValue = {
-                try await iterator.next()
-            }
-        }
-
-        public mutating func next() async throws -> Element? {
-            try await nextValue()
-        }
-
-        private let nextValue: () async throws -> Element?
-    }
-
-    init<S: AsyncSequence>(_ sequence: S) where S.Element == Element {
-        makeIterator = {
-            AsyncIterator(sequence)
-        }
-    }
-
-    public func makeAsyncIterator() -> AsyncIterator {
-        makeIterator()
-    }
-
-    private let makeIterator: () -> AsyncIterator
 }
 
 public struct AyahBookmarkCollectionService {
@@ -191,7 +161,7 @@ public struct AyahBookmarkCollectionService {
         try await removeAyahs(ayahs, from: [collection])
     }
 
-    public func collectionsSequence() -> AyahBookmarkCollectionsSequence {
+    public func collectionsSequence() -> AnyAsyncSequence<[AyahBookmarkCollection]> {
         let quranDataService = quranDataService
         let readingPreferences = readingPreferences
         let sequence = quranDataService.collectionsWithBookmarksSequence()
@@ -203,7 +173,7 @@ public struct AyahBookmarkCollectionService {
                 await quranDataService.createHighlightCollectionsIfNeeded(collections)
                 return collections
             }
-        return AyahBookmarkCollectionsSequence(sequence)
+        return .init(sequence)
     }
 
     // MARK: Internal

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionServiceTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionServiceTests.swift
@@ -3,6 +3,7 @@ import MobileSync
 import MobileSyncTestSupport
 import QuranAnnotations
 import QuranKit
+import Utilities
 import XCTest
 @testable import BookmarksFeature
 
@@ -151,7 +152,7 @@ final class AyahBookmarkCollectionServiceTests: XCTestCase {
     }
 
     private func nextCollections(
-        from iterator: inout AyahBookmarkCollectionsSequence.AsyncIterator,
+        from iterator: inout AnyAsyncSequence<[AyahBookmarkCollection]>.AsyncIterator,
         where predicate: ([AyahBookmarkCollection]) -> Bool
     ) async throws -> [AyahBookmarkCollection] {
         while let collections = try await iterator.next() {

--- a/Package.swift
+++ b/Package.swift
@@ -505,6 +505,7 @@ private func domainTargets() -> [[Target]] {
             "QuranTextKit",
             "Localization",
             "Analytics",
+            "Utilities",
         ], testDependencies: [
             "LastPagePersistence",
             "MobileSyncTestSupport",
@@ -631,6 +632,7 @@ private func featuresTargets() -> [[Target]] {
             "Preferences",
             "QuranTextKit",
             "ReadingService",
+            "Utilities",
         ], testDependencies: [
             "Analytics",
             "AnnotationsService",


### PR DESCRIPTION
## Summary

- add a shared `AnyAsyncSequence` implementation to `Utilities`
- replace duplicated sequence erasers used by last pages, synced notes, and bookmark collections
- consolidate value, completion, error, cancellation, and iterator-independence coverage in `AnyAsyncSequenceTests`

## Why

The existing services repeated the same closure-based async-sequence type erasure. A shared utility removes that duplication while preserving the existing runtime behavior and iOS 15-compatible untyped `Error` propagation.

## Impact

No user-facing behavior change. Service APIs now expose the shared type directly.

## Validation

- `make format-lint`
- `make test-no-sync`
- `make test-sync`