### PR TITLE
fix: refresh bookmark bar after navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Keeping these commands green locally should keep the CI workflow green as well.
 - Add new modules through the `Package.swift` target helpers and keep dependencies explicit.
 - Prefer extending existing services/builders over creating parallel abstractions.
 - Keep feature entry points in `*Builder` types; dependency wiring belongs in builders/container, not views.
+- Pass dependencies directly to view-model initializers; do not introduce nested `Deps` or dependency-bag types.
 
 ## UI and features
 

--- a/Features/AppDependencies/Sources/AppDependencies.swift
+++ b/Features/AppDependencies/Sources/AppDependencies.swift
@@ -74,6 +74,10 @@ extension AppDependencies {
     }
 
     #if QURAN_SYNC
+    public func readingBookmarkService() -> MobileSyncReadingBookmarkService {
+        MobileSyncReadingBookmarkService(quranDataService: quranDataService)
+    }
+
     public func mobileSyncNoteService() -> MobileSyncNoteService {
         MobileSyncNoteService(quranDataService: quranDataService)
     }

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsBuilder.swift
@@ -27,8 +27,12 @@ struct BookmarkCollectionsBuilder {
         let viewModel = BookmarkCollectionsViewModel(
             authenticationClient: container.authenticationClient,
             ayahBookmarkCollectionService: collectionService,
+            readingBookmarkService: container.readingBookmarkService(),
             collectionsBuilder: collectionsBuilder,
-            navigationController: navigationController
+            navigationController: navigationController,
+            navigateToPage: { [weak listener] page, ayah in
+                listener?.navigateTo(page: page, lastPage: nil, highlightingSearchAyah: ayah)
+            }
         )
         return BookmarkCollectionsViewController(viewModel: viewModel)
     }

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
@@ -3,6 +3,7 @@
 //  BookmarkCollectionsView.swift
 //
 
+import FeaturesSupport
 import Localization
 import NoorUI
 import QuranAnnotations
@@ -33,6 +34,15 @@ private struct BookmarkCollectionsContent: View {
                     BookmarkCollectionsSyncBanner(
                         dismiss: { viewModel.dismissSyncBanner() },
                         signInAction: { await viewModel.loginToQuranCom() }
+                    )
+                }
+            }
+
+            if let readingBookmark = viewModel.readingBookmark {
+                NoorBasicSection(title: l("ayah.menu.reading-bookmark.title")) {
+                    ReadingBookmarkListItem(
+                        bookmark: readingBookmark,
+                        action: { viewModel.navigateTo(readingBookmark) }
                     )
                 }
             }

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -3,10 +3,13 @@
 //  BookmarkCollectionsViewModel.swift
 //
 
+import AnnotationsService
 import AuthenticationClient
 import Combine
 import Foundation
 import QuranAnnotations
+import QuranKit
+import ReadingService
 import SwiftUI
 import UIKit
 import VLogging
@@ -18,13 +21,17 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     init(
         authenticationClient: any AuthenticationClient,
         ayahBookmarkCollectionService: AyahBookmarkCollectionService,
+        readingBookmarkService: MobileSyncReadingBookmarkService,
         collectionsBuilder: AyahBookmarkCollectionsBuilder,
-        navigationController: UINavigationController
+        navigationController: UINavigationController,
+        navigateToPage: @escaping (Page, AyahNumber?) -> Void
     ) {
         self.authenticationClient = authenticationClient
         self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
+        self.readingBookmarkService = readingBookmarkService
         self.collectionsBuilder = collectionsBuilder
         self.navigationController = navigationController
+        self.navigateToPage = navigateToPage
         isSyncBannerDismissed = preferences.isSyncBannerDismissed
     }
 
@@ -37,6 +44,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     @Published var isPresentingAddCollection = false
     @Published var isSyncBannerDismissed: Bool
     @Published var newCollectionName = ""
+    @Published var readingBookmark: ReadingPositionBookmark?
 
     var shouldShowSyncBanner: Bool {
         !isAuthenticated && !isSyncBannerDismissed
@@ -97,8 +105,9 @@ final class BookmarkCollectionsViewModel: ObservableObject {
 
     func start() async {
         async let observeCollections: Void = observeCollections()
+        async let observeReadingBookmark: Void = observeReadingBookmark()
         isAuthenticated = await authenticationClient.safelyRestoreState() == .authenticated
-        await observeCollections
+        _ = await (observeCollections, observeReadingBookmark)
     }
 
     func loginToQuranCom() async {
@@ -161,12 +170,24 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         )
     }
 
+    func navigateTo(_ readingBookmark: ReadingPositionBookmark) {
+        switch readingBookmark.location {
+        case .ayah(let ayahNumber):
+            navigateToPage(ayahNumber.page, ayahNumber)
+        case .page(let page):
+            navigateToPage(page, nil)
+        }
+    }
+
     // MARK: Private
 
     private let authenticationClient: any AuthenticationClient
     private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
+    private let readingBookmarkService: MobileSyncReadingBookmarkService
     private let collectionsBuilder: AyahBookmarkCollectionsBuilder
+    private let navigateToPage: (Page, AyahNumber?) -> Void
     private let preferences = BookmarkCollectionsPreferences.shared
+    private let readingPreferences = ReadingPreferences.shared
     private weak var navigationController: UINavigationController?
 
     private static func highlightSortIndex(_ collection: AyahBookmarkCollection) -> Int? {
@@ -200,6 +221,32 @@ final class BookmarkCollectionsViewModel: ObservableObject {
             }
         } catch {
             self.error = error
+        }
+    }
+
+    private func observeReadingBookmark() async {
+        let readings = readingPreferences.$reading
+            .prepend(readingPreferences.reading)
+            .values()
+        var observationTask: Task<Void, Never>?
+        defer { observationTask?.cancel() }
+
+        for await reading in readings {
+            observationTask?.cancel()
+            let sequence = readingBookmarkService.readingBookmarkSequence(quran: reading.quran)
+            observationTask = Task { [weak self] in
+                do {
+                    for try await bookmark in sequence {
+                        guard !Task.isCancelled else { return }
+                        self?.readingBookmark = bookmark
+                    }
+                } catch is CancellationError {
+                    return
+                } catch {
+                    guard !Task.isCancelled else { return }
+                    self?.error = error
+                }
+            }
         }
     }
 }

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -1,4 +1,5 @@
 #if QURAN_SYNC
+import AnnotationsService
 import AuthenticationClient
 import AuthenticationClientFake
 import Combine
@@ -9,6 +10,7 @@ import QuranAnnotations
 import QuranKit
 import QuranResources
 import QuranTextKit
+import ReadingService
 import UIKit
 import XCTest
 @testable import BookmarksFeature
@@ -344,6 +346,59 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         task.cancel()
     }
 
+    func test_start_observesReadingBookmarkFromMobileSync() async throws {
+        let service = makeReadingBookmarkService()
+        let page = ReadingPreferences.shared.reading.quran.pages[269]
+        let sut = makeSUT(readingBookmarkService: service)
+        let task = Task { await sut.start() }
+
+        try await service.addReadingBookmark(at: .page(page))
+        await waitUntil { sut.readingBookmark?.location == .page(page) }
+
+        XCTAssertEqual(sut.readingBookmark?.sura, page.firstVerse.sura)
+        task.cancel()
+    }
+
+    func test_navigateToPageReadingBookmark_navigatesToPageWithoutAyah() {
+        let page = Quran.hafsMadani1405.pages[269]
+        let bookmark = ReadingPositionBookmark(
+            id: "reading-bookmark",
+            location: .page(page),
+            modifiedOn: .distantPast
+        )
+        var navigatedPage: Page?
+        var navigatedAyah: AyahNumber?
+        let sut = makeSUT(navigateToPage: {
+            navigatedPage = $0
+            navigatedAyah = $1
+        })
+
+        sut.navigateTo(bookmark)
+
+        XCTAssertEqual(navigatedPage, page)
+        XCTAssertNil(navigatedAyah)
+    }
+
+    func test_navigateToAyahReadingBookmark_navigatesToPageAndAyah() {
+        let ayah = Quran.hafsMadani1405.pages[269].firstVerse
+        let bookmark = ReadingPositionBookmark(
+            id: "reading-bookmark",
+            location: .ayah(ayah),
+            modifiedOn: .distantPast
+        )
+        var navigatedPage: Page?
+        var navigatedAyah: AyahNumber?
+        let sut = makeSUT(navigateToPage: {
+            navigatedPage = $0
+            navigatedAyah = $1
+        })
+
+        sut.navigateTo(bookmark)
+
+        XCTAssertEqual(navigatedPage, ayah.page)
+        XCTAssertEqual(navigatedAyah, ayah)
+    }
+
     func test_showCollection_pushesCollectionViewController() async throws {
         let service = makeService()
         try await service.createCollection(named: "Favorites")
@@ -367,9 +422,12 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
     private func makeSUT(
         authenticationClient: any AuthenticationClient = UnavailableAuthenticationClient(),
         collectionService: AyahBookmarkCollectionService? = nil,
-        navigationController: UINavigationController? = nil
+        readingBookmarkService: MobileSyncReadingBookmarkService? = nil,
+        navigationController: UINavigationController? = nil,
+        navigateToPage: @escaping (Page, AyahNumber?) -> Void = { _, _ in }
     ) -> BookmarkCollectionsViewModel {
         let collectionService = collectionService ?? makeService()
+        let readingBookmarkService = readingBookmarkService ?? makeReadingBookmarkService()
         let navigationController = navigationController ?? UINavigationController()
         let collectionsBuilder = AyahBookmarkCollectionsBuilder(
             ayahBookmarkCollectionService: collectionService,
@@ -379,13 +437,19 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         return BookmarkCollectionsViewModel(
             authenticationClient: authenticationClient,
             ayahBookmarkCollectionService: collectionService,
+            readingBookmarkService: readingBookmarkService,
             collectionsBuilder: collectionsBuilder,
-            navigationController: navigationController
+            navigationController: navigationController,
+            navigateToPage: navigateToPage
         )
     }
 
     private func makeService() -> AyahBookmarkCollectionService {
         AyahBookmarkCollectionService(quranDataService: database.quranDataService)
+    }
+
+    private func makeReadingBookmarkService() -> MobileSyncReadingBookmarkService {
+        MobileSyncReadingBookmarkService(quranDataService: database.quranDataService)
     }
 
     private func makeCollectionDetailsViewModel(

--- a/Features/FeaturesSupport/Sources/ReadingBookmarkListItem.swift
+++ b/Features/FeaturesSupport/Sources/ReadingBookmarkListItem.swift
@@ -1,0 +1,57 @@
+#if QURAN_SYNC
+//
+//  ReadingBookmarkListItem.swift
+//
+
+import Foundation
+import Localization
+import NoorUI
+import QuranAnnotations
+import QuranTextKit
+import SwiftUI
+import UIx
+
+public struct ReadingBookmarkListItem: View {
+    // MARK: Lifecycle
+
+    public init(
+        bookmark: ReadingPositionBookmark,
+        action: @escaping AsyncAction
+    ) {
+        self.bookmark = bookmark
+        self.action = action
+    }
+
+    // MARK: Public
+
+    public var body: some View {
+        NoorListItem(
+            image: .init(
+                Image(uiImage: ReadingBookmarkPin.image(style: .filled)),
+                color: .appIdentity
+            ),
+            title: "\(bookmark.sura.localizedName()) \(sura: bookmark.sura.arabicSuraName)",
+            subtitle: .init(
+                text: "\(locationTitle) · \(bookmark.modifiedOn.timeAgo())",
+                location: .bottom
+            ),
+            accessory: .disclosureIndicator,
+            action: action
+        )
+    }
+
+    // MARK: Private
+
+    private let bookmark: ReadingPositionBookmark
+    private let action: AsyncAction
+
+    private var locationTitle: String {
+        switch bookmark.location {
+        case .ayah(let ayah):
+            lFormat("quran_ayah", table: .android, ayah.ayah)
+        case .page(let page):
+            "\(lAndroid("quran_page")) \(NumberFormatter.shared.format(page.pageNumber))"
+        }
+    }
+}
+#endif

--- a/Features/HomeFeature/Sources/HomeBuilder.swift
+++ b/Features/HomeFeature/Sources/HomeBuilder.swift
@@ -28,11 +28,13 @@ public struct HomeBuilder {
             databasesURL: container.databasesURL,
             quranFileURL: container.quranUthmaniV2Database
         )
+        #if QURAN_SYNC
         let viewModel = HomeViewModel(
             lastPageService: container.lastPageService(),
             textRetriever: textRetriever,
-            navigateToPage: { [weak listener] lastPage in
-                listener?.navigateTo(page: lastPage.page, lastPage: lastPage, highlightingSearchAyah: nil)
+            readingBookmarkService: container.readingBookmarkService(),
+            navigateToPage: { [weak listener] page, lastPage, ayah in
+                listener?.navigateTo(page: page, lastPage: lastPage, highlightingSearchAyah: ayah)
             },
             navigateToSura: { [weak listener] sura in
                 listener?.navigateTo(page: sura.page, lastPage: nil, highlightingSearchAyah: nil)
@@ -41,6 +43,21 @@ public struct HomeBuilder {
                 listener?.navigateTo(page: quarter.page, lastPage: nil, highlightingSearchAyah: nil)
             }
         )
+        #else
+        let viewModel = HomeViewModel(
+            lastPageService: container.lastPageService(),
+            textRetriever: textRetriever,
+            navigateToPage: { [weak listener] page, lastPage, ayah in
+                listener?.navigateTo(page: page, lastPage: lastPage, highlightingSearchAyah: ayah)
+            },
+            navigateToSura: { [weak listener] sura in
+                listener?.navigateTo(page: sura.page, lastPage: nil, highlightingSearchAyah: nil)
+            },
+            navigateToQuarter: { [weak listener] quarter in
+                listener?.navigateTo(page: quarter.page, lastPage: nil, highlightingSearchAyah: nil)
+            }
+        )
+        #endif
         let viewController = HomeViewController(
             viewModel: viewModel,
             readingSelectorBuilder: ReadingSelectorBuilder(container: container)

--- a/Features/HomeFeature/Sources/HomeView.swift
+++ b/Features/HomeFeature/Sources/HomeView.swift
@@ -5,6 +5,7 @@
 //  Created by Mohamed Afifi on 2023-07-16.
 //
 
+import FeaturesSupport
 import Localization
 import NoorUI
 import QuranAnnotations
@@ -16,6 +17,23 @@ struct HomeView: View {
     @StateObject var viewModel: HomeViewModel
 
     var body: some View {
+        #if QURAN_SYNC
+        HomeViewUI(
+            type: viewModel.type,
+            readingBookmark: viewModel.readingBookmark,
+            lastPages: viewModel.lastPages,
+            suras: viewModel.suras,
+            quarters: viewModel.quarters,
+            start: { await viewModel.start() },
+            selectReadingBookmark: { viewModel.navigateTo($0) },
+            selectLastPage: { viewModel.navigateTo($0) },
+            selectSura: { viewModel.navigateTo($0) },
+            selectQuarter: { viewModel.navigateTo($0) },
+            surahSortOrder: viewModel.surahSortOrder,
+            isJuzExpanded: { viewModel.isJuzExpanded($0) },
+            setJuzExpanded: { viewModel.setJuz($0, expanded: $1) }
+        )
+        #else
         HomeViewUI(
             type: viewModel.type,
             lastPages: viewModel.lastPages,
@@ -29,17 +47,24 @@ struct HomeView: View {
             isJuzExpanded: { viewModel.isJuzExpanded($0) },
             setJuzExpanded: { viewModel.setJuz($0, expanded: $1) }
         )
+        #endif
     }
 }
 
 private struct HomeViewUI: View {
     let type: HomeViewType
+    #if QURAN_SYNC
+    let readingBookmark: ReadingPositionBookmark?
+    #endif
     let lastPages: [LastPage]
     let suras: [Sura]
     let quarters: [QuarterItem]
 
     let start: AsyncAction
 
+    #if QURAN_SYNC
+    let selectReadingBookmark: ItemAction<ReadingPositionBookmark>
+    #endif
     let selectLastPage: ItemAction<LastPage>
     let selectSura: ItemAction<Sura>
     let selectQuarter: ItemAction<QuarterItem>
@@ -49,6 +74,14 @@ private struct HomeViewUI: View {
 
     var body: some View {
         NoorList {
+            #if QURAN_SYNC
+            if let readingBookmark {
+                NoorBasicSection(title: l("ayah.menu.reading-bookmark.title")) {
+                    readingBookmarkView(readingBookmark)
+                }
+            }
+            #endif
+
             NoorSection(title: lAndroid("recent_pages"), lastPages) { lastPage in
                 lastPageView(lastPage)
             }
@@ -66,6 +99,15 @@ private struct HomeViewUI: View {
         }
         .task { await start() }
     }
+
+    #if QURAN_SYNC
+    func readingBookmarkView(_ bookmark: ReadingPositionBookmark) -> some View {
+        ReadingBookmarkListItem(
+            bookmark: bookmark,
+            action: { selectReadingBookmark(bookmark) }
+        )
+    }
+    #endif
 
     func lastPageView(_ lastPage: LastPage) -> some View {
         let ayah = lastPage.page.firstVerse
@@ -169,26 +211,55 @@ struct HomeView_Previews: PreviewProvider {
         let quran = Quran.hafsMadani1405
 
         @State var lastPages: [LastPage] = staticLastPages
+        #if QURAN_SYNC
+        @State var readingBookmark = ReadingPositionBookmark(
+            id: "preview-reading-bookmark",
+            location: .page(Quran.hafsMadani1405.pages[269]),
+            modifiedOn: Date(timeIntervalSinceNow: -180)
+        )
+        #endif
         @State var type: HomeViewType = .juzs
         @State var collapsedJuzs: Set<Juz> = []
 
         var body: some View {
             NavigationView {
-                HomeViewUI(
-                    type: type,
-                    lastPages: lastPages,
-                    suras: quran.suras,
-                    quarters: quran.quarters.map { QuarterItem(quarter: $0, ayahText: Self.ayahText) },
-                    start: {},
-                    selectLastPage: { _ in },
-                    selectSura: { _ in },
-                    selectQuarter: { _ in },
-                    surahSortOrder: .ascending,
-                    isJuzExpanded: { !collapsedJuzs.contains($0) },
-                    setJuzExpanded: { juz, expanded in
-                        if expanded { collapsedJuzs.remove(juz) } else { collapsedJuzs.insert(juz) }
-                    }
-                )
+                Group {
+                    #if QURAN_SYNC
+                    HomeViewUI(
+                        type: type,
+                        readingBookmark: readingBookmark,
+                        lastPages: lastPages,
+                        suras: quran.suras,
+                        quarters: quran.quarters.map { QuarterItem(quarter: $0, ayahText: Self.ayahText) },
+                        start: {},
+                        selectReadingBookmark: { _ in },
+                        selectLastPage: { _ in },
+                        selectSura: { _ in },
+                        selectQuarter: { _ in },
+                        surahSortOrder: .ascending,
+                        isJuzExpanded: { !collapsedJuzs.contains($0) },
+                        setJuzExpanded: { juz, expanded in
+                            if expanded { collapsedJuzs.remove(juz) } else { collapsedJuzs.insert(juz) }
+                        }
+                    )
+                    #else
+                    HomeViewUI(
+                        type: type,
+                        lastPages: lastPages,
+                        suras: quran.suras,
+                        quarters: quran.quarters.map { QuarterItem(quarter: $0, ayahText: Self.ayahText) },
+                        start: {},
+                        selectLastPage: { _ in },
+                        selectSura: { _ in },
+                        selectQuarter: { _ in },
+                        surahSortOrder: .ascending,
+                        isJuzExpanded: { !collapsedJuzs.contains($0) },
+                        setJuzExpanded: { juz, expanded in
+                            if expanded { collapsedJuzs.remove(juz) } else { collapsedJuzs.insert(juz) }
+                        }
+                    )
+                    #endif
+                }
                 .navigationTitle("Home")
                 .toolbar {
                     if type == .suras {

--- a/Features/HomeFeature/Sources/HomeViewModel.swift
+++ b/Features/HomeFeature/Sources/HomeViewModel.swift
@@ -31,10 +31,30 @@ enum HomeViewType: Int {
 final class HomeViewModel: ObservableObject {
     // MARK: Lifecycle
 
+    #if QURAN_SYNC
     init(
         lastPageService: any LastPageService,
         textRetriever: QuranTextDataService,
-        navigateToPage: @escaping (LastPage) -> Void,
+        readingBookmarkService: MobileSyncReadingBookmarkService,
+        navigateToPage: @escaping (Page, LastPage?, AyahNumber?) -> Void,
+        navigateToSura: @escaping (Sura) -> Void,
+        navigateToQuarter: @escaping (Quarter) -> Void
+    ) {
+        self.lastPageService = lastPageService
+        self.textRetriever = textRetriever
+        self.readingBookmarkService = readingBookmarkService
+        self.navigateToPage = navigateToPage
+        self.navigateToSura = navigateToSura
+        self.navigateToQuarter = navigateToQuarter
+
+        HomePreferences.shared.$surahSortOrder
+            .assign(to: &$surahSortOrder)
+    }
+    #else
+    init(
+        lastPageService: any LastPageService,
+        textRetriever: QuranTextDataService,
+        navigateToPage: @escaping (Page, LastPage?, AyahNumber?) -> Void,
         navigateToSura: @escaping (Sura) -> Void,
         navigateToQuarter: @escaping (Quarter) -> Void
     ) {
@@ -47,12 +67,16 @@ final class HomeViewModel: ObservableObject {
         HomePreferences.shared.$surahSortOrder
             .assign(to: &$surahSortOrder)
     }
+    #endif
 
     // MARK: Internal
 
     @Published var suras: [Sura] = []
     @Published var quarters: [QuarterItem] = []
     @Published var lastPages: [LastPage] = []
+    #if QURAN_SYNC
+    @Published var readingBookmark: ReadingPositionBookmark?
+    #endif
 
     @Published var surahSortOrder: SurahSortOrder = HomePreferences.shared.surahSortOrder
 
@@ -80,12 +104,28 @@ final class HomeViewModel: ObservableObject {
         async let lastPages: () = loadLastPages()
         async let suras: () = loadSuras()
         async let quarters: () = loadQuarters()
+        #if QURAN_SYNC
+        async let readingBookmark: () = loadReadingBookmark()
+        _ = await [lastPages, suras, quarters, readingBookmark]
+        #else
         _ = await [lastPages, suras, quarters]
+        #endif
     }
 
     func navigateTo(_ lastPage: LastPage) {
-        navigateToPage(lastPage)
+        navigateToPage(lastPage.page, lastPage, nil)
     }
+
+    #if QURAN_SYNC
+    func navigateTo(_ readingBookmark: ReadingPositionBookmark) {
+        switch readingBookmark.location {
+        case .ayah(let ayahNumber):
+            navigateToPage(ayahNumber.page, nil, ayahNumber)
+        case .page(let page):
+            navigateToPage(page, nil, nil)
+        }
+    }
+    #endif
 
     func navigateTo(_ sura: Sura) {
         navigateToSura(sura)
@@ -103,7 +143,10 @@ final class HomeViewModel: ObservableObject {
 
     private let lastPageService: any LastPageService
     private let textRetriever: QuranTextDataService
-    private let navigateToPage: (LastPage) -> Void
+    #if QURAN_SYNC
+    private let readingBookmarkService: MobileSyncReadingBookmarkService
+    #endif
+    private let navigateToPage: (Page, LastPage?, AyahNumber?) -> Void
     private let navigateToSura: (Sura) -> Void
     private let navigateToQuarter: (Quarter) -> Void
     private let readingPreferences = ReadingPreferences.shared
@@ -133,6 +176,34 @@ final class HomeViewModel: ObservableObject {
             }
         }
     }
+
+    #if QURAN_SYNC
+    private func loadReadingBookmark() async {
+        let readings = readingPreferences.$reading
+            .prepend(readingPreferences.reading)
+            .values()
+        var observationTask: Task<Void, Never>?
+        defer { observationTask?.cancel() }
+
+        for await reading in readings {
+            observationTask?.cancel()
+            let sequence = readingBookmarkService.readingBookmarkSequence(quran: reading.quran)
+            observationTask = Task { [weak self] in
+                do {
+                    for try await bookmark in sequence {
+                        guard !Task.isCancelled else { return }
+                        self?.readingBookmark = bookmark
+                    }
+                } catch is CancellationError {
+                    return
+                } catch {
+                    guard !Task.isCancelled else { return }
+                    crasher.recordError(error, reason: "Failed to load reading bookmark")
+                }
+            }
+        }
+    }
+    #endif
 
     private func loadSuras() async {
         let readings = readingPreferences.$reading

--- a/Features/QuranViewFeature/Sources/QuranBuilder.swift
+++ b/Features/QuranViewFeature/Sources/QuranBuilder.swift
@@ -42,7 +42,7 @@ public struct QuranBuilder {
             highlightsService: highlightsService
         )
         let readingBookmarkObserver = QuranReadingBookmarkObserver(
-            service: MobileSyncReadingBookmarkService(quranDataService: container.quranDataService),
+            service: container.readingBookmarkService(),
             quran: quran
         )
         let interactorDeps = QuranInteractor.Deps(

--- a/Features/QuranViewFeature/Sources/QuranInteractor.swift
+++ b/Features/QuranViewFeature/Sources/QuranInteractor.swift
@@ -114,6 +114,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         #if QURAN_SYNC
         deps.syncedHighlightsObserver.start()
         deps.readingBookmarkObserver.$bookmark
+            .receive(on: DispatchQueue.main) // sink after the bookmark property is updated
             .sink { [weak self] _ in self?.reloadPageBookmark() }
             .store(in: &cancellables)
         deps.readingBookmarkObserver.start()

--- a/Model/QuranAnnotations/Sources/ReadingPositionBookmark.swift
+++ b/Model/QuranAnnotations/Sources/ReadingPositionBookmark.swift
@@ -26,6 +26,15 @@ public struct ReadingPositionBookmark: Equatable {
     public let location: Location
     public let modifiedOn: Date
 
+    public var sura: Sura {
+        switch location {
+        case .ayah(let ayah):
+            ayah.sura
+        case .page(let page):
+            page.firstVerse.sura
+        }
+    }
+
     public func isAt(_ ayah: AyahNumber) -> Bool {
         switch location {
         case .ayah(let bookmarkedAyah):

--- a/Package.swift
+++ b/Package.swift
@@ -543,7 +543,9 @@ private func featuresTargets() -> [[Target]] {
             "Localization",
             "Analytics",
             "QuranAnnotations",
+            "QuranTextKit",
             "NoorUI",
+            "UIx",
         ]),
 
         target(type, name: "ReciterListFeature", hasTests: false, dependencies: [

--- a/UI/NoorUI/Sources/Components/List/NoorListItem.swift
+++ b/UI/NoorUI/Sources/Components/List/NoorListItem.swift
@@ -30,13 +30,18 @@ public struct NoorListItem: View {
         // MARK: Lifecycle
 
         public init(_ image: NoorSystemImage, color: Color? = nil) {
+            self.image = image.image
+            self.color = color
+        }
+
+        public init(_ image: Image, color: Color? = nil) {
             self.image = image
             self.color = color
         }
 
         // MARK: Internal
 
-        let image: NoorSystemImage
+        let image: Image
         let color: Color?
     }
 
@@ -168,10 +173,10 @@ public struct NoorListItem: View {
 
             if let image {
                 if let color = image.color {
-                    image.image.image
+                    image.image
                         .foregroundColor(color)
                 } else {
-                    image.image.image
+                    image.image
                 }
             }
 


### PR DESCRIPTION
## Summary

- refresh the Quran bookmark bar after the reading bookmark observer has stored its new value
- show the filled bookmarked state when navigating to the currently bookmarked page

## Root cause

Combine's `@Published` publisher emits during property assignment, before the observer's `bookmark` property returns the new value. The interactor synchronously re-read that property and rendered the previous state.

Scheduling the reload on the main queue lets the assignment finish before the interactor derives the bookmark bar state.

## Stack

- Base: #904

## Validation

- `make format-lint`
- `make build-no-sync TARGET=QuranViewFeature`
- `make test-sync TARGET=QuranViewFeatureTests` — 15 tests passed