### PR TITLE
feat: add synced reading position bookmarks

### DIFF
--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -195,6 +195,13 @@
 "ayah.menu.edit-note" = "Edit Note";
 "ayah.menu.delete-note" = "Delete Note";
 "ayah.menu.delete-highlight" = "Delete Highlight";
+"ayah.menu.reading-bookmark.title" = "Reading Bookmark";
+"ayah.menu.reading-bookmark.single-ayah-only" = "Select a single Ayah";
+"ayah.menu.reading-bookmark.move-here" = "At %@ • Move here";
+"ayah.menu.reading-bookmark.save-here" = "Save your place here";
+"ayah.menu.reading-bookmark.saved-here" = "Your place is saved here";
+"ayah.menu.reading-bookmark.moved" = "Reading bookmark moved from %@ to %@";
+"ayah.menu.reading-bookmark.removed" = "Reading bookmark removed from %@";
 
 // MARK: - Highlights
 

--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -200,6 +200,7 @@
 "ayah.menu.reading-bookmark.move-here" = "At %@ • Move here";
 "ayah.menu.reading-bookmark.save-here" = "Save your place here";
 "ayah.menu.reading-bookmark.saved-here" = "Your place is saved here";
+"ayah.menu.reading-bookmark.saved" = "Reading bookmark saved at %@";
 "ayah.menu.reading-bookmark.moved" = "Reading bookmark moved from %@ to %@";
 "ayah.menu.reading-bookmark.removed" = "Reading bookmark removed from %@";
 

--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -199,7 +199,7 @@
 "ayah.menu.reading-bookmark.single-ayah-only" = "Select a single Ayah";
 "ayah.menu.reading-bookmark.move-here" = "At %@ • Move here";
 "ayah.menu.reading-bookmark.save-here" = "Save your place here";
-"ayah.menu.reading-bookmark.saved-here" = "Your place is saved here";
+"ayah.menu.reading-bookmark.saved-here" = "Saved here • Tap to delete";
 "ayah.menu.reading-bookmark.saved" = "Reading bookmark saved at %@";
 "ayah.menu.reading-bookmark.moved" = "Reading bookmark moved from %@ to %@";
 "ayah.menu.reading-bookmark.removed" = "Reading bookmark removed from %@";

--- a/Domain/AnnotationsService/Sources/MobileSyncReadingBookmarkService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncReadingBookmarkService.swift
@@ -1,0 +1,111 @@
+#if QURAN_SYNC
+//
+//  MobileSyncReadingBookmarkService.swift
+//
+
+@preconcurrency import MobileSync
+import QuranAnnotations
+import QuranKit
+import Utilities
+
+public struct MobileSyncReadingBookmarkService {
+    // MARK: Lifecycle
+
+    public init(quranDataService: QuranDataService, storedPageQuran: Quran = .hafsMadani1405) {
+        self.quranDataService = quranDataService
+        self.storedPageQuran = storedPageQuran
+    }
+
+    // MARK: Public
+
+    public func readingBookmarkSequence(quran: Quran) -> AnyAsyncSequence<ReadingPositionBookmark?> {
+        let storedPageQuran = storedPageQuran
+        let sequence = quranDataService.readingBookmarkSequence()
+            .map { bookmark in
+                bookmark.flatMap {
+                    Self.readingBookmark(from: $0, quran: quran, storedPageQuran: storedPageQuran)
+                }
+            }
+        return .init(sequence)
+    }
+
+    @discardableResult
+    public func addReadingBookmark(
+        at location: ReadingPositionBookmark.Location
+    ) async throws -> ReadingPositionBookmark {
+        switch location {
+        case .ayah(let ayah):
+            let bookmark = try await quranDataService.addAyahReadingBookmark(
+                sura: Int32(ayah.sura.suraNumber),
+                ayah: Int32(ayah.ayah)
+            )
+            return ReadingPositionBookmark(
+                id: bookmark.id,
+                location: location,
+                modifiedOn: bookmark.lastUpdated
+            )
+        case .page(let page):
+            let storedPage = try storedPage(for: page)
+            let bookmark = try await quranDataService.addPageReadingBookmark(page: Int32(storedPage.pageNumber))
+            return ReadingPositionBookmark(
+                id: bookmark.id,
+                location: location,
+                modifiedOn: bookmark.lastUpdated
+            )
+        }
+    }
+
+    public func removeReadingBookmark() async throws -> Bool {
+        try await quranDataService.removeReadingBookmark()
+    }
+
+    // MARK: Private
+
+    private let quranDataService: QuranDataService
+    private let storedPageQuran: Quran
+
+    private static func readingBookmark(
+        from bookmark: any ReadingBookmark,
+        quran: Quran,
+        storedPageQuran: Quran
+    ) -> ReadingPositionBookmark? {
+        let location: ReadingPositionBookmark.Location
+        switch bookmark {
+        case let bookmark as AyahReadingBookmark:
+            guard let ayah = AyahNumber(
+                quran: quran,
+                sura: Int(bookmark.sura),
+                ayah: Int(bookmark.ayah)
+            ) else {
+                return nil
+            }
+            location = .ayah(ayah)
+        case let bookmark as PageReadingBookmark:
+            guard let storedPage = Page(quran: storedPageQuran, pageNumber: Int(bookmark.page)),
+                  let page = QuranPageMapper(destination: quran).mapPage(storedPage)
+            else {
+                return nil
+            }
+            location = .page(page)
+        default:
+            return nil
+        }
+        return ReadingPositionBookmark(
+            id: bookmark.id,
+            location: location,
+            modifiedOn: bookmark.lastUpdated
+        )
+    }
+
+    private func storedPage(for page: Page) throws -> Page {
+        guard let storedPage = QuranPageMapper(destination: storedPageQuran).mapPage(page) else {
+            throw PageMappingError.unableToMapPage(
+                pageNumber: page.pageNumber,
+                source: page.quran,
+                destination: storedPageQuran
+            )
+        }
+        return storedPage
+    }
+}
+#endif

--- a/Domain/AnnotationsService/Tests/MobileSyncReadingBookmarkServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncReadingBookmarkServiceTests.swift
@@ -1,0 +1,90 @@
+#if QURAN_SYNC
+import MobileSyncTestSupport
+import QuranAnnotations
+import QuranKit
+import XCTest
+@testable import AnnotationsService
+
+final class MobileSyncReadingBookmarkServiceTests: XCTestCase {
+    private let database = MobileSyncTestDatabase.shared
+    private var service: MobileSyncReadingBookmarkService!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+        service = MobileSyncReadingBookmarkService(quranDataService: database.quranDataService)
+    }
+
+    override func tearDown() async throws {
+        try await database.reset()
+        service = nil
+        try await super.tearDown()
+    }
+
+    func test_addReadingBookmark_persistsAyahLocation() async throws {
+        let ayah = ayah(255)
+
+        let created = try await service.addReadingBookmark(at: .ayah(ayah))
+        let stored = try await storedBookmark()
+
+        XCTAssertEqual(created.location, .ayah(ayah))
+        XCTAssertEqual(stored?.location, .ayah(ayah))
+    }
+
+    func test_addReadingBookmark_replacesExistingBookmark() async throws {
+        let original = ayah(254)
+        let destination = ayah(255)
+        try await service.addReadingBookmark(at: .ayah(original))
+
+        try await service.addReadingBookmark(at: .ayah(destination))
+        let stored = try await storedBookmark()
+
+        XCTAssertEqual(stored?.location, .ayah(destination))
+    }
+
+    func test_removeReadingBookmark_deletesCurrentBookmark() async throws {
+        try await service.addReadingBookmark(at: .ayah(ayah(255)))
+
+        let removed = try await service.removeReadingBookmark()
+        let stored = try await storedBookmark()
+
+        XCTAssertTrue(removed)
+        XCTAssertNil(stored)
+    }
+
+    func test_readingBookmarkSequence_mapsPageIntoRequestedQuran() async throws {
+        let storedPage = Quran.hafsMadani1405.pages[254]
+        _ = try await database.quranDataService.addPageReadingBookmark(page: Int32(storedPage.pageNumber))
+        let quran = Quran.hafsNaskh
+        let expectedPage = try XCTUnwrap(QuranPageMapper(destination: quran).mapPage(storedPage))
+
+        let bookmark = try await storedBookmark(quran: quran)
+
+        XCTAssertEqual(bookmark?.location, .page(expectedPage))
+        XCTAssertTrue(bookmark?.isAt(expectedPage.firstVerse) == true)
+    }
+
+    func test_addReadingBookmark_persistsPageLocation() async throws {
+        let storedPage = Quran.hafsMadani1405.pages[254]
+
+        let created = try await service.addReadingBookmark(at: .page(storedPage))
+        let stored = try await storedBookmark()
+
+        XCTAssertEqual(created.location, .page(storedPage))
+        XCTAssertEqual(stored?.location, .page(storedPage))
+    }
+
+    private func storedBookmark(quran: Quran = .hafsMadani1405) async throws -> ReadingPositionBookmark? {
+        var iterator = service.readingBookmarkSequence(quran: quran).makeAsyncIterator()
+        guard let bookmark = try await iterator.next() else {
+            XCTFail("Reading bookmark sequence ended unexpectedly")
+            return nil
+        }
+        return bookmark
+    }
+
+    private func ayah(_ number: Int) -> AyahNumber {
+        AyahNumber(quran: .hafsMadani1405, sura: 2, ayah: number)!
+    }
+}
+#endif

--- a/Features/AyahMenuFeature/Sources/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/Sources/AyahMenuBuilder.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Quran.com. All rights reserved.
 //
 
+import AnnotationsService
 import AppDependencies
 import QuranAnnotations
 import QuranKit
@@ -15,6 +16,25 @@ import UIKit
 public struct AyahMenuInput {
     // MARK: Lifecycle
 
+    #if QURAN_SYNC
+    public init(
+        sourceView: UIView,
+        pointInView: CGPoint,
+        verses: [AyahNumber],
+        notes: [QuranAnnotations.Note],
+        highlightVerses: [AyahNumber: HighlightColor] = [:],
+        bookmarkedVerses: Set<AyahNumber> = [],
+        readingBookmark: ReadingPositionBookmark? = nil
+    ) {
+        self.sourceView = sourceView
+        self.pointInView = pointInView
+        self.verses = verses
+        self.notes = notes
+        self.highlightVerses = highlightVerses
+        self.bookmarkedVerses = bookmarkedVerses
+        self.readingBookmark = readingBookmark
+    }
+    #else
     public init(
         sourceView: UIView,
         pointInView: CGPoint,
@@ -30,6 +50,7 @@ public struct AyahMenuInput {
         self.highlightVerses = highlightVerses
         self.bookmarkedVerses = bookmarkedVerses
     }
+    #endif
 
     // MARK: Internal
 
@@ -39,6 +60,9 @@ public struct AyahMenuInput {
     let notes: [QuranAnnotations.Note]
     let highlightVerses: [AyahNumber: HighlightColor]
     let bookmarkedVerses: Set<AyahNumber>
+    #if QURAN_SYNC
+    let readingBookmark: ReadingPositionBookmark?
+    #endif
 }
 
 @MainActor
@@ -64,7 +88,8 @@ public struct AyahMenuBuilder {
             textRetriever: textRetriever,
             notes: input.notes,
             highlightVerses: input.highlightVerses,
-            bookmarkedVerses: input.bookmarkedVerses
+            bookmarkedVerses: input.bookmarkedVerses,
+            readingBookmark: input.readingBookmark
         )
         #else
         let deps = AyahMenuViewModel.Deps(

--- a/Features/AyahMenuFeature/Sources/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/Sources/AyahMenuViewController.swift
@@ -35,6 +35,20 @@ final class AyahMenuViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        #if QURAN_SYNC
+        let actions = AyahMenuUI.Actions(
+            play: { [weak self] in self?.viewModel.play() },
+            repeatVerses: { [weak self] in self?.viewModel.repeatVerses() },
+            bookmark: { [weak self] in self?.viewModel.bookmark() },
+            addNote: { [weak self] in await self?.viewModel.editNote() },
+            deleteNote: { [weak self] in await self?.viewModel.deleteNotes() },
+            showTranslation: { [weak self] in self?.viewModel.showTranslation() },
+            copy: { [weak self] in self?.viewModel.copy() },
+            share: { [weak self] in self?.viewModel.share() },
+            moveReadingBookmark: { [weak self] in await self?.viewModel.moveReadingBookmark() },
+            deleteReadingBookmark: { [weak self] in await self?.viewModel.deleteReadingBookmark() }
+        )
+        #else
         let actions = AyahMenuUI.Actions(
             play: { [weak self] in self?.viewModel.play() },
             repeatVerses: { [weak self] in self?.viewModel.repeatVerses() },
@@ -45,7 +59,22 @@ final class AyahMenuViewController: UIViewController {
             copy: { [weak self] in self?.viewModel.copy() },
             share: { [weak self] in self?.viewModel.share() }
         )
+        #endif
         let highlightingColor = viewModel.highlightingColor
+        #if QURAN_SYNC
+        let dataObject = AyahMenuUI.DataObject(
+            highlightingColor: highlightingColor,
+            state: viewModel.noteState,
+            bookmarkTitle: viewModel.bookmarkTitle,
+            bookmarkState: viewModel.bookmarkState,
+            playSubtitle: viewModel.playSubtitle,
+            repeatSubtitle: viewModel.repeatSubtitle,
+            actions: actions,
+            isTranslationView: viewModel.isTranslationView,
+            usesSyncedNotesIcon: viewModel.usesSyncedNotesIcon,
+            readingBookmarkState: viewModel.readingBookmarkState
+        )
+        #else
         let dataObject = AyahMenuUI.DataObject(
             highlightingColor: highlightingColor,
             state: viewModel.noteState,
@@ -57,6 +86,7 @@ final class AyahMenuViewController: UIViewController {
             isTranslationView: viewModel.isTranslationView,
             usesSyncedNotesIcon: viewModel.usesSyncedNotesIcon
         )
+        #endif
         showAyahMenu(dataObject)
     }
 

--- a/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
@@ -29,6 +29,10 @@ public protocol AyahMenuListener: AnyObject {
     func showBookmarkEditor(for verses: [AyahNumber])
     func showNoteEditor(for verses: [AyahNumber]) async
     func deleteNotes(in verses: [AyahNumber]) async
+    #if QURAN_SYNC
+    func moveReadingBookmark(to ayah: AyahNumber, from bookmark: ReadingPositionBookmark?) async
+    func deleteReadingBookmark(_ bookmark: ReadingPositionBookmark) async
+    #endif
 }
 
 // MARK: - ViewModel
@@ -43,7 +47,9 @@ final class AyahMenuViewModel {
         let notes: [QuranAnnotations.Note]
         let highlightVerses: [AyahNumber: HighlightColor]
         let bookmarkedVerses: Set<AyahNumber>
-        #if !QURAN_SYNC
+        #if QURAN_SYNC
+        let readingBookmark: ReadingPositionBookmark?
+        #else
         let noteService: NoteService
         #endif
         let quranContentStatePreferences = QuranContentStatePreferences.shared
@@ -106,6 +112,21 @@ final class AyahMenuViewModel {
         return l("ayah.menu.selected-verses")
     }
 
+    #if QURAN_SYNC
+    var readingBookmarkState: AyahMenuUI.ReadingBookmarkState {
+        guard deps.verses.count == 1, let ayah = deps.verses.first else {
+            return .disabled(message: l("ayah.menu.reading-bookmark.single-ayah-only"))
+        }
+        guard let readingBookmark = deps.readingBookmark else {
+            return .unset
+        }
+        if readingBookmark.isAt(ayah) {
+            return .current
+        }
+        return .elsewhere(location: readingBookmarkLocation(readingBookmark))
+    }
+    #endif
+
     var usesSyncedNotesIcon: Bool {
         #if QURAN_SYNC
         return true
@@ -150,6 +171,28 @@ final class AyahMenuViewModel {
         logger.info("AyahMenu: bookmark tapped. Verses: \(deps.verses)")
         listener?.showBookmarkEditor(for: deps.verses)
     }
+
+    #if QURAN_SYNC
+    func moveReadingBookmark() async {
+        guard deps.verses.count == 1, let ayah = deps.verses.first else {
+            return
+        }
+        logger.info("AyahMenu: move reading bookmark. Ayah: \(ayah)")
+        await listener?.moveReadingBookmark(to: ayah, from: deps.readingBookmark)
+    }
+
+    func deleteReadingBookmark() async {
+        guard deps.verses.count == 1,
+              let ayah = deps.verses.first,
+              let readingBookmark = deps.readingBookmark,
+              readingBookmark.isAt(ayah)
+        else {
+            return
+        }
+        logger.info("AyahMenu: delete reading bookmark. Bookmark: \(readingBookmark)")
+        await listener?.deleteReadingBookmark(readingBookmark)
+    }
+    #endif
 
     func deleteNotes() async {
         logger.info("AyahMenu: delete notes. Verses: \(deps.verses)")
@@ -209,4 +252,19 @@ final class AyahMenuViewModel {
             try await deps.textRetriever.textForVerses(deps.verses)
         }
     }
+
+    #if QURAN_SYNC
+    private func readingBookmarkLocation(_ bookmark: ReadingPositionBookmark) -> MultipartText {
+        let location: MultipartText
+        switch bookmark.location {
+        case .ayah(let ayah):
+            let localizedLocation = "\(ayah.sura.localizedName()) \(ayah.sura.localizedSuraNumber):\(NumberFormatter.shared.format(ayah.ayah))"
+            location = "\(localizedLocation) \(sura: ayah.sura.arabicSuraName)"
+        case .page(let page):
+            location = "\(page.localizedName)"
+        }
+
+        return .localizedFormat("ayah.menu.reading-bookmark.move-here", location)
+    }
+    #endif
 }

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -64,7 +64,7 @@ final class AyahMenuViewModelTests: XCTestCase {
 
     func test_readingBookmarkCopy_describesEachLocationState() {
         XCTAssertEqual(l("ayah.menu.reading-bookmark.save-here"), "Save your place here")
-        XCTAssertEqual(l("ayah.menu.reading-bookmark.saved-here"), "Your place is saved here")
+        XCTAssertEqual(l("ayah.menu.reading-bookmark.saved-here"), "Saved here • Tap to delete")
         XCTAssertEqual(
             lFormat("ayah.menu.reading-bookmark.move-here", "Al-Baqarah 2:255"),
             "At Al-Baqarah 2:255 • Move here"

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -1,4 +1,5 @@
 #if QURAN_SYNC
+import AnnotationsService
 import Localization
 import QuranAnnotations
 import QuranKit
@@ -61,6 +62,104 @@ final class AyahMenuViewModelTests: XCTestCase {
         XCTAssertEqual(lFormat("bookmarks.editor.title", language: .english, 2), "Save Ayahs...")
     }
 
+    func test_readingBookmarkCopy_describesEachLocationState() {
+        XCTAssertEqual(l("ayah.menu.reading-bookmark.save-here"), "Save your place here")
+        XCTAssertEqual(l("ayah.menu.reading-bookmark.saved-here"), "Your place is saved here")
+        XCTAssertEqual(
+            lFormat("ayah.menu.reading-bookmark.move-here", "Al-Baqarah 2:255"),
+            "At Al-Baqarah 2:255 • Move here"
+        )
+    }
+
+    func test_readingBookmarkState_isDisabledForMultipleSelectedAyahs() {
+        let sut = makeSUT()
+
+        guard case .disabled(let message) = sut.readingBookmarkState else {
+            return XCTFail("Expected disabled reading bookmark state")
+        }
+        XCTAssertEqual(message, l("ayah.menu.reading-bookmark.single-ayah-only"))
+    }
+
+    func test_readingBookmarkState_isUnsetWhenNoReadingBookmarkExists() {
+        let sut = makeSUT(verses: [verses[0]])
+
+        guard case .unset = sut.readingBookmarkState else {
+            return XCTFail("Expected unset reading bookmark state")
+        }
+    }
+
+    func test_readingBookmarkState_isCurrentForSelectedAyah() {
+        let selected = verses[0]
+        let sut = makeSUT(
+            verses: [selected],
+            readingBookmark: readingBookmark(at: .ayah(selected))
+        )
+
+        guard case .current = sut.readingBookmarkState else {
+            return XCTFail("Expected current reading bookmark state")
+        }
+    }
+
+    func test_readingBookmarkState_isCurrentForPageContainingSelectedAyah() {
+        let selected = verses[0]
+        let sut = makeSUT(
+            verses: [selected],
+            readingBookmark: readingBookmark(at: .page(selected.page))
+        )
+
+        guard case .current = sut.readingBookmarkState else {
+            return XCTFail("Expected current reading bookmark state")
+        }
+    }
+
+    func test_readingBookmarkState_isElsewhereForDifferentAyah() {
+        let sut = makeSUT(
+            verses: [verses[0]],
+            readingBookmark: readingBookmark(at: .ayah(verses[1]))
+        )
+
+        guard case .elsewhere = sut.readingBookmarkState else {
+            return XCTFail("Expected elsewhere reading bookmark state")
+        }
+    }
+
+    func test_moveReadingBookmark_requestsMoveWithoutPreviousBookmark() async {
+        let selected = verses[0]
+        let sut = makeSUT(verses: [selected])
+        let listener = BookmarkListenerSpy()
+        sut.listener = listener
+
+        await sut.moveReadingBookmark()
+
+        XCTAssertEqual(listener.readingBookmarkMove?.to, selected)
+        XCTAssertNil(listener.readingBookmarkMove?.from)
+    }
+
+    func test_moveReadingBookmark_requestsMoveFromPreviousBookmark() async {
+        let selected = verses[0]
+        let previousBookmark = readingBookmark(at: .ayah(verses[1]))
+        let sut = makeSUT(verses: [selected], readingBookmark: previousBookmark)
+        let listener = BookmarkListenerSpy()
+        sut.listener = listener
+
+        await sut.moveReadingBookmark()
+
+        XCTAssertEqual(listener.readingBookmarkMove?.to, selected)
+        XCTAssertEqual(listener.readingBookmarkMove?.from, previousBookmark)
+    }
+
+    func test_deleteReadingBookmark_requestsDeletionOfCurrentBookmark() async {
+        let selected = verses[0]
+        let bookmark = readingBookmark(at: .ayah(selected))
+        let sut = makeSUT(verses: [selected], readingBookmark: bookmark)
+        let listener = BookmarkListenerSpy()
+        sut.listener = listener
+
+        await sut.deleteReadingBookmark()
+
+        XCTAssertEqual(listener.deletedReadingBookmark, bookmark)
+    }
+
     private var verses: [AyahNumber] {
         [
             AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 7)!,
@@ -69,28 +168,37 @@ final class AyahMenuViewModelTests: XCTestCase {
     }
 
     private func makeSUT(
+        verses: [AyahNumber]? = nil,
         highlightVerses: [AyahNumber: HighlightColor] = [:],
-        bookmarkedVerses: Set<AyahNumber> = []
+        bookmarkedVerses: Set<AyahNumber> = [],
+        readingBookmark: ReadingPositionBookmark? = nil
     ) -> AyahMenuViewModel {
         let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-quran-database")
         return AyahMenuViewModel(deps: .init(
             sourceView: UIView(),
             pointInView: .zero,
-            verses: verses,
+            verses: verses ?? self.verses,
             textRetriever: ShareableVerseTextRetriever(
                 databasesURL: unavailableDatabase,
                 quranFileURL: unavailableDatabase
             ),
             notes: [],
             highlightVerses: highlightVerses,
-            bookmarkedVerses: bookmarkedVerses
+            bookmarkedVerses: bookmarkedVerses,
+            readingBookmark: readingBookmark
         ))
+    }
+
+    private func readingBookmark(at location: ReadingPositionBookmark.Location) -> ReadingPositionBookmark {
+        ReadingPositionBookmark(id: "reading-bookmark", location: location, modifiedOn: .distantPast)
     }
 }
 
 @MainActor
 private final class BookmarkListenerSpy: AyahMenuListener {
     private(set) var bookmarkedVerses: [AyahNumber]?
+    private(set) var readingBookmarkMove: (to: AyahNumber, from: ReadingPositionBookmark?)?
+    private(set) var deletedReadingBookmark: ReadingPositionBookmark?
 
     func dismissAyahMenu() {}
     func playAudio(_ from: AyahNumber, to: AyahNumber?, repeatVerses: Bool) {}
@@ -98,6 +206,14 @@ private final class BookmarkListenerSpy: AyahMenuListener {
     func showTranslation(_ verses: [AyahNumber]) {}
     func showNoteEditor(for verses: [AyahNumber]) async {}
     func deleteNotes(in verses: [AyahNumber]) async {}
+
+    func moveReadingBookmark(to ayah: AyahNumber, from bookmark: ReadingPositionBookmark?) async {
+        readingBookmarkMove = (ayah, bookmark)
+    }
+
+    func deleteReadingBookmark(_ bookmark: ReadingPositionBookmark) async {
+        deletedReadingBookmark = bookmark
+    }
 
     func showBookmarkEditor(for verses: [AyahNumber]) {
         bookmarkedVerses = verses

--- a/Features/QuranViewFeature/Sources/QuranBuilder.swift
+++ b/Features/QuranViewFeature/Sources/QuranBuilder.swift
@@ -42,6 +42,10 @@ public struct QuranBuilder {
             ayahBookmarkCollectionService: AyahBookmarkCollectionService(quranDataService: container.quranDataService),
             highlightsService: highlightsService
         )
+        let readingBookmarkObserver = QuranReadingBookmarkObserver(
+            service: MobileSyncReadingBookmarkService(quranDataService: container.quranDataService),
+            quran: quran
+        )
         let interactorDeps = QuranInteractor.Deps(
             quran: quran,
             analytics: container.analytics,
@@ -58,7 +62,8 @@ public struct QuranBuilder {
             resources: container.readingResources,
             notesObserver: notesObserver,
             noteEditorBuilder: NoteEditorBuilder(container: container),
-            syncedHighlightsObserver: syncedHighlightsObserver
+            syncedHighlightsObserver: syncedHighlightsObserver,
+            readingBookmarkObserver: readingBookmarkObserver
         )
         #else
         let noteService = container.noteService()

--- a/Features/QuranViewFeature/Sources/QuranInteractor.swift
+++ b/Features/QuranViewFeature/Sources/QuranInteractor.swift
@@ -54,6 +54,7 @@ protocol QuranPresentable: UIViewController {
 
     func dismissWordPointer(_ viewController: UIViewController)
     func dismissPresentedViewController(completion: (() -> Void)?)
+    func showToast(_ toast: Toast)
 }
 
 @MainActor
@@ -78,6 +79,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let noteEditorBuilder: NoteEditorBuilder
         #if QURAN_SYNC
         let syncedHighlightsObserver: QuranSyncedHighlightsObserver
+        let readingBookmarkObserver: QuranReadingBookmarkObserver
         #else
         let noteService: NoteService
         #endif
@@ -111,6 +113,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         deps.notesObserver.start()
         #if QURAN_SYNC
         deps.syncedHighlightsObserver.start()
+        deps.readingBookmarkObserver.start()
         #endif
 
         deps.pageBookmarkService.pageBookmarks(quran: deps.quran)
@@ -276,6 +279,43 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         }
     }
 
+    #if QURAN_SYNC
+    func moveReadingBookmark(to ayah: AyahNumber, from previousBookmark: ReadingPositionBookmark?) async {
+        do {
+            let movedBookmark = try await deps.readingBookmarkObserver.add(at: .ayah(ayah))
+            dismissAyahMenu()
+            if let previousBookmark {
+                presenter?.showToast(
+                    ReadingBookmarkUndoToast.moved(from: previousBookmark, to: movedBookmark) { [weak self] in
+                        self?.undoReadingBookmarkMove(movedBookmark, to: previousBookmark)
+                    }
+                )
+            }
+        } catch {
+            crasher.recordError(error, reason: "Failed to move reading bookmark")
+        }
+    }
+
+    func deleteReadingBookmark(_ bookmark: ReadingPositionBookmark) async {
+        do {
+            let observer = deps.readingBookmarkObserver
+            guard observer.bookmark == bookmark,
+                  let deletedBookmark = try await observer.remove()
+            else {
+                return
+            }
+            dismissAyahMenu()
+            presenter?.showToast(
+                ReadingBookmarkUndoToast.removed(deletedBookmark) { [weak self] in
+                    self?.addReadingBookmark(at: deletedBookmark.location)
+                }
+            )
+        } catch {
+            crasher.recordError(error, reason: "Failed to delete reading bookmark")
+        }
+    }
+    #endif
+
     func dismissNoteEditor() {
         logger.info("Quran: dismiss note editor")
         presenter?.dismiss(animated: true)
@@ -310,6 +350,17 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let highlightVerses = deps.highlightsService.highlights.noteVerses.mapValues(\.color)
         let bookmarkedVerses: Set<AyahNumber> = []
         #endif
+        #if QURAN_SYNC
+        let input = AyahMenuInput(
+            sourceView: sourceView,
+            pointInView: point,
+            verses: verses,
+            notes: notesInteractingVerses(verses),
+            highlightVerses: highlightVerses,
+            bookmarkedVerses: bookmarkedVerses,
+            readingBookmark: deps.readingBookmarkObserver.bookmark
+        )
+        #else
         let input = AyahMenuInput(
             sourceView: sourceView,
             pointInView: point,
@@ -318,6 +369,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             highlightVerses: highlightVerses,
             bookmarkedVerses: bookmarkedVerses
         )
+        #endif
         let ayahMenuViewController = deps.ayahMenuBuilder.build(withListener: self, input: input)
         presenter?.presentAyahMenu(ayahMenuViewController, in: sourceView, at: point)
     }
@@ -327,6 +379,34 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         presenter?.dismissPresentedViewController(completion: nil)
         contentViewModel?.removeAyahMenuHighlight()
     }
+
+    #if QURAN_SYNC
+    private func addReadingBookmark(at location: ReadingPositionBookmark.Location) {
+        Task {
+            do {
+                try await deps.readingBookmarkObserver.add(at: location)
+            } catch {
+                crasher.recordError(error, reason: "Failed to undo reading bookmark change")
+            }
+        }
+    }
+
+    private func undoReadingBookmarkMove(
+        _ movedBookmark: ReadingPositionBookmark,
+        to previousBookmark: ReadingPositionBookmark
+    ) {
+        Task {
+            guard deps.readingBookmarkObserver.bookmark == movedBookmark else {
+                return
+            }
+            do {
+                try await deps.readingBookmarkObserver.add(at: previousBookmark.location)
+            } catch {
+                crasher.recordError(error, reason: "Failed to undo reading bookmark move")
+            }
+        }
+    }
+    #endif
 
     // MARK: - Word Pointer
 

--- a/Features/QuranViewFeature/Sources/QuranInteractor.swift
+++ b/Features/QuranViewFeature/Sources/QuranInteractor.swift
@@ -290,6 +290,8 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
                         self?.undoReadingBookmarkMove(movedBookmark, to: previousBookmark)
                     }
                 )
+            } else {
+                presenter?.showToast(ReadingBookmarkUndoToast.saved(movedBookmark))
             }
         } catch {
             crasher.recordError(error, reason: "Failed to move reading bookmark")

--- a/Features/QuranViewFeature/Sources/QuranReadingBookmarkObserver.swift
+++ b/Features/QuranViewFeature/Sources/QuranReadingBookmarkObserver.swift
@@ -1,0 +1,70 @@
+#if QURAN_SYNC
+//
+//  QuranReadingBookmarkObserver.swift
+//
+
+import AnnotationsService
+import QuranAnnotations
+import QuranKit
+import VLogging
+
+@MainActor
+final class QuranReadingBookmarkObserver {
+    // MARK: Lifecycle
+
+    init(service: MobileSyncReadingBookmarkService, quran: Quran) {
+        self.service = service
+        self.quran = quran
+    }
+
+    deinit {
+        task?.cancel()
+    }
+
+    // MARK: Internal
+
+    private(set) var bookmark: ReadingPositionBookmark?
+
+    func start() {
+        guard task == nil else {
+            return
+        }
+        let service = service
+        let quran = quran
+        task = Task { [weak self] in
+            do {
+                for try await bookmark in service.readingBookmarkSequence(quran: quran) {
+                    self?.bookmark = bookmark
+                }
+            } catch is CancellationError {
+            } catch {
+                logger.error("Failed to observe reading bookmark: \(error)")
+            }
+        }
+    }
+
+    @discardableResult
+    func add(at location: ReadingPositionBookmark.Location) async throws -> ReadingPositionBookmark {
+        let bookmark = try await service.addReadingBookmark(at: location)
+        self.bookmark = bookmark
+        return bookmark
+    }
+
+    func remove() async throws -> ReadingPositionBookmark? {
+        guard let bookmark else {
+            return nil
+        }
+        guard try await service.removeReadingBookmark() else {
+            return nil
+        }
+        self.bookmark = nil
+        return bookmark
+    }
+
+    // MARK: Private
+
+    private let service: MobileSyncReadingBookmarkService
+    private let quran: Quran
+    private var task: Task<Void, Never>?
+}
+#endif

--- a/Features/QuranViewFeature/Sources/QuranViewController.swift
+++ b/Features/QuranViewFeature/Sources/QuranViewController.swift
@@ -243,6 +243,14 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         dismiss(animated: true, completion: completion)
     }
 
+    func showToast(_ toast: Toast) {
+        guard let windowScene = view.window?.windowScene else {
+            logger.error("Unable to show toast without a window scene")
+            return
+        }
+        ToastPresenter.shared.showToast(toast, in: windowScene)
+    }
+
     func didDismissPopover() {
         interactor.didDismissPopover()
     }

--- a/Features/QuranViewFeature/Sources/ReadingBookmarkUndoToast.swift
+++ b/Features/QuranViewFeature/Sources/ReadingBookmarkUndoToast.swift
@@ -10,6 +10,10 @@ import QuranTextKit
 import UIx
 
 enum ReadingBookmarkUndoToast {
+    static func saved(_ bookmark: ReadingPositionBookmark) -> Toast {
+        Toast(lFormat("ayah.menu.reading-bookmark.saved", location(of: bookmark)))
+    }
+
     static func moved(
         from previousBookmark: ReadingPositionBookmark,
         to currentBookmark: ReadingPositionBookmark,

--- a/Features/QuranViewFeature/Sources/ReadingBookmarkUndoToast.swift
+++ b/Features/QuranViewFeature/Sources/ReadingBookmarkUndoToast.swift
@@ -1,0 +1,54 @@
+#if QURAN_SYNC
+//
+//  ReadingBookmarkUndoToast.swift
+//
+
+import Foundation
+import Localization
+import QuranAnnotations
+import QuranTextKit
+import UIx
+
+enum ReadingBookmarkUndoToast {
+    static func moved(
+        from previousBookmark: ReadingPositionBookmark,
+        to currentBookmark: ReadingPositionBookmark,
+        undo: @escaping () -> Void
+    ) -> Toast {
+        makeToast(
+            lFormat(
+                "ayah.menu.reading-bookmark.moved",
+                location(of: previousBookmark),
+                location(of: currentBookmark)
+            ),
+            undo: undo
+        )
+    }
+
+    static func removed(
+        _ bookmark: ReadingPositionBookmark,
+        undo: @escaping () -> Void
+    ) -> Toast {
+        makeToast(
+            lFormat("ayah.menu.reading-bookmark.removed", location(of: bookmark)),
+            undo: undo
+        )
+    }
+
+    private static func makeToast(_ message: String, undo: @escaping () -> Void) -> Toast {
+        Toast(
+            message,
+            action: ToastAction(title: lAndroid("undo"), handler: undo)
+        )
+    }
+
+    private static func location(of bookmark: ReadingPositionBookmark) -> String {
+        switch bookmark.location {
+        case .ayah(let ayah):
+            return "\(ayah.sura.localizedName()) \(ayah.sura.localizedSuraNumber):\(NumberFormatter.shared.format(ayah.ayah))"
+        case .page(let page):
+            return page.localizedName
+        }
+    }
+}
+#endif

--- a/Features/QuranViewFeature/Tests/ReadingBookmarkUndoToastTests.swift
+++ b/Features/QuranViewFeature/Tests/ReadingBookmarkUndoToastTests.swift
@@ -6,6 +6,15 @@ import XCTest
 @testable import QuranViewFeature
 
 final class ReadingBookmarkUndoToastTests: XCTestCase {
+    func test_saved_describesLocationWithoutAction() {
+        let bookmark = bookmark(at: .ayah(ayah(255)))
+
+        let toast = ReadingBookmarkUndoToast.saved(bookmark)
+
+        XCTAssertEqual(toast.message, "Reading bookmark saved at Al-Baqarah 2:255")
+        XCTAssertNil(toast.action)
+    }
+
     func test_moved_describesBothLocationsAndProvidesUndo() {
         let previousBookmark = bookmark(at: .page(ayah(255).page))
         let currentBookmark = bookmark(at: .ayah(ayah(255)))

--- a/Features/QuranViewFeature/Tests/ReadingBookmarkUndoToastTests.swift
+++ b/Features/QuranViewFeature/Tests/ReadingBookmarkUndoToastTests.swift
@@ -1,0 +1,46 @@
+#if QURAN_SYNC
+import Foundation
+import QuranAnnotations
+import QuranKit
+import XCTest
+@testable import QuranViewFeature
+
+final class ReadingBookmarkUndoToastTests: XCTestCase {
+    func test_moved_describesBothLocationsAndProvidesUndo() {
+        let previousBookmark = bookmark(at: .page(ayah(255).page))
+        let currentBookmark = bookmark(at: .ayah(ayah(255)))
+        var didUndo = false
+
+        let toast = ReadingBookmarkUndoToast.moved(from: previousBookmark, to: currentBookmark) {
+            didUndo = true
+        }
+
+        XCTAssertEqual(toast.message, "Reading bookmark moved from Page 42 to Al-Baqarah 2:255")
+        XCTAssertEqual(toast.action?.title, "Undo")
+        toast.action?.handler()
+        XCTAssertTrue(didUndo)
+    }
+
+    func test_removed_describesLocationAndProvidesUndo() {
+        let bookmark = bookmark(at: .ayah(ayah(255)))
+        var didUndo = false
+
+        let toast = ReadingBookmarkUndoToast.removed(bookmark) {
+            didUndo = true
+        }
+
+        XCTAssertEqual(toast.message, "Reading bookmark removed from Al-Baqarah 2:255")
+        XCTAssertEqual(toast.action?.title, "Undo")
+        toast.action?.handler()
+        XCTAssertTrue(didUndo)
+    }
+
+    private func bookmark(at location: ReadingPositionBookmark.Location) -> ReadingPositionBookmark {
+        ReadingPositionBookmark(id: "reading-bookmark", location: location, modifiedOn: .distantPast)
+    }
+
+    private func ayah(_ number: Int) -> AyahNumber {
+        AyahNumber(quran: .hafsMadani1405, sura: 2, ayah: number)!
+    }
+}
+#endif

--- a/Model/QuranAnnotations/Sources/ReadingPositionBookmark.swift
+++ b/Model/QuranAnnotations/Sources/ReadingPositionBookmark.swift
@@ -1,0 +1,38 @@
+#if QURAN_SYNC
+//
+//  ReadingPositionBookmark.swift
+//
+
+import Foundation
+import QuranKit
+
+public struct ReadingPositionBookmark: Equatable {
+    // MARK: Lifecycle
+
+    public init(id: String, location: Location, modifiedOn: Date) {
+        self.id = id
+        self.location = location
+        self.modifiedOn = modifiedOn
+    }
+
+    // MARK: Public
+
+    public enum Location: Equatable {
+        case ayah(AyahNumber)
+        case page(Page)
+    }
+
+    public let id: String
+    public let location: Location
+    public let modifiedOn: Date
+
+    public func isAt(_ ayah: AyahNumber) -> Bool {
+        switch location {
+        case .ayah(let bookmarkedAyah):
+            return bookmarkedAyah == ayah
+        case .page(let bookmarkedPage):
+            return bookmarkedPage == ayah.page
+        }
+    }
+}
+#endif

--- a/UI/NoorUI/Sources/Components/MultipartText.swift
+++ b/UI/NoorUI/Sources/Components/MultipartText.swift
@@ -178,8 +178,12 @@ public struct MultipartText: ExpressibleByStringInterpolation {
         parts.append(contentsOf: other.parts)
     }
 
-    public func view(ofSize size: FontSize, alignment: Alignment = .leading) -> some View {
-        MultiPartTextView(text: self, size: size, alignment: alignment)
+    public func view(
+        ofSize size: FontSize,
+        alignment: Alignment = .leading,
+        allowsWrapping: Bool = true
+    ) -> some View {
+        MultiPartTextView(text: self, size: size, alignment: alignment, allowsWrapping: allowsWrapping)
     }
 
     // MARK: Internal
@@ -205,6 +209,7 @@ private struct MultiPartTextView: View {
     let text: MultipartText
     let size: MultipartText.FontSize
     let alignment: Alignment
+    let allowsWrapping: Bool
 
     var body: some View {
         wrap {
@@ -216,7 +221,12 @@ private struct MultiPartTextView: View {
 
     @ViewBuilder
     private func wrap(@ViewBuilder content: () -> some View) -> some View {
-        if #available(iOS 16.0, *) {
+        if !allowsWrapping {
+            HStack(spacing: 0) {
+                content()
+            }
+            .lineLimit(1)
+        } else if #available(iOS 16.0, *) {
             WrappingHStack(alignment: alignment, horizontalSpacing: 0, fitContentWidth: true) {
                 content()
             }

--- a/UI/NoorUI/Sources/Components/ReadingBookmarkPin.swift
+++ b/UI/NoorUI/Sources/Components/ReadingBookmarkPin.swift
@@ -1,0 +1,89 @@
+//
+//  ReadingBookmarkPin.swift
+//
+
+import SwiftUI
+
+public struct ReadingBookmarkPin: View {
+    // MARK: Lifecycle
+
+    public init(style: Style) {
+        self.style = style
+    }
+
+    // MARK: Public
+
+    public enum Style {
+        case outline
+        case filled
+    }
+
+    public var body: some View {
+        Group {
+            switch style {
+            case .outline:
+                ReadingBookmarkPinShape()
+                    .stroke(style: StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round))
+            case .filled:
+                ReadingBookmarkPinShape()
+                    .fill(style: FillStyle(eoFill: true))
+            }
+        }
+        .frame(width: size, height: size)
+    }
+
+    // MARK: Private
+
+    private let style: Style
+    @ScaledMetric private var lineWidth = 1.8
+    @ScaledMetric private var size = 24.0
+}
+
+private struct ReadingBookmarkPinShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let scaleX = rect.width / 24
+        let scaleY = rect.height / 24
+        func point(_ x: CGFloat, _ y: CGFloat) -> CGPoint {
+            CGPoint(x: rect.minX + x * scaleX, y: rect.minY + y * scaleY)
+        }
+
+        var path = Path()
+        path.move(to: point(12, 2))
+        path.addCurve(
+            to: point(5, 9),
+            control1: point(8.13, 2),
+            control2: point(5, 5.13)
+        )
+        path.addCurve(
+            to: point(12, 22),
+            control1: point(5, 14.25),
+            control2: point(12, 22)
+        )
+        path.addCurve(
+            to: point(19, 9),
+            control1: point(12, 22),
+            control2: point(19, 14.25)
+        )
+        path.addCurve(
+            to: point(12, 2),
+            control1: point(19, 5.13),
+            control2: point(15.87, 2)
+        )
+        path.closeSubpath()
+        path.addEllipse(in: CGRect(
+            x: rect.minX + 9.5 * scaleX,
+            y: rect.minY + 6.5 * scaleY,
+            width: 5 * scaleX,
+            height: 5 * scaleY
+        ))
+        return path
+    }
+}
+
+#Preview {
+    HStack {
+        ReadingBookmarkPin(style: .outline)
+        ReadingBookmarkPin(style: .filled)
+            .foregroundColor(.appIdentity)
+    }
+}

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuUI.swift
@@ -12,6 +12,31 @@ public enum AyahMenuUI {
     public struct Actions {
         // MARK: Lifecycle
 
+        #if QURAN_SYNC
+        public init(
+            play: @escaping AsyncAction,
+            repeatVerses: @escaping AsyncAction,
+            bookmark: @escaping AsyncAction,
+            addNote: @escaping AsyncAction,
+            deleteNote: @escaping AsyncAction,
+            showTranslation: @escaping AsyncAction,
+            copy: @escaping AsyncAction,
+            share: @escaping AsyncAction,
+            moveReadingBookmark: @escaping AsyncAction,
+            deleteReadingBookmark: @escaping AsyncAction
+        ) {
+            self.play = play
+            self.repeatVerses = repeatVerses
+            self.bookmark = bookmark
+            self.addNote = addNote
+            self.deleteNote = deleteNote
+            self.showTranslation = showTranslation
+            self.copy = copy
+            self.share = share
+            self.moveReadingBookmark = moveReadingBookmark
+            self.deleteReadingBookmark = deleteReadingBookmark
+        }
+        #else
         public init(
             play: @escaping AsyncAction,
             repeatVerses: @escaping AsyncAction,
@@ -31,6 +56,7 @@ public enum AyahMenuUI {
             self.copy = copy
             self.share = share
         }
+        #endif
 
         // MARK: Internal
 
@@ -42,11 +68,40 @@ public enum AyahMenuUI {
         let showTranslation: AsyncAction
         let copy: AsyncAction
         let share: AsyncAction
+        #if QURAN_SYNC
+        let moveReadingBookmark: AsyncAction
+        let deleteReadingBookmark: AsyncAction
+        #endif
     }
 
     public struct DataObject {
         // MARK: Lifecycle
 
+        #if QURAN_SYNC
+        public init(
+            highlightingColor: HighlightColor,
+            state: NoteState,
+            bookmarkTitle: String,
+            bookmarkState: BookmarkState = .unhighlighted,
+            playSubtitle: String,
+            repeatSubtitle: String,
+            actions: Actions,
+            isTranslationView: Bool,
+            usesSyncedNotesIcon: Bool = false,
+            readingBookmarkState: ReadingBookmarkState
+        ) {
+            self.highlightingColor = highlightingColor
+            self.state = state
+            self.bookmarkTitle = bookmarkTitle
+            self.bookmarkState = bookmarkState
+            self.playSubtitle = playSubtitle
+            self.repeatSubtitle = repeatSubtitle
+            self.actions = actions
+            self.isTranslationView = isTranslationView
+            self.usesSyncedNotesIcon = usesSyncedNotesIcon
+            self.readingBookmarkState = readingBookmarkState
+        }
+        #else
         public init(
             highlightingColor: HighlightColor,
             state: NoteState,
@@ -68,6 +123,7 @@ public enum AyahMenuUI {
             self.isTranslationView = isTranslationView
             self.usesSyncedNotesIcon = usesSyncedNotesIcon
         }
+        #endif
 
         // MARK: Internal
 
@@ -80,6 +136,9 @@ public enum AyahMenuUI {
         let repeatSubtitle: String
         let isTranslationView: Bool
         let usesSyncedNotesIcon: Bool
+        #if QURAN_SYNC
+        let readingBookmarkState: ReadingBookmarkState
+        #endif
     }
 
     // MARK: Public
@@ -96,4 +155,13 @@ public enum AyahMenuUI {
         case partiallyHighlighted
         case highlighted(HighlightColor)
     }
+
+    #if QURAN_SYNC
+    public enum ReadingBookmarkState {
+        case disabled(message: String)
+        case unset
+        case elsewhere(location: MultipartText)
+        case current
+    }
+    #endif
 }

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -7,6 +7,7 @@
 //
 
 import Localization
+import QuranAnnotations
 import SwiftUI
 import UIx
 
@@ -74,7 +75,7 @@ private struct AyahMenuViewList: View {
             MenuGroup {
                 Row(
                     title: lAndroid("play"),
-                    subtitle: dataObject.playSubtitle,
+                    subtitle: .text(dataObject.playSubtitle),
                     action: dataObject.actions.play
                 ) {
                     NoorSystemImage.play.image
@@ -82,7 +83,7 @@ private struct AyahMenuViewList: View {
                 Divider()
                 Row(
                     title: l("ayah.menu.repeat"),
-                    subtitle: dataObject.repeatSubtitle,
+                    subtitle: .text(dataObject.repeatSubtitle),
                     action: dataObject.actions.repeatVerses
                 ) {
                     Image(systemName: "repeat")
@@ -92,6 +93,13 @@ private struct AyahMenuViewList: View {
 
             MenuGroup {
                 Divider()
+
+                #if QURAN_SYNC
+                readingBookmarkRow(dataObject.readingBookmarkState)
+                Divider()
+                    .padding(.leading)
+                #endif
+
                 Row(title: dataObject.bookmarkTitle, action: dataObject.actions.bookmark) {
                     bookmarkIcon
                 }
@@ -152,6 +160,56 @@ private struct AyahMenuViewList: View {
         }
     }
 
+    #if QURAN_SYNC
+    @ViewBuilder
+    private func readingBookmarkRow(_ state: AyahMenuUI.ReadingBookmarkState) -> some View {
+        switch state {
+        case .disabled(let message):
+            Row(
+                title: l("ayah.menu.reading-bookmark.title"),
+                subtitle: .text(message),
+                subtitlePlacement: .below,
+                isEnabled: false,
+                action: dataObject.actions.moveReadingBookmark
+            ) {
+                ReadingBookmarkPin(style: .outline)
+            }
+        case .unset:
+            Row(
+                title: l("ayah.menu.reading-bookmark.title"),
+                subtitle: .text(l("ayah.menu.reading-bookmark.save-here")),
+                subtitlePlacement: .below,
+                action: dataObject.actions.moveReadingBookmark
+            ) {
+                ReadingBookmarkPin(style: .outline)
+            }
+        case .elsewhere(let location):
+            Row(
+                title: l("ayah.menu.reading-bookmark.title"),
+                subtitle: location,
+                subtitlePlacement: .below,
+                action: dataObject.actions.moveReadingBookmark
+            ) {
+                ReadingBookmarkPin(style: .outline)
+            }
+        case .current:
+            Row(
+                title: l("ayah.menu.reading-bookmark.title"),
+                subtitle: .text(l("ayah.menu.reading-bookmark.saved-here")),
+                subtitlePlacement: .below,
+                action: dataObject.actions.deleteReadingBookmark
+            ) {
+                ReadingBookmarkPin(style: .filled)
+                    .foregroundColor(.appIdentity)
+            } accessory: {
+                NoorSystemImage.checkmark.image
+                    .foregroundColor(.appIdentity)
+            }
+        }
+    }
+
+    #endif
+
     private func noteIcon(legacySystemName: String) -> some View {
         Group {
             if dataObject.usesSyncedNotesIcon {
@@ -165,11 +223,18 @@ private struct AyahMenuViewList: View {
 }
 
 private struct Row<Symbol: View, Accessory: View>: View {
+    enum SubtitlePlacement {
+        case inline
+        case below
+    }
+
     // MARK: Lifecycle
 
     init(
         title: String,
-        subtitle: String? = nil,
+        subtitle: MultipartText? = nil,
+        subtitlePlacement: SubtitlePlacement = .inline,
+        isEnabled: Bool = true,
         action: @Sendable @escaping () async -> Void,
         @ViewBuilder symbol: () -> Symbol
     ) where Accessory == EmptyView {
@@ -177,13 +242,17 @@ private struct Row<Symbol: View, Accessory: View>: View {
         accessory = EmptyView()
         self.title = title
         self.subtitle = subtitle
+        self.subtitlePlacement = subtitlePlacement
+        self.isEnabled = isEnabled
         self.action = action
         hasAccessory = false
     }
 
     init(
         title: String,
-        subtitle: String? = nil,
+        subtitle: MultipartText? = nil,
+        subtitlePlacement: SubtitlePlacement = .inline,
+        isEnabled: Bool = true,
         action: @Sendable @escaping () async -> Void,
         @ViewBuilder symbol: () -> Symbol,
         @ViewBuilder accessory: () -> Accessory
@@ -192,6 +261,8 @@ private struct Row<Symbol: View, Accessory: View>: View {
         self.accessory = accessory()
         self.title = title
         self.subtitle = subtitle
+        self.subtitlePlacement = subtitlePlacement
+        self.isEnabled = isEnabled
         self.action = action
         hasAccessory = true
     }
@@ -201,7 +272,9 @@ private struct Row<Symbol: View, Accessory: View>: View {
     let symbol: Symbol
     let accessory: Accessory
     let title: String
-    let subtitle: String?
+    let subtitle: MultipartText?
+    let subtitlePlacement: SubtitlePlacement
+    let isEnabled: Bool
     let action: @Sendable () async -> Void
     let hasAccessory: Bool
     @ScaledMetric var verticalPadding = 12
@@ -213,20 +286,9 @@ private struct Row<Symbol: View, Accessory: View>: View {
                     HighlightPaletteIcon()
                         .hidden()
                     symbol
-                        .foregroundColor(Color.label)
+                        .foregroundColor(primaryColor)
                 }
-                HStack(spacing: 0) {
-                    Text(title)
-                        .foregroundColor(Color.label)
-                    if let subtitle {
-                        Group {
-                            Text(" ")
-                            Text(subtitle)
-                        }
-                        .font(.footnote)
-                        .foregroundColor(.secondaryLabel)
-                    }
-                }
+                label
                 if hasAccessory {
                     Spacer(minLength: 12)
                     accessory
@@ -238,6 +300,41 @@ private struct Row<Symbol: View, Accessory: View>: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(BackgroundHighlightingStyle())
+        .disabled(!isEnabled)
+    }
+
+    // MARK: Private
+
+    private var primaryColor: Color {
+        isEnabled ? .label : .tertiaryLabel
+    }
+
+    private var secondaryColor: Color {
+        isEnabled ? .secondaryLabel : .tertiaryLabel
+    }
+
+    @ViewBuilder private var label: some View {
+        switch subtitlePlacement {
+        case .inline:
+            HStack(spacing: 0) {
+                Text(title)
+                    .foregroundColor(primaryColor)
+                if let subtitle {
+                    Text(" ")
+                    subtitle.view(ofSize: .footnote)
+                        .foregroundColor(secondaryColor)
+                }
+            }
+        case .below:
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .foregroundColor(primaryColor)
+                if let subtitle {
+                    subtitle.view(ofSize: .footnote)
+                        .foregroundColor(secondaryColor)
+                }
+            }
+        }
     }
 }
 
@@ -255,6 +352,20 @@ private struct MenuGroup<Content: View>: View {
 }
 
 struct AyahMenuView_Previews: PreviewProvider {
+    #if QURAN_SYNC
+    static let actions = AyahMenuUI.Actions(
+        play: {},
+        repeatVerses: {},
+        bookmark: {},
+        addNote: {},
+        deleteNote: {},
+        showTranslation: {},
+        copy: {},
+        share: {},
+        moveReadingBookmark: {},
+        deleteReadingBookmark: {}
+    )
+    #else
     static let actions = AyahMenuUI.Actions(
         play: {},
         repeatVerses: {},
@@ -265,19 +376,17 @@ struct AyahMenuView_Previews: PreviewProvider {
         copy: {},
         share: {}
     )
+    #endif
 
     static var previews: some View {
         Group {
             VStack {
                 Spacer()
-                AyahMenuView(dataObject: AyahMenuUI.DataObject(
+                AyahMenuView(dataObject: dataObject(
                     highlightingColor: .green,
                     state: .noted,
                     bookmarkTitle: "Save Ayah...",
                     bookmarkState: .highlighted(.green),
-                    playSubtitle: "To the end of Juz'",
-                    repeatSubtitle: "selected verses",
-                    actions: actions,
                     isTranslationView: true
                 ))
                 Spacer()
@@ -286,14 +395,11 @@ struct AyahMenuView_Previews: PreviewProvider {
 
             VStack {
                 Spacer()
-                AyahMenuView(dataObject: AyahMenuUI.DataObject(
+                AyahMenuView(dataObject: dataObject(
                     highlightingColor: .red,
                     state: .highlighted,
                     bookmarkTitle: "Save Ayahs...",
                     bookmarkState: .partiallyHighlighted,
-                    playSubtitle: "To the end of Juz'",
-                    repeatSubtitle: "selected verses",
-                    actions: actions,
                     isTranslationView: true
                 ))
                 Spacer()
@@ -303,14 +409,11 @@ struct AyahMenuView_Previews: PreviewProvider {
 
             VStack {
                 Spacer()
-                AyahMenuView(dataObject: AyahMenuUI.DataObject(
+                AyahMenuView(dataObject: dataObject(
                     highlightingColor: .green,
                     state: .noHighlight,
                     bookmarkTitle: "Save Ayah...",
                     bookmarkState: .unhighlighted,
-                    playSubtitle: "To the end of Juz'",
-                    repeatSubtitle: "selected verses",
-                    actions: actions,
                     isTranslationView: true
                 ))
                 Spacer()
@@ -319,5 +422,38 @@ struct AyahMenuView_Previews: PreviewProvider {
             .environment(\.sizeCategory, .extraExtraExtraLarge)
         }
         .previewLayout(.fixed(width: 320, height: 470))
+    }
+
+    private static func dataObject(
+        highlightingColor: HighlightColor,
+        state: AyahMenuUI.NoteState,
+        bookmarkTitle: String,
+        bookmarkState: AyahMenuUI.BookmarkState,
+        isTranslationView: Bool
+    ) -> AyahMenuUI.DataObject {
+        #if QURAN_SYNC
+        AyahMenuUI.DataObject(
+            highlightingColor: highlightingColor,
+            state: state,
+            bookmarkTitle: bookmarkTitle,
+            bookmarkState: bookmarkState,
+            playSubtitle: "To the end of Juz'",
+            repeatSubtitle: "selected verses",
+            actions: actions,
+            isTranslationView: isTranslationView,
+            readingBookmarkState: .unset
+        )
+        #else
+        AyahMenuUI.DataObject(
+            highlightingColor: highlightingColor,
+            state: state,
+            bookmarkTitle: bookmarkTitle,
+            bookmarkState: bookmarkState,
+            playSubtitle: "To the end of Juz'",
+            repeatSubtitle: "selected verses",
+            actions: actions,
+            isTranslationView: isTranslationView
+        )
+        #endif
     }
 }

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -200,7 +200,7 @@ private struct AyahMenuViewList: View {
                 action: dataObject.actions.deleteReadingBookmark
             ) {
                 ReadingBookmarkPin(style: .filled)
-                    .foregroundColor(.appIdentity)
+                    .foregroundColor(.label)
             } accessory: {
                 NoorSystemImage.checkmark.image
                     .foregroundColor(.appIdentity)

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -321,7 +321,7 @@ private struct Row<Symbol: View, Accessory: View>: View {
                     .foregroundColor(primaryColor)
                 if let subtitle {
                     Text(" ")
-                    subtitle.view(ofSize: .footnote)
+                    subtitle.view(ofSize: .footnote, allowsWrapping: false)
                         .foregroundColor(secondaryColor)
                         .lineLimit(1)
                         .truncationMode(.tail)
@@ -332,7 +332,7 @@ private struct Row<Symbol: View, Accessory: View>: View {
                 Text(title)
                     .foregroundColor(primaryColor)
                 if let subtitle {
-                    subtitle.view(ofSize: .footnote)
+                    subtitle.view(ofSize: .footnote, allowsWrapping: false)
                         .foregroundColor(secondaryColor)
                         .lineLimit(1)
                         .truncationMode(.tail)

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -323,6 +323,8 @@ private struct Row<Symbol: View, Accessory: View>: View {
                     Text(" ")
                     subtitle.view(ofSize: .footnote)
                         .foregroundColor(secondaryColor)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                 }
             }
         case .below:
@@ -332,6 +334,8 @@ private struct Row<Symbol: View, Accessory: View>: View {
                 if let subtitle {
                     subtitle.view(ofSize: .footnote)
                         .foregroundColor(secondaryColor)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                 }
             }
         }

--- a/UI/NoorUI/Tests/MultipartTextLayoutTests.swift
+++ b/UI/NoorUI/Tests/MultipartTextLayoutTests.swift
@@ -1,0 +1,42 @@
+//
+//  MultipartTextLayoutTests.swift
+//
+//
+//  Created by Mohamed Afifi on 2026-07-20.
+//
+
+import SwiftUI
+import UIKit
+import XCTest
+@testable import NoorUI
+
+final class MultipartTextLayoutTests: XCTestCase {
+    func test_view_whenWrappingIsDisabled_keepsMultipartContentOnOneLine() async {
+        guard #available(iOS 16.0, *) else { return }
+
+        let heights = await MainActor.run {
+            let text: MultipartText = "At An-Nahl 16:30 \(sura: "النحل") • Move here"
+
+            let wrappingHeight = fittingHeight(
+                text.view(ofSize: .footnote)
+                    .lineLimit(1)
+            )
+            let singleLineHeight = fittingHeight(
+                text.view(ofSize: .footnote, allowsWrapping: false)
+            )
+
+            return (wrappingHeight, singleLineHeight)
+        }
+
+        XCTAssertLessThan(heights.1, heights.0)
+    }
+
+    @MainActor
+    private func fittingHeight(_ content: some View) -> CGFloat {
+        let width: CGFloat = 120
+        let controller = UIHostingController(rootView: content.frame(width: width, alignment: .leading))
+        return controller.sizeThatFits(
+            in: CGSize(width: width, height: .greatestFiniteMagnitude)
+        ).height
+    }
+}


### PR DESCRIPTION
## Summary

- add `ReadingPositionBookmark` to `QuranAnnotations`
- add MobileSync persistence for ayah and page reading bookmark locations
- add explicit reading bookmark move and delete actions to the Ayah menu
- show location-aware confirmation for first-time saves and Undo toasts for moves and deletions
- keep reading bookmark UI APIs absent from no-sync builds and required in sync builds

## Why

Reading position bookmarks need a single model and persistence API that supports both ayah and page locations. Explicit move/delete flows also make the UI behavior and Undo semantics clearer than toggling.

## User impact

Users can save, move, and delete their reading position from the Ayah menu. First-time saves receive confirmation without an Undo button; moves and deletions include location details and an Undo action.

## Validation

- `make format-lint`
- `make test-sync`
- `make test-no-sync`


### Screenshots

<img width="306" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-20 at 13 31 35" src="https://github.com/user-attachments/assets/1c91970d-b5d8-46e4-b225-e2d7c6027d4d" />

<img width="306" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-20 at 13 38 49" src="https://github.com/user-attachments/assets/dcd2104d-300b-408f-95a2-39c368b3db1a" />


<img width="306" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-20 at 13 30 20" src="https://github.com/user-attachments/assets/1345b88e-d103-4320-ac0a-4787a8df0f41" />
