### PR TITLE
fix: use Quran font for footnote verses

### DIFF
--- a/UI/NoorUI/Sources/Components/MultipartText.swift
+++ b/UI/NoorUI/Sources/Components/MultipartText.swift
@@ -168,7 +168,7 @@ public struct MultipartText: ExpressibleByStringInterpolation {
         var verseFont: Font {
             switch self {
             case .body: return .custom(.quran, size: 20, relativeTo: .body)
-            case .footnote: return .custom(.suraNames, size: 16, relativeTo: .footnote)
+            case .footnote: return .custom(.quran, size: 16, relativeTo: .footnote)
             case .caption: return .custom(.quran, size: 15, relativeTo: .caption)
             }
         }


### PR DESCRIPTION
## Summary

- render footnote-sized verse text with the Quran font
- keep verse font selection consistent across body, footnote, and caption sizes

## Root cause

The footnote branch incorrectly selected the Sura names icon font while the body and caption branches selected the Quran font. This could render Quran verse text with a font intended for decorated Sura-name glyphs.

## Checks

Not run, per request.