### PR TITLE
feat: add synced page reading bookmarks

### DIFF
--- a/Features/AyahMenuFeature/Sources/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/Sources/AyahMenuViewController.swift
@@ -45,8 +45,8 @@ final class AyahMenuViewController: UIViewController {
             showTranslation: { [weak self] in self?.viewModel.showTranslation() },
             copy: { [weak self] in self?.viewModel.copy() },
             share: { [weak self] in self?.viewModel.share() },
-            moveReadingBookmark: { [weak self] in await self?.viewModel.moveReadingBookmark() },
-            deleteReadingBookmark: { [weak self] in await self?.viewModel.deleteReadingBookmark() }
+            setReadingBookmark: { [weak self] in await self?.viewModel.setReadingBookmark() },
+            removeReadingBookmark: { [weak self] in await self?.viewModel.removeReadingBookmark() }
         )
         #else
         let actions = AyahMenuUI.Actions(

--- a/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
@@ -30,8 +30,8 @@ public protocol AyahMenuListener: AnyObject {
     func showNoteEditor(for verses: [AyahNumber]) async
     func deleteNotes(in verses: [AyahNumber]) async
     #if QURAN_SYNC
-    func moveReadingBookmark(to ayah: AyahNumber, from bookmark: ReadingPositionBookmark?) async
-    func deleteReadingBookmark(_ bookmark: ReadingPositionBookmark) async
+    func setReadingBookmark(at ayah: AyahNumber, replacing bookmark: ReadingPositionBookmark?) async
+    func removeReadingBookmark(_ bookmark: ReadingPositionBookmark) async
     #endif
 }
 
@@ -173,15 +173,15 @@ final class AyahMenuViewModel {
     }
 
     #if QURAN_SYNC
-    func moveReadingBookmark() async {
+    func setReadingBookmark() async {
         guard deps.verses.count == 1, let ayah = deps.verses.first else {
             return
         }
-        logger.info("AyahMenu: move reading bookmark. Ayah: \(ayah)")
-        await listener?.moveReadingBookmark(to: ayah, from: deps.readingBookmark)
+        logger.info("AyahMenu: set reading bookmark. Ayah: \(ayah)")
+        await listener?.setReadingBookmark(at: ayah, replacing: deps.readingBookmark)
     }
 
-    func deleteReadingBookmark() async {
+    func removeReadingBookmark() async {
         guard deps.verses.count == 1,
               let ayah = deps.verses.first,
               let readingBookmark = deps.readingBookmark,
@@ -189,8 +189,8 @@ final class AyahMenuViewModel {
         else {
             return
         }
-        logger.info("AyahMenu: delete reading bookmark. Bookmark: \(readingBookmark)")
-        await listener?.deleteReadingBookmark(readingBookmark)
+        logger.info("AyahMenu: remove reading bookmark. Bookmark: \(readingBookmark)")
+        await listener?.removeReadingBookmark(readingBookmark)
     }
     #endif
 

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -123,41 +123,41 @@ final class AyahMenuViewModelTests: XCTestCase {
         }
     }
 
-    func test_moveReadingBookmark_requestsMoveWithoutPreviousBookmark() async {
+    func test_setReadingBookmark_requestsSetWithoutPreviousBookmark() async {
         let selected = verses[0]
         let sut = makeSUT(verses: [selected])
         let listener = BookmarkListenerSpy()
         sut.listener = listener
 
-        await sut.moveReadingBookmark()
+        await sut.setReadingBookmark()
 
-        XCTAssertEqual(listener.readingBookmarkMove?.to, selected)
-        XCTAssertNil(listener.readingBookmarkMove?.from)
+        XCTAssertEqual(listener.readingBookmarkSet?.ayah, selected)
+        XCTAssertNil(listener.readingBookmarkSet?.replacedBookmark)
     }
 
-    func test_moveReadingBookmark_requestsMoveFromPreviousBookmark() async {
+    func test_setReadingBookmark_requestsReplacementOfPreviousBookmark() async {
         let selected = verses[0]
         let previousBookmark = readingBookmark(at: .ayah(verses[1]))
         let sut = makeSUT(verses: [selected], readingBookmark: previousBookmark)
         let listener = BookmarkListenerSpy()
         sut.listener = listener
 
-        await sut.moveReadingBookmark()
+        await sut.setReadingBookmark()
 
-        XCTAssertEqual(listener.readingBookmarkMove?.to, selected)
-        XCTAssertEqual(listener.readingBookmarkMove?.from, previousBookmark)
+        XCTAssertEqual(listener.readingBookmarkSet?.ayah, selected)
+        XCTAssertEqual(listener.readingBookmarkSet?.replacedBookmark, previousBookmark)
     }
 
-    func test_deleteReadingBookmark_requestsDeletionOfCurrentBookmark() async {
+    func test_removeReadingBookmark_requestsRemovalOfCurrentBookmark() async {
         let selected = verses[0]
         let bookmark = readingBookmark(at: .ayah(selected))
         let sut = makeSUT(verses: [selected], readingBookmark: bookmark)
         let listener = BookmarkListenerSpy()
         sut.listener = listener
 
-        await sut.deleteReadingBookmark()
+        await sut.removeReadingBookmark()
 
-        XCTAssertEqual(listener.deletedReadingBookmark, bookmark)
+        XCTAssertEqual(listener.removedReadingBookmark, bookmark)
     }
 
     private var verses: [AyahNumber] {
@@ -197,8 +197,8 @@ final class AyahMenuViewModelTests: XCTestCase {
 @MainActor
 private final class BookmarkListenerSpy: AyahMenuListener {
     private(set) var bookmarkedVerses: [AyahNumber]?
-    private(set) var readingBookmarkMove: (to: AyahNumber, from: ReadingPositionBookmark?)?
-    private(set) var deletedReadingBookmark: ReadingPositionBookmark?
+    private(set) var readingBookmarkSet: (ayah: AyahNumber, replacedBookmark: ReadingPositionBookmark?)?
+    private(set) var removedReadingBookmark: ReadingPositionBookmark?
 
     func dismissAyahMenu() {}
     func playAudio(_ from: AyahNumber, to: AyahNumber?, repeatVerses: Bool) {}
@@ -207,12 +207,12 @@ private final class BookmarkListenerSpy: AyahMenuListener {
     func showNoteEditor(for verses: [AyahNumber]) async {}
     func deleteNotes(in verses: [AyahNumber]) async {}
 
-    func moveReadingBookmark(to ayah: AyahNumber, from bookmark: ReadingPositionBookmark?) async {
-        readingBookmarkMove = (ayah, bookmark)
+    func setReadingBookmark(at ayah: AyahNumber, replacing bookmark: ReadingPositionBookmark?) async {
+        readingBookmarkSet = (ayah, bookmark)
     }
 
-    func deleteReadingBookmark(_ bookmark: ReadingPositionBookmark) async {
-        deletedReadingBookmark = bookmark
+    func removeReadingBookmark(_ bookmark: ReadingPositionBookmark) async {
+        removedReadingBookmark = bookmark
     }
 
     func showBookmarkEditor(for verses: [AyahNumber]) {

--- a/Features/QuranViewFeature/Sources/QuranBuilder.swift
+++ b/Features/QuranViewFeature/Sources/QuranBuilder.swift
@@ -35,7 +35,6 @@ public struct QuranBuilder {
         let highlightsService = QuranHighlightsService()
 
         let quran = ReadingPreferences.shared.reading.quran
-        let pageBookmarkService = PageBookmarkService(persistence: container.pageBookmarkPersistence)
         #if QURAN_SYNC
         let notesObserver = QuranNotesObserver(noteService: container.mobileSyncNoteService(), quran: quran)
         let syncedHighlightsObserver = QuranSyncedHighlightsObserver(
@@ -48,8 +47,6 @@ public struct QuranBuilder {
         )
         let interactorDeps = QuranInteractor.Deps(
             quran: quran,
-            analytics: container.analytics,
-            pageBookmarkService: pageBookmarkService,
             highlightsService: highlightsService,
             ayahMenuBuilder: AyahMenuBuilder(container: container),
             bookmarkAyahsBuilder: BookmarkAyahsBuilder(container: container),
@@ -66,12 +63,11 @@ public struct QuranBuilder {
             readingBookmarkObserver: readingBookmarkObserver
         )
         #else
+        let pageBookmarkService = PageBookmarkService(persistence: container.pageBookmarkPersistence)
         let noteService = container.noteService()
         let notesObserver = QuranNotesObserver(noteService: noteService, quran: quran)
         let interactorDeps = QuranInteractor.Deps(
             quran: quran,
-            analytics: container.analytics,
-            pageBookmarkService: pageBookmarkService,
             highlightsService: highlightsService,
             ayahMenuBuilder: AyahMenuBuilder(container: container),
             bookmarkAyahsBuilder: BookmarkAyahsBuilder(container: container),
@@ -84,6 +80,8 @@ public struct QuranBuilder {
             resources: container.readingResources,
             notesObserver: notesObserver,
             noteEditorBuilder: NoteEditorBuilder(container: container),
+            analytics: container.analytics,
+            pageBookmarkService: pageBookmarkService,
             noteService: noteService
         )
         #endif

--- a/Features/QuranViewFeature/Sources/QuranInteractor.swift
+++ b/Features/QuranViewFeature/Sources/QuranInteractor.swift
@@ -63,8 +63,6 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 {
     struct Deps {
         let quran: Quran
-        let analytics: AnalyticsLibrary
-        let pageBookmarkService: PageBookmarkService
         let highlightsService: QuranHighlightsService
         let ayahMenuBuilder: AyahMenuBuilder
         let bookmarkAyahsBuilder: BookmarkAyahsBuilder
@@ -81,6 +79,8 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let syncedHighlightsObserver: QuranSyncedHighlightsObserver
         let readingBookmarkObserver: QuranReadingBookmarkObserver
         #else
+        let analytics: AnalyticsLibrary
+        let pageBookmarkService: PageBookmarkService
         let noteService: NoteService
         #endif
     }
@@ -113,13 +113,16 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         deps.notesObserver.start()
         #if QURAN_SYNC
         deps.syncedHighlightsObserver.start()
+        deps.readingBookmarkObserver.$bookmark
+            .sink { [weak self] _ in self?.reloadPageBookmark() }
+            .store(in: &cancellables)
         deps.readingBookmarkObserver.start()
-        #endif
-
+        #else
         deps.pageBookmarkService.pageBookmarks(quran: deps.quran)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in self?.pageBookmarks = $0 }
             .store(in: &cancellables)
+        #endif
 
         contentStatePreferences.$quranMode
             .sink { [weak self] _ in self?.onQuranModeUpdated() }
@@ -280,40 +283,17 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     }
 
     #if QURAN_SYNC
-    func moveReadingBookmark(to ayah: AyahNumber, from previousBookmark: ReadingPositionBookmark?) async {
-        do {
-            let movedBookmark = try await deps.readingBookmarkObserver.add(at: .ayah(ayah))
+    func setReadingBookmark(at ayah: AyahNumber, replacing previousBookmark: ReadingPositionBookmark?) async {
+        if await performReadingBookmarkAction(
+            .set(location: .ayah(ayah), replacing: previousBookmark)
+        ) {
             dismissAyahMenu()
-            if let previousBookmark {
-                presenter?.showToast(
-                    ReadingBookmarkUndoToast.moved(from: previousBookmark, to: movedBookmark) { [weak self] in
-                        self?.undoReadingBookmarkMove(movedBookmark, to: previousBookmark)
-                    }
-                )
-            } else {
-                presenter?.showToast(ReadingBookmarkUndoToast.saved(movedBookmark))
-            }
-        } catch {
-            crasher.recordError(error, reason: "Failed to move reading bookmark")
         }
     }
 
-    func deleteReadingBookmark(_ bookmark: ReadingPositionBookmark) async {
-        do {
-            let observer = deps.readingBookmarkObserver
-            guard observer.bookmark == bookmark,
-                  let deletedBookmark = try await observer.remove()
-            else {
-                return
-            }
+    func removeReadingBookmark(_ bookmark: ReadingPositionBookmark) async {
+        if await performReadingBookmarkAction(.remove(bookmark)) {
             dismissAyahMenu()
-            presenter?.showToast(
-                ReadingBookmarkUndoToast.removed(deletedBookmark) { [weak self] in
-                    self?.addReadingBookmark(at: deletedBookmark.location)
-                }
-            )
-        } catch {
-            crasher.recordError(error, reason: "Failed to delete reading bookmark")
         }
     }
     #endif
@@ -383,12 +363,49 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     }
 
     #if QURAN_SYNC
-    private func addReadingBookmark(at location: ReadingPositionBookmark.Location) {
+    private func performReadingBookmarkAction(_ action: ReadingBookmarkAction) async -> Bool {
+        do {
+            switch action {
+            case .set(let location, let previousBookmark):
+                let bookmark = try await deps.readingBookmarkObserver.add(at: location)
+                if let previousBookmark {
+                    presenter?.showToast(
+                        ReadingBookmarkUndoToast.moved(from: previousBookmark, to: bookmark) { [weak self] in
+                            self?.undoReadingBookmarkMove(bookmark, to: previousBookmark)
+                        }
+                    )
+                } else {
+                    presenter?.showToast(ReadingBookmarkUndoToast.saved(bookmark))
+                }
+            case .remove(let bookmark):
+                let observer = deps.readingBookmarkObserver
+                guard observer.bookmark == bookmark,
+                      let removedBookmark = try await observer.remove()
+                else {
+                    return false
+                }
+                presenter?.showToast(
+                    ReadingBookmarkUndoToast.removed(removedBookmark) { [weak self] in
+                        self?.undoReadingBookmarkRemoval(removedBookmark)
+                    }
+                )
+            }
+            return true
+        } catch {
+            crasher.recordError(error, reason: "Failed to update reading bookmark")
+            return false
+        }
+    }
+
+    private func undoReadingBookmarkRemoval(_ deletedBookmark: ReadingPositionBookmark) {
         Task {
+            guard deps.readingBookmarkObserver.bookmark == nil else {
+                return
+            }
             do {
-                try await deps.readingBookmarkObserver.add(at: location)
+                try await deps.readingBookmarkObserver.add(at: deletedBookmark.location)
             } catch {
-                crasher.recordError(error, reason: "Failed to undo reading bookmark change")
+                crasher.recordError(error, reason: "Failed to undo reading bookmark removal")
             }
         }
     }
@@ -442,6 +459,15 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
     func toogleBookmark() async {
         logger.info("Quran: onBookmarkBarButtonTapped")
+        #if QURAN_SYNC
+        guard let action = ReadingBookmarkAction.page(
+            visiblePages: visiblePages,
+            bookmark: deps.readingBookmarkObserver.bookmark
+        ) else {
+            return
+        }
+        _ = await performReadingBookmarkAction(action)
+        #else
         let pages = visiblePages
         let wasBookmarked = bookmarked(pages)
 
@@ -465,6 +491,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         } catch {
             crasher.recordError(error, reason: "Failed to toggle page bookmark")
         }
+        #endif
     }
 
     // MARK: Private
@@ -491,11 +518,13 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         }
     }
 
+    #if !QURAN_SYNC
     private var pageBookmarks: [PageBookmark] = [] {
         didSet {
             reloadPageBookmark()
         }
     }
+    #endif
 
     private func setVisiblePages(_ pages: [Page]) {
         logger.info("Quran: set visible pages \(pages)")
@@ -597,8 +626,18 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     }
 
     private func bookmarked(_ pages: [Page]) -> Bool {
+        #if QURAN_SYNC
+        guard case .remove = ReadingBookmarkAction.page(
+            visiblePages: pages,
+            bookmark: deps.readingBookmarkObserver.bookmark
+        ) else {
+            return false
+        }
+        return true
+        #else
         let visibleBookmarks = pageBookmarks.filter { pages.contains($0.page) }
         return !visibleBookmarks.isEmpty
+        #endif
     }
 
     private func showPageBookmarkIfNeeded(for pages: [Page]) {

--- a/Features/QuranViewFeature/Sources/QuranReadingBookmarkObserver.swift
+++ b/Features/QuranViewFeature/Sources/QuranReadingBookmarkObserver.swift
@@ -4,6 +4,7 @@
 //
 
 import AnnotationsService
+import Combine
 import QuranAnnotations
 import QuranKit
 import VLogging
@@ -23,7 +24,7 @@ final class QuranReadingBookmarkObserver {
 
     // MARK: Internal
 
-    private(set) var bookmark: ReadingPositionBookmark?
+    @Published private(set) var bookmark: ReadingPositionBookmark?
 
     func start() {
         guard task == nil else {

--- a/Features/QuranViewFeature/Sources/QuranViewController.swift
+++ b/Features/QuranViewFeature/Sources/QuranViewController.swift
@@ -383,11 +383,21 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
     }
 
     private func updateRightBarItems(animated: Bool, isBookmarked: Bool) {
+        #if QURAN_SYNC
+        let style: ReadingBookmarkPin.Style = isBookmarked ? .filled : .outline
+        let bookmarkImage = ReadingBookmarkPin.image(style: style)
+        let bookmark = UIBarButtonItem(image: bookmarkImage, style: .plain, target: self, action: #selector(onBookmarkButtonTapped))
+        bookmark.accessibilityLabel = l("ayah.menu.reading-bookmark.title")
+        bookmark.accessibilityValue = l(isBookmarked
+            ? "ayah.menu.reading-bookmark.saved-here"
+            : "ayah.menu.reading-bookmark.save-here")
+        #else
         let bookmarkImage = UIImage.symbol(isBookmarked ? "bookmark.fill" : "bookmark")
         let bookmark = UIBarButtonItem(image: bookmarkImage, style: .plain, target: self, action: #selector(onBookmarkButtonTapped))
         if isBookmarked {
             bookmark.tintColor = .systemRed
         }
+        #endif
 
         quranView?.navigationItem.setRightBarButtonItems([moreNavigationButton, bookmark], animated: animated)
     }

--- a/Features/QuranViewFeature/Sources/ReadingBookmarkAction.swift
+++ b/Features/QuranViewFeature/Sources/ReadingBookmarkAction.swift
@@ -1,0 +1,32 @@
+#if QURAN_SYNC
+//
+//  ReadingBookmarkAction.swift
+//
+
+import QuranAnnotations
+import QuranKit
+
+enum ReadingBookmarkAction: Equatable {
+    case set(
+        location: ReadingPositionBookmark.Location,
+        replacing: ReadingPositionBookmark?
+    )
+    case remove(ReadingPositionBookmark)
+
+    static func page(
+        visiblePages: [Page],
+        bookmark: ReadingPositionBookmark?
+    ) -> ReadingBookmarkAction? {
+        guard let targetPage = visiblePages.min() else {
+            return nil
+        }
+        if let bookmark,
+           case .page(let page) = bookmark.location,
+           page == targetPage
+        {
+            return .remove(bookmark)
+        }
+        return .set(location: .page(targetPage), replacing: bookmark)
+    }
+}
+#endif

--- a/Features/QuranViewFeature/Tests/QuranReadingBookmarkObserverTests.swift
+++ b/Features/QuranViewFeature/Tests/QuranReadingBookmarkObserverTests.swift
@@ -1,0 +1,61 @@
+#if QURAN_SYNC
+import AnnotationsService
+import Combine
+import MobileSyncTestSupport
+import QuranAnnotations
+import QuranKit
+import XCTest
+@testable import QuranViewFeature
+
+@MainActor
+final class QuranReadingBookmarkObserverTests: XCTestCase {
+    private let database = MobileSyncTestDatabase.shared
+    private var service: MobileSyncReadingBookmarkService!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+        service = MobileSyncReadingBookmarkService(quranDataService: database.quranDataService)
+    }
+
+    override func tearDown() async throws {
+        try await database.reset()
+        service = nil
+        try await super.tearDown()
+    }
+
+    func test_start_publishesPersistedPageBookmark() async throws {
+        let page = Quran.hafsMadani1405.pages[40]
+        try await service.addReadingBookmark(at: .page(page))
+        let sut = QuranReadingBookmarkObserver(service: service, quran: .hafsMadani1405)
+        let observed = expectation(description: "Publishes persisted page bookmark")
+        let observation = sut.$bookmark.sink { bookmark in
+            if bookmark?.location == .page(page) {
+                observed.fulfill()
+            }
+        }
+
+        sut.start()
+        await fulfillment(of: [observed], timeout: 2)
+
+        XCTAssertEqual(sut.bookmark?.location, .page(page))
+        observation.cancel()
+        withExtendedLifetime(sut) {}
+    }
+
+    func test_addAndRemove_publishLocalPageBookmarkChanges() async throws {
+        let page = Quran.hafsMadani1405.pages[40]
+        let sut = QuranReadingBookmarkObserver(service: service, quran: .hafsMadani1405)
+        var observedLocations: [ReadingPositionBookmark.Location?] = []
+        let observation = sut.$bookmark.sink { observedLocations.append($0?.location) }
+
+        let added = try await sut.add(at: .page(page))
+        let removed = try await sut.remove()
+
+        XCTAssertEqual(added.location, .page(page))
+        XCTAssertEqual(removed?.location, .page(page))
+        XCTAssertEqual(observedLocations, [nil, .page(page), nil])
+        observation.cancel()
+    }
+}
+#endif

--- a/Features/QuranViewFeature/Tests/ReadingBookmarkActionTests.swift
+++ b/Features/QuranViewFeature/Tests/ReadingBookmarkActionTests.swift
@@ -1,0 +1,59 @@
+#if QURAN_SYNC
+import Foundation
+import QuranAnnotations
+import QuranKit
+import XCTest
+@testable import QuranViewFeature
+
+final class ReadingBookmarkActionTests: XCTestCase {
+    private let quran = Quran.hafsMadani1405
+
+    func test_emptyVisiblePages_hasNoAction() {
+        XCTAssertNil(ReadingBookmarkAction.page(visiblePages: [], bookmark: nil))
+    }
+
+    func test_noBookmark_setsBookmarkOnLowerVisiblePage() {
+        let lowerPage = quran.pages[40]
+        let upperPage = quran.pages[41]
+
+        let action = ReadingBookmarkAction.page(
+            visiblePages: [upperPage, lowerPage],
+            bookmark: nil
+        )
+
+        XCTAssertEqual(action, .set(location: .page(lowerPage), replacing: nil))
+    }
+
+    func test_exactPageBookmark_removesBookmark() {
+        let page = quran.pages[40]
+        let bookmark = bookmark(at: .page(page))
+
+        let action = ReadingBookmarkAction.page(visiblePages: [page], bookmark: bookmark)
+
+        XCTAssertEqual(action, .remove(bookmark))
+    }
+
+    func test_differentPageBookmark_replacesBookmark() {
+        let currentPage = quran.pages[40]
+        let targetPage = quran.pages[41]
+        let bookmark = bookmark(at: .page(currentPage))
+
+        let action = ReadingBookmarkAction.page(visiblePages: [targetPage], bookmark: bookmark)
+
+        XCTAssertEqual(action, .set(location: .page(targetPage), replacing: bookmark))
+    }
+
+    func test_ayahBookmarkOnTargetPage_replacesBookmarkWithPage() {
+        let page = quran.pages[40]
+        let bookmark = bookmark(at: .ayah(page.firstVerse))
+
+        let action = ReadingBookmarkAction.page(visiblePages: [page], bookmark: bookmark)
+
+        XCTAssertEqual(action, .set(location: .page(page), replacing: bookmark))
+    }
+
+    private func bookmark(at location: ReadingPositionBookmark.Location) -> ReadingPositionBookmark {
+        ReadingPositionBookmark(id: "reading-bookmark", location: location, modifiedOn: .distantPast)
+    }
+}
+#endif

--- a/Features/QuranViewFeature/Tests/ReadingBookmarkUndoToastTests.swift
+++ b/Features/QuranViewFeature/Tests/ReadingBookmarkUndoToastTests.swift
@@ -15,6 +15,15 @@ final class ReadingBookmarkUndoToastTests: XCTestCase {
         XCTAssertNil(toast.action)
     }
 
+    func test_savedPage_describesPageWithoutAction() {
+        let bookmark = bookmark(at: .page(ayah(255).page))
+
+        let toast = ReadingBookmarkUndoToast.saved(bookmark)
+
+        XCTAssertEqual(toast.message, "Reading bookmark saved at Page 42")
+        XCTAssertNil(toast.action)
+    }
+
     func test_moved_describesBothLocationsAndProvidesUndo() {
         let previousBookmark = bookmark(at: .page(ayah(255).page))
         let currentBookmark = bookmark(at: .ayah(ayah(255)))
@@ -39,6 +48,20 @@ final class ReadingBookmarkUndoToastTests: XCTestCase {
         }
 
         XCTAssertEqual(toast.message, "Reading bookmark removed from Al-Baqarah 2:255")
+        XCTAssertEqual(toast.action?.title, "Undo")
+        toast.action?.handler()
+        XCTAssertTrue(didUndo)
+    }
+
+    func test_removedPage_describesPageAndProvidesUndo() {
+        let bookmark = bookmark(at: .page(ayah(255).page))
+        var didUndo = false
+
+        let toast = ReadingBookmarkUndoToast.removed(bookmark) {
+            didUndo = true
+        }
+
+        XCTAssertEqual(toast.message, "Reading bookmark removed from Page 42")
         XCTAssertEqual(toast.action?.title, "Undo")
         toast.action?.handler()
         XCTAssertTrue(didUndo)

--- a/UI/NoorUI/Sources/Components/ReadingBookmarkPin.swift
+++ b/UI/NoorUI/Sources/Components/ReadingBookmarkPin.swift
@@ -3,6 +3,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 public struct ReadingBookmarkPin: View {
     // MARK: Lifecycle
@@ -16,6 +17,29 @@ public struct ReadingBookmarkPin: View {
     public enum Style {
         case outline
         case filled
+    }
+
+    public static func image(style: Style) -> UIImage {
+        let size = CGSize(width: defaultSize, height: defaultSize)
+        let bounds = CGRect(origin: .zero, size: size)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let image = renderer.image { context in
+            let context = context.cgContext
+            context.addPath(ReadingBookmarkPinShape().path(in: bounds).cgPath)
+            context.setFillColor(UIColor.black.cgColor)
+            context.setStrokeColor(UIColor.black.cgColor)
+
+            switch style {
+            case .outline:
+                context.setLineWidth(defaultLineWidth)
+                context.setLineCap(.round)
+                context.setLineJoin(.round)
+                context.strokePath()
+            case .filled:
+                context.drawPath(using: .eoFill)
+            }
+        }
+        return image.withRenderingMode(.alwaysTemplate)
     }
 
     public var body: some View {
@@ -35,8 +59,10 @@ public struct ReadingBookmarkPin: View {
     // MARK: Private
 
     private let style: Style
-    @ScaledMetric private var lineWidth = 1.8
-    @ScaledMetric private var size = 24.0
+    private static let defaultLineWidth: CGFloat = 1.8
+    private static let defaultSize: CGFloat = 24
+    @ScaledMetric private var lineWidth = defaultLineWidth
+    @ScaledMetric private var size = defaultSize
 }
 
 private struct ReadingBookmarkPinShape: Shape {

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuUI.swift
@@ -22,8 +22,8 @@ public enum AyahMenuUI {
             showTranslation: @escaping AsyncAction,
             copy: @escaping AsyncAction,
             share: @escaping AsyncAction,
-            moveReadingBookmark: @escaping AsyncAction,
-            deleteReadingBookmark: @escaping AsyncAction
+            setReadingBookmark: @escaping AsyncAction,
+            removeReadingBookmark: @escaping AsyncAction
         ) {
             self.play = play
             self.repeatVerses = repeatVerses
@@ -33,8 +33,8 @@ public enum AyahMenuUI {
             self.showTranslation = showTranslation
             self.copy = copy
             self.share = share
-            self.moveReadingBookmark = moveReadingBookmark
-            self.deleteReadingBookmark = deleteReadingBookmark
+            self.setReadingBookmark = setReadingBookmark
+            self.removeReadingBookmark = removeReadingBookmark
         }
         #else
         public init(
@@ -69,8 +69,8 @@ public enum AyahMenuUI {
         let copy: AsyncAction
         let share: AsyncAction
         #if QURAN_SYNC
-        let moveReadingBookmark: AsyncAction
-        let deleteReadingBookmark: AsyncAction
+        let setReadingBookmark: AsyncAction
+        let removeReadingBookmark: AsyncAction
         #endif
     }
 

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -170,7 +170,7 @@ private struct AyahMenuViewList: View {
                 subtitle: .text(message),
                 subtitlePlacement: .below,
                 isEnabled: false,
-                action: dataObject.actions.moveReadingBookmark
+                action: dataObject.actions.setReadingBookmark
             ) {
                 ReadingBookmarkPin(style: .outline)
             }
@@ -179,7 +179,7 @@ private struct AyahMenuViewList: View {
                 title: l("ayah.menu.reading-bookmark.title"),
                 subtitle: .text(l("ayah.menu.reading-bookmark.save-here")),
                 subtitlePlacement: .below,
-                action: dataObject.actions.moveReadingBookmark
+                action: dataObject.actions.setReadingBookmark
             ) {
                 ReadingBookmarkPin(style: .outline)
             }
@@ -188,7 +188,7 @@ private struct AyahMenuViewList: View {
                 title: l("ayah.menu.reading-bookmark.title"),
                 subtitle: location,
                 subtitlePlacement: .below,
-                action: dataObject.actions.moveReadingBookmark
+                action: dataObject.actions.setReadingBookmark
             ) {
                 ReadingBookmarkPin(style: .outline)
             }
@@ -197,7 +197,7 @@ private struct AyahMenuViewList: View {
                 title: l("ayah.menu.reading-bookmark.title"),
                 subtitle: .text(l("ayah.menu.reading-bookmark.saved-here")),
                 subtitlePlacement: .below,
-                action: dataObject.actions.deleteReadingBookmark
+                action: dataObject.actions.removeReadingBookmark
             ) {
                 ReadingBookmarkPin(style: .filled)
                     .foregroundColor(.label)
@@ -366,8 +366,8 @@ struct AyahMenuView_Previews: PreviewProvider {
         showTranslation: {},
         copy: {},
         share: {},
-        moveReadingBookmark: {},
-        deleteReadingBookmark: {}
+        setReadingBookmark: {},
+        removeReadingBookmark: {}
     )
     #else
     static let actions = AyahMenuUI.Actions(

--- a/UI/NoorUI/Tests/ReadingBookmarkPinTests.swift
+++ b/UI/NoorUI/Tests/ReadingBookmarkPinTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import NoorUI
+
+final class ReadingBookmarkPinTests: XCTestCase {
+    func test_images_areTemplateRenderedAtNavigationBarSize() throws {
+        let outline = ReadingBookmarkPin.image(style: .outline)
+        let filled = ReadingBookmarkPin.image(style: .filled)
+
+        XCTAssertEqual(outline.size, CGSize(width: 24, height: 24))
+        XCTAssertEqual(filled.size, CGSize(width: 24, height: 24))
+        XCTAssertEqual(outline.renderingMode, .alwaysTemplate)
+        XCTAssertEqual(filled.renderingMode, .alwaysTemplate)
+        XCTAssertNotEqual(try XCTUnwrap(outline.pngData()), try XCTUnwrap(filled.pngData()))
+    }
+}


### PR DESCRIPTION
## Summary

- replace the Quran reader navbar page bookmark with the synced reading-position bookmark when `QURAN_SYNC` is enabled
- show outline and filled reading-bookmark pins from live synced state
- support saving, moving, converting ayah bookmarks, removal, and safe Undo feedback
- unify ayah and page mutations behind a shared `ReadingBookmarkAction` executor while preserving the legacy no-sync implementation
- add regression coverage for action resolution, MobileSync observation, Undo copy, and pin rendering

## Impact

The navbar now represents the user's single synced reading position consistently with the ayah long-press menu. Two-page mode targets the lower-numbered visible page. Existing no-sync page bookmarks remain unchanged.

## Validation

- `make test-sync`
- `make test-no-sync`
- `make build-example-sync`
- `make build-example-no-sync`
- `make format-lint`

## Screenshots 

<img width="368" height="800" alt="image" src="https://github.com/user-attachments/assets/c755994e-3c74-4978-a494-3b75f52411f3" />

<img width="368" height="800" alt="image" src="https://github.com/user-attachments/assets/3688afd5-11b6-46d7-8b62-e34b6d7bc4f8" />

<img width="368" height="800" alt="image" src="https://github.com/user-attachments/assets/7ba8473e-29c2-4a20-aa72-d7147fae3f67" />

<img width="368" height="800" alt="image" src="https://github.com/user-attachments/assets/1fd9fcb8-3c19-4e17-bea1-ea5e62620591" />
