### PR TITLE
fix: distinguish page and ayah reading bookmarks

### DIFF
--- a/Domain/AnnotationsService/Tests/MobileSyncReadingBookmarkServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncReadingBookmarkServiceTests.swift
@@ -61,7 +61,6 @@ final class MobileSyncReadingBookmarkServiceTests: XCTestCase {
         let bookmark = try await storedBookmark(quran: quran)
 
         XCTAssertEqual(bookmark?.location, .page(expectedPage))
-        XCTAssertTrue(bookmark?.isAt(expectedPage.firstVerse) == true)
     }
 
     func test_addReadingBookmark_persistsPageLocation() async throws {

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -100,15 +100,15 @@ final class AyahMenuViewModelTests: XCTestCase {
         }
     }
 
-    func test_readingBookmarkState_isCurrentForPageContainingSelectedAyah() {
+    func test_readingBookmarkState_isElsewhereForPageContainingSelectedAyah() {
         let selected = verses[0]
         let sut = makeSUT(
             verses: [selected],
             readingBookmark: readingBookmark(at: .page(selected.page))
         )
 
-        guard case .current = sut.readingBookmarkState else {
-            return XCTFail("Expected current reading bookmark state")
+        guard case .elsewhere = sut.readingBookmarkState else {
+            return XCTFail("Expected elsewhere reading bookmark state")
         }
     }
 
@@ -158,6 +158,18 @@ final class AyahMenuViewModelTests: XCTestCase {
         await sut.removeReadingBookmark()
 
         XCTAssertEqual(listener.removedReadingBookmark, bookmark)
+    }
+
+    func test_removeReadingBookmark_doesNotRemovePageBookmarkContainingSelectedAyah() async {
+        let selected = verses[0]
+        let bookmark = readingBookmark(at: .page(selected.page))
+        let sut = makeSUT(verses: [selected], readingBookmark: bookmark)
+        let listener = BookmarkListenerSpy()
+        sut.listener = listener
+
+        await sut.removeReadingBookmark()
+
+        XCTAssertNil(listener.removedReadingBookmark)
     }
 
     private var verses: [AyahNumber] {

--- a/Model/QuranAnnotations/Sources/ReadingPositionBookmark.swift
+++ b/Model/QuranAnnotations/Sources/ReadingPositionBookmark.swift
@@ -39,8 +39,8 @@ public struct ReadingPositionBookmark: Equatable {
         switch location {
         case .ayah(let bookmarkedAyah):
             return bookmarkedAyah == ayah
-        case .page(let bookmarkedPage):
-            return bookmarkedPage == ayah.page
+        case .page:
+            return false
         }
     }
 }


### PR DESCRIPTION
## Summary

- treat page reading bookmarks as distinct from exact ayah bookmarks
- show a page bookmark as an elsewhere location in the ayah menu
- prevent the selected-ayah removal action from deleting a page bookmark
- update the mapping test that encoded the previous semantics

## Root cause

`ReadingPositionBookmark.isAt(_:)` returned true for every ayah on a bookmarked page. The ayah menu therefore displayed “Saved here” for any ayah on that page and allowed the page bookmark to be removed as though it were attached to that exact ayah.

## Impact

Page bookmarks now remain page-level positions. Selecting an ayah on that page offers to move the reading bookmark instead of treating the ayah as the current saved location.

## Validation

- `make format-lint`
- `make test-sync TARGET=AyahMenuFeatureTests` — 18 tests passed
- `make test-sync TARGET=AnnotationsServiceTests` — 31 tests passed