### PR TITLE
refactor: render toast messages with multipart text

### DIFF
--- a/Features/AudioBannerFeature/Sources/AudioBannerBuilder.swift
+++ b/Features/AudioBannerFeature/Sources/AudioBannerBuilder.swift
@@ -8,6 +8,7 @@
 
 import AdvancedAudioOptionsFeature
 import AppDependencies
+import NoorUI
 import QuranAudioKit
 import ReciterListFeature
 import ReciterService

--- a/Features/AudioBannerFeature/Sources/AudioBannerView.swift
+++ b/Features/AudioBannerFeature/Sources/AudioBannerView.swift
@@ -5,6 +5,7 @@
 //  Created by Mohamed Afifi on 2024-09-23.
 //
 
+import Combine
 import NoorUI
 import SwiftUI
 import UIx
@@ -32,11 +33,9 @@ struct AudioBannerView: View {
             state: viewModel.audioBannerState,
             actions: actions
         )
-        .onChange(of: viewModel.toast?.message) { _ in
-            if let toast = viewModel.toast {
-                viewModel.toast = nil
-                showToast?(Toast(toast.message, action: toast.action, bottomOffset: toastOffset))
-            }
+        .onReceive(viewModel.$toast.compactMap { $0 }) { toast in
+            viewModel.toast = nil
+            showToast?(Toast(toast.message, action: toast.action, bottomOffset: toastOffset))
         }
         .onChange(of: viewModel.viewControllerToPresent) { _ in
             if let presentingVC = viewModel.viewControllerToPresent {

--- a/Features/AudioBannerFeature/Sources/AudioBannerViewModel.swift
+++ b/Features/AudioBannerFeature/Sources/AudioBannerViewModel.swift
@@ -17,12 +17,10 @@ import QueuePlayer
 import QuranAudio
 import QuranAudioKit
 import QuranKit
-import QuranLocalization
 import ReciterListFeature
 import ReciterService
 import SwiftUI
 import UIKit
-import UIx
 import Utilities
 import VLogging
 
@@ -90,7 +88,7 @@ public final class AudioBannerViewModel: ObservableObject {
     weak var listener: AudioBannerListener?
 
     @Published var error: Error?
-    @Published var toast: (message: String, action: ToastAction?)?
+    @Published var toast: (message: MultipartText, action: ToastAction?)?
     @Published var viewControllerToPresent: UIViewController?
     @Published var dismissPresentedViewController = false
     @Published var playbackRate: Float
@@ -443,8 +441,10 @@ public final class AudioBannerViewModel: ObservableObject {
         playbackEnded()
     }
 
-    private func audioMessage(_ format: String, audioRange: AudioRange) -> String {
-        lFormat(format, audioRange.start.localizedName, audioRange.end.localizedName)
+    private func audioMessage(_ format: String, audioRange: AudioRange) -> MultipartText {
+        let start: MultipartText = "\(ayah: audioRange.start)"
+        let end: MultipartText = "\(ayah: audioRange.end)"
+        return MultipartText.localizedFormat(format, start, end)
     }
 }
 

--- a/Features/QuranViewFeature/Sources/ReadingBookmarkUndoToast.swift
+++ b/Features/QuranViewFeature/Sources/ReadingBookmarkUndoToast.swift
@@ -4,14 +4,13 @@
 //
 
 import Localization
+import NoorUI
 import QuranAnnotations
 import QuranLocalization
-import QuranTextKit
-import UIx
 
 enum ReadingBookmarkUndoToast {
     static func saved(_ bookmark: ReadingPositionBookmark) -> Toast {
-        Toast(lFormat("ayah.menu.reading-bookmark.saved", location(of: bookmark)))
+        Toast(MultipartText.localizedFormat("ayah.menu.reading-bookmark.saved", location(of: bookmark)))
     }
 
     static func moved(
@@ -20,7 +19,7 @@ enum ReadingBookmarkUndoToast {
         undo: @escaping () -> Void
     ) -> Toast {
         makeToast(
-            lFormat(
+            MultipartText.localizedFormat(
                 "ayah.menu.reading-bookmark.moved",
                 location(of: previousBookmark),
                 location(of: currentBookmark)
@@ -34,24 +33,24 @@ enum ReadingBookmarkUndoToast {
         undo: @escaping () -> Void
     ) -> Toast {
         makeToast(
-            lFormat("ayah.menu.reading-bookmark.removed", location(of: bookmark)),
+            MultipartText.localizedFormat("ayah.menu.reading-bookmark.removed", location(of: bookmark)),
             undo: undo
         )
     }
 
-    private static func makeToast(_ message: String, undo: @escaping () -> Void) -> Toast {
+    private static func makeToast(_ message: MultipartText, undo: @escaping () -> Void) -> Toast {
         Toast(
             message,
             action: ToastAction(title: lAndroid("undo"), handler: undo)
         )
     }
 
-    private static func location(of bookmark: ReadingPositionBookmark) -> String {
+    private static func location(of bookmark: ReadingPositionBookmark) -> MultipartText {
         switch bookmark.location {
         case .ayah(let ayah):
-            return ayah.localizedCompactName
+            return "\(ayah: ayah, format: .compact)"
         case .page(let page):
-            return page.localizedName
+            return .text(page.localizedName)
         }
     }
 }

--- a/Features/QuranViewFeature/Tests/ReadingBookmarkUndoToastTests.swift
+++ b/Features/QuranViewFeature/Tests/ReadingBookmarkUndoToastTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import QuranAnnotations
 import QuranKit
 import XCTest
+@testable import NoorUI
 @testable import QuranViewFeature
 
 final class ReadingBookmarkUndoToastTests: XCTestCase {
@@ -11,7 +12,7 @@ final class ReadingBookmarkUndoToastTests: XCTestCase {
 
         let toast = ReadingBookmarkUndoToast.saved(bookmark)
 
-        XCTAssertEqual(toast.message, "Reading bookmark saved at Al-Baqarah 2:255")
+        XCTAssertEqual(toast.message.rawValue, "Reading bookmark saved at Al-Baqarah 2:255 \u{E905}")
         XCTAssertNil(toast.action)
     }
 
@@ -20,7 +21,7 @@ final class ReadingBookmarkUndoToastTests: XCTestCase {
 
         let toast = ReadingBookmarkUndoToast.saved(bookmark)
 
-        XCTAssertEqual(toast.message, "Reading bookmark saved at Page 42")
+        XCTAssertEqual(toast.message.rawValue, "Reading bookmark saved at Page 42")
         XCTAssertNil(toast.action)
     }
 
@@ -33,7 +34,10 @@ final class ReadingBookmarkUndoToastTests: XCTestCase {
             didUndo = true
         }
 
-        XCTAssertEqual(toast.message, "Reading bookmark moved from Page 42 to Al-Baqarah 2:255")
+        XCTAssertEqual(
+            toast.message.rawValue,
+            "Reading bookmark moved from Page 42 to Al-Baqarah 2:255 \u{E905}"
+        )
         XCTAssertEqual(toast.action?.title, "Undo")
         toast.action?.handler()
         XCTAssertTrue(didUndo)
@@ -47,7 +51,7 @@ final class ReadingBookmarkUndoToastTests: XCTestCase {
             didUndo = true
         }
 
-        XCTAssertEqual(toast.message, "Reading bookmark removed from Al-Baqarah 2:255")
+        XCTAssertEqual(toast.message.rawValue, "Reading bookmark removed from Al-Baqarah 2:255 \u{E905}")
         XCTAssertEqual(toast.action?.title, "Undo")
         toast.action?.handler()
         XCTAssertTrue(didUndo)
@@ -61,7 +65,7 @@ final class ReadingBookmarkUndoToastTests: XCTestCase {
             didUndo = true
         }
 
-        XCTAssertEqual(toast.message, "Reading bookmark removed from Page 42")
+        XCTAssertEqual(toast.message.rawValue, "Reading bookmark removed from Page 42")
         XCTAssertEqual(toast.action?.title, "Undo")
         toast.action?.handler()
         XCTAssertTrue(didUndo)

--- a/Package.swift
+++ b/Package.swift
@@ -607,7 +607,6 @@ private func featuresTargets() -> [[Target]] {
             "Caching",
             "AppDependencies",
             "NoorUI",
-            "QuranLocalization",
             "ReciterListFeature",
             "AdvancedAudioOptionsFeature",
         ]),

--- a/UI/NoorUI/Sources/Components/Toast.swift
+++ b/UI/NoorUI/Sources/Components/Toast.swift
@@ -10,6 +10,7 @@
 import Foundation
 import SwiftUI
 import UIKit
+import UIx
 
 public struct ToastAction {
     public let title: String
@@ -22,13 +23,13 @@ public struct ToastAction {
 }
 
 public struct Toast {
-    public let message: String
+    public let message: MultipartText
     public let action: ToastAction?
     public let duration: TimeInterval
     public let bottomOffset: CGFloat
 
     public init(
-        _ message: String,
+        _ message: MultipartText,
         action: ToastAction? = nil,
         duration: TimeInterval = 4.0,
         bottomOffset: CGFloat = 40
@@ -41,14 +42,14 @@ public struct Toast {
 }
 
 private struct ToastView: View {
-    let message: String
+    let message: MultipartText
     let action: ToastAction?
     let dismiss: () -> Void
     @ScaledMetric var shadowRadius = 5
 
     var body: some View {
         HStack {
-            Text(message)
+            message.view(ofSize: .body)
                 .foregroundColor(.systemBackground)
             Spacer()
             if let action {

--- a/UI/NoorUI/Sources/Components/ToastEnvironmentKey.swift
+++ b/UI/NoorUI/Sources/Components/ToastEnvironmentKey.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 import VLogging
 
 extension EnvironmentValues {


### PR DESCRIPTION
## Summary

- move the owned Toast component from UIx to NoorUI so it can accept and render `MultipartText` without reversing the UI dependency direction
- preserve typed ayah references through localized audio-range and reading-bookmark toast messages
- keep the existing presenter queue, actions, timing, offsets, and dismissal behavior unchanged
- remove the now-unused direct `QuranLocalization` dependency from `AudioBannerFeature`

## Validation

- `make build-no-sync TARGET=NoorUI`
- `make build-sync TARGET=QuranViewFeature`
- `make test-no-sync TARGET=NoorUI`
- `make test-sync TARGET=QuranViewFeature`
- `make format-lint`