### PR TITLE
style: make reading bookmarks red

### DIFF
--- a/Features/FeaturesSupport/Sources/ReadingBookmarkListItem.swift
+++ b/Features/FeaturesSupport/Sources/ReadingBookmarkListItem.swift
@@ -28,7 +28,7 @@ public struct ReadingBookmarkListItem: View {
         NoorListItem(
             image: .init(
                 Image(uiImage: ReadingBookmarkPin.image(style: .filled)),
-                color: .appIdentity
+                color: .red
             ),
             title: "\(bookmark.sura.localizedName()) \(sura: bookmark.sura.arabicSuraName)",
             subtitle: .init(

--- a/Features/QuranViewFeature/Sources/QuranViewController.swift
+++ b/Features/QuranViewFeature/Sources/QuranViewController.swift
@@ -387,6 +387,7 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         let style: ReadingBookmarkPin.Style = isBookmarked ? .filled : .outline
         let bookmarkImage = ReadingBookmarkPin.image(style: style)
         let bookmark = UIBarButtonItem(image: bookmarkImage, style: .plain, target: self, action: #selector(onBookmarkButtonTapped))
+        bookmark.tintColor = isBookmarked ? .systemRed : nil
         bookmark.accessibilityLabel = l("ayah.menu.reading-bookmark.title")
         bookmark.accessibilityValue = l(isBookmarked
             ? "ayah.menu.reading-bookmark.saved-here"

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -200,10 +200,7 @@ private struct AyahMenuViewList: View {
                 action: dataObject.actions.removeReadingBookmark
             ) {
                 ReadingBookmarkPin(style: .filled)
-                    .foregroundColor(.label)
-            } accessory: {
-                NoorSystemImage.checkmark.image
-                    .foregroundColor(.appIdentity)
+                    .foregroundColor(.red)
             }
         }
     }


### PR DESCRIPTION
## Summary

- use red for filled reading bookmark pins in Home and Collections
- tint the Quran toolbar bookmark red when the visible page is bookmarked
- use the same red filled pin in the ayah menu
- remove the redundant saved checkmark from the ayah menu row

## Why

A consistent red filled-pin treatment makes the active reading bookmark state distinct across every surface.

## Stack

- Base: #905

## Validation

- `make format-lint`
- `make test-no-sync`
- `make test-sync`


## Screenshots

<img width="306" alt="image" src="https://github.com/user-attachments/assets/6c22b89f-6ddb-48a3-afe1-9d4ea11aa890" />

<img width="306" alt="image" src="https://github.com/user-attachments/assets/a2f6753f-ac59-43fb-859f-4bc868121e84" />

<img width="306" alt="image" src="https://github.com/user-attachments/assets/931da7b9-bf83-4f01-8d4a-92e73a27458a" />

<img width="306" alt="image" src="https://github.com/user-attachments/assets/2e9ad6b9-ee6b-4b6f-8d09-d85f05714192" />
