### PR TITLE
feat: standardize Quran reference display

### DIFF
--- a/Core/Localization/Sources/Locale+Language.swift
+++ b/Core/Localization/Sources/Locale+Language.swift
@@ -1,0 +1,18 @@
+//
+//  Locale+Language.swift
+//
+
+import Foundation
+
+public extension Locale {
+    static var preferredLanguageLocale: Locale {
+        guard let identifier = NSLocale.preferredLanguages.first else {
+            return .current
+        }
+        return Locale(identifier: identifier)
+    }
+
+    var isArabicLanguage: Bool {
+        languageCode == "ar"
+    }
+}

--- a/Core/Localization/Sources/Localizations.swift
+++ b/Core/Localization/Sources/Localizations.swift
@@ -42,7 +42,7 @@ public func l(_ key: String, table: Table = .localizable, language: Language? = 
         return localizedString(key, table: table, language: language)
     }
     let value = NSLocalizedString(key, tableName: table.rawValue, bundle: Bundle.fixedModule, comment: "")
-    if value != key || NSLocale.preferredLanguages.first == "en" {
+    if value != key || Locale.preferredLanguageLocale.languageCode == Language.english.rawValue {
         return value
     }
 

--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
@@ -86,16 +86,20 @@ struct AdvancedAudioOptionsRootViewUI: View {
 
             Section(header: Text(l("audio.playback-ayah-range"))) {
                 FromRow(verse: fromVerse) {
-                    navigator?.push {
-                        StaticViewControllerRepresentable(viewController: fromVerseSelectionViewController)
-                    }
+                    showVerseSelection(
+                        title: l("audio.select-start-verse"),
+                        selected: fromVerse,
+                        onSelection: updateFromVerseTo
+                    )
                 }
                 EndAtRow(selection: endAtBinding)
                 if endAt == .custom {
                     ToRow(verse: toVerse) {
-                        navigator?.push {
-                            StaticViewControllerRepresentable(viewController: toVerseSelectionViewController)
-                        }
+                        showVerseSelection(
+                            title: l("audio.select-end-verse"),
+                            selected: toVerse,
+                            onSelection: updateToVerseTo
+                        )
                     }
                 }
             }
@@ -139,22 +143,20 @@ struct AdvancedAudioOptionsRootViewUI: View {
         )
     }
 
-    private var fromVerseSelectionViewController: UIViewController {
-        let verseSelection = AdvancedAudioVersesViewController(suras: fromVerse.quran.suras, selected: fromVerse) { fromVerse in
-            updateFromVerseTo(fromVerse)
-            navigator?.pop()
+    private func showVerseSelection(
+        title: String,
+        selected: AyahNumber,
+        onSelection: @escaping ItemAction<AyahNumber>
+    ) {
+        navigator?.push(configuration: .init(title: title)) {
+            AdvancedAudioVersesView(
+                suras: selected.quran.suras,
+                selected: selected
+            ) { ayah in
+                onSelection(ayah)
+                navigator?.pop()
+            }
         }
-        verseSelection.title = l("audio.select-start-verse")
-        return verseSelection
-    }
-
-    private var toVerseSelectionViewController: UIViewController {
-        let verseSelection = AdvancedAudioVersesViewController(suras: toVerse.quran.suras, selected: toVerse) { toVerse in
-            updateToVerseTo(toVerse)
-            navigator?.pop()
-        }
-        verseSelection.title = l("audio.select-end-verse")
-        return verseSelection
     }
 }
 
@@ -297,7 +299,7 @@ private struct FromRow: View {
     var body: some View {
         NoorListItem(
             title: .text(lAndroid("from")),
-            subtitle: .init(text: verse.localizedNameWithSuraNumber, location: .trailing),
+            subtitle: .init(text: "\(ayah: verse)", location: .trailing),
             accessory: .disclosureIndicator,
             action: action
         )
@@ -311,7 +313,7 @@ private struct ToRow: View {
     var body: some View {
         NoorListItem(
             title: .text(lAndroid("to")),
-            subtitle: .init(text: verse.localizedNameWithSuraNumber, location: .trailing),
+            subtitle: .init(text: "\(ayah: verse)", location: .trailing),
             accessory: .disclosureIndicator,
             action: action
         )

--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioVersesViewController.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioVersesViewController.swift
@@ -5,83 +5,80 @@
 //  Created by Afifi, Mohamed on 10/10/21.
 //
 
+import NoorUI
 import QuranKit
 import QuranLocalization
-import UIKit
+import SwiftUI
 
-class AdvancedAudioVersesViewController: UITableViewController {
-    // MARK: Lifecycle
+struct AdvancedAudioVersesView: View {
+    let suras: [Sura]
+    let selected: AyahNumber
+    let onSelection: @MainActor (AyahNumber) -> Void
 
-    init(suras: [Sura], selected: AyahNumber, onSelection: @MainActor @escaping (AyahNumber) -> Void) {
-        self.suras = suras
-        self.selected = selected
-        self.onSelection = onSelection
-        super.init(style: .insetGrouped)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: Internal
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
-        tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = 44
-
-        if let selectedIndexPath = selectedIndexPath() {
-            DispatchQueue.main.async {
-                self.tableView?.scrollToRow(at: selectedIndexPath, at: .middle, animated: false)
+    var body: some View {
+        ScrollViewReader { proxy in
+            List {
+                ForEach(suras) { sura in
+                    SuraSectionView(
+                        sura: sura,
+                        selected: selected,
+                        onSelection: onSelection
+                    )
+                }
             }
-        }
-    }
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        suras.count
-    }
-
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        suras[section].verses.count
-    }
-
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-        let verse = verseAtIndexPath(indexPath)
-        cell.textLabel?.text = verse.localizedName
-        cell.textLabel?.font = .preferredFont(forTextStyle: .body)
-        cell.accessoryType = verse == selected ? .checkmark : .none
-        return cell
-    }
-
-    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        suras[section].localizedName()
-    }
-
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        onSelection(verseAtIndexPath(indexPath))
-    }
-
-    // MARK: Private
-
-    private let onSelection: (AyahNumber) -> Void
-    private let suras: [Sura]
-    private let selected: AyahNumber
-
-    private func selectedIndexPath() -> IndexPath? {
-        for (section, sura) in suras.enumerated() {
-            for (item, verse) in sura.verses.enumerated() {
-                if verse == selected {
-                    return IndexPath(item: item, section: section)
+            .listStyle(.insetGrouped)
+            .onAppear {
+                DispatchQueue.main.async {
+                    proxy.scrollTo(selected, anchor: .center)
                 }
             }
         }
-        return nil
     }
+}
 
-    private func verseAtIndexPath(_ indexPath: IndexPath) -> AyahNumber {
-        suras[indexPath.section].verses[indexPath.item]
+private struct SuraSectionView: View {
+    let sura: Sura
+    let selected: AyahNumber
+    let onSelection: @MainActor (AyahNumber) -> Void
+
+    var body: some View {
+        Section {
+            ForEach(sura.verses, id: \.self) { ayah in
+                AyahRowView(
+                    ayah: ayah,
+                    isSelected: ayah == selected,
+                    onSelection: onSelection
+                )
+                .id(ayah)
+            }
+        } header: {
+            let title: MultipartText = "\(sura: sura)"
+            title.view(ofSize: .caption, allowsWrapping: false)
+        }
+    }
+}
+
+private struct AyahRowView: View {
+    let ayah: AyahNumber
+    let isSelected: Bool
+    let onSelection: @MainActor (AyahNumber) -> Void
+
+    var body: some View {
+        Button {
+            onSelection(ayah)
+        } label: {
+            HStack {
+                ("\(ayah: ayah)" as MultipartText)
+                    .view(ofSize: .body)
+                    .foregroundColor(.primary)
+                Spacer()
+                if isSelected {
+                    NoorSystemImage.checkmark.image
+                        .foregroundColor(.accentColor)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/Features/AudioDownloadsFeature/Sources/AudioDownloadsView.swift
+++ b/Features/AudioDownloadsFeature/Sources/AudioDownloadsView.swift
@@ -44,7 +44,7 @@ private struct AudioDownloadsViewUI: View {
                 listItem: { item in
                     NoorListItem(
                         title: .text(item.reciter.localizedName),
-                        subtitle: .init(text: item.size.formattedString(), location: .bottom),
+                        subtitle: .init(text: .text(item.size.formattedString()), location: .bottom),
                         accessory: accessory(item)
                     )
                 },

--- a/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
@@ -258,7 +258,7 @@ final class AyahMenuViewModel {
     private func readingBookmarkLocation(_ bookmark: ReadingPositionBookmark) -> MultipartText {
         let location: MultipartText = switch bookmark.location {
         case .ayah(let ayah):
-            "\(ayah: ayah, format: .compact)"
+            "\(ayah: ayah)"
         case .page(let page):
             "\(page.localizedName)"
         }

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
@@ -114,7 +114,7 @@ private struct AyahBookmarkCollectionDetails: View {
 
     private func bookmarkLocation(_ bookmark: AyahCollectionBookmark) -> MultipartText {
         let ayah = bookmark.ayah
-        return "\(ayah: ayah, format: .numberedSura) · \(ayah.page.localizedName)"
+        return "\(ayah: ayah) · \(ayah.page.localizedName)"
     }
 
     private func quranText(_ bookmark: AyahCollectionBookmark) -> MultipartText? {

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
@@ -116,7 +116,7 @@ private struct BookmarkCollectionsContent: View {
             image: .init(image, color: imageColor),
             title: .text(title),
             subtitle: .init(
-                text: NumberFormatter.shared.format(collection?.bookmarks.count ?? 0),
+                text: .text(NumberFormatter.shared.format(collection?.bookmarks.count ?? 0)),
                 location: .trailing
             ),
             accessory: .disclosureIndicator,

--- a/Features/BookmarksFeature/Sources/BookmarksView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksView.swift
@@ -80,8 +80,8 @@ private struct BookmarksViewUI: View {
         return NoorListItem(
             image: .init(.bookmark, color: .red),
             title: "\(sura: ayah.sura)",
-            subtitle: .init(text: bookmark.creationDate.timeAgo(), location: .bottom),
-            accessory: .text(NumberFormatter.shared.format(bookmark.page.pageNumber))
+            subtitle: .init(text: .text(bookmark.creationDate.timeAgo()), location: .bottom),
+            accessory: .text(bookmark.page.localizedNumber, accessibilityLabel: bookmark.page.localizedName)
         ) {
             selectAction(bookmark)
         }

--- a/Features/HomeFeature/Sources/HomeView.swift
+++ b/Features/HomeFeature/Sources/HomeView.swift
@@ -115,8 +115,8 @@ private struct HomeViewUI: View {
         return NoorListItem(
             image: .init(.lastPage, color: .secondaryLabel),
             title: "\(sura: ayah.sura)",
-            subtitle: .init(text: lastPage.modifiedOn.timeAgo(), location: .bottom),
-            accessory: .text(NumberFormatter.shared.format(lastPage.page.pageNumber))
+            subtitle: .init(text: .text(lastPage.modifiedOn.timeAgo()), location: .bottom),
+            accessory: .text(lastPage.page.localizedNumber, accessibilityLabel: lastPage.page.localizedName)
         ) {
             selectLastPage(lastPage)
         }
@@ -126,12 +126,10 @@ private struct HomeViewUI: View {
         let ayahsString = lFormat("verses", table: .android, sura.verses.count)
         let suraType = sura.isMakki ? lAndroid("makki") : lAndroid("madani")
 
-        let numberFormatter = NumberFormatter.shared
-
         return NoorListItem(
-            title: "\(sura: sura, format: .numbered)",
+            title: "\(sura.localizedSuraNumber). \(sura: sura)",
             subtitle: .init(text: "\(suraType) - \(ayahsString)", location: .bottom),
-            accessory: .text(numberFormatter.format(sura.page.pageNumber))
+            accessory: .text(sura.page.localizedNumber, accessibilityLabel: sura.page.localizedName)
         ) {
             selectSura(sura)
         }
@@ -143,9 +141,10 @@ private struct HomeViewUI: View {
         let page = ayah.page
 
         return NoorListItem(
-            title: "\(quarter.localizedName) - \(ayah: ayah)",
+            subheading: .text(quarter.localizedName),
+            title: "\(ayah: ayah)",
             rightSubtitle: "\(quran: item.ayahText, lineLimit: 1)",
-            accessory: .text(NumberFormatter.shared.format(page.pageNumber))
+            accessory: .text(page.localizedNumber, accessibilityLabel: page.localizedName)
         ) {
             selectQuarter(item)
         }

--- a/Features/MoreMenuFeature/Sources/views/MoreMenuWordPointerType.swift
+++ b/Features/MoreMenuFeature/Sources/views/MoreMenuWordPointerType.swift
@@ -16,7 +16,7 @@ struct MoreMenuWordPointerType: View {
     var body: some View {
         NoorListItem(
             title: .text(l("menu.pointer.select_translation")),
-            subtitle: .init(text: type.localizedName, location: .trailing),
+            subtitle: .init(text: .text(type.localizedName), location: .trailing),
             accessory: .disclosureIndicator
         )
         .padding()

--- a/Features/NotesFeature/Sources/NotesView.swift
+++ b/Features/NotesFeature/Sources/NotesView.swift
@@ -107,8 +107,8 @@ private struct NotesViewUI: View {
             ),
             rightPretitle: quranText(item, color: color),
             title: titleText(for: noteText),
-            subtitle: .init(text: note.modifiedDate.timeAgo(), location: .bottom),
-            accessory: .text(NumberFormatter.shared.format(page.pageNumber))
+            subtitle: .init(text: .text(note.modifiedDate.timeAgo()), location: .bottom),
+            accessory: .text(page.localizedNumber, accessibilityLabel: page.localizedName)
         ) {
             selectAction(item)
         }
@@ -133,8 +133,8 @@ private struct NotesViewUI: View {
     }
 
     private func subheadingText(ayah: AyahNumber, ayahCount: Int) -> MultipartText {
-        let ranges = highlightRanges(in: ayah.localizedName)
-        let ayahText: MultipartText = "\(ayah: ayah, highlighting: ranges)"
+        let emphasizesSura = !highlightRanges(in: ayah.sura.localizedName()).isEmpty
+        let ayahText: MultipartText = "\(ayah: ayah, emphasizingSura: emphasizesSura)"
         if ayahCount > 1 {
             return "\(ayahText) \(lFormat("notes.verses-count", ayahCount - 1))"
         } else {

--- a/Features/QuranPagesFeature/Sources/Page+Localization.swift
+++ b/Features/QuranPagesFeature/Sources/Page+Localization.swift
@@ -6,25 +6,11 @@
 //
 
 import Caching
-import Foundation
 import NoorUI
 import QuranKit
 import QuranTextKit
 
 extension Page {
-    // TODO: Remove
-    public func suraNames() -> NSAttributedString {
-        let suras = verses.map(\.sura).orderedUnique()
-        return suras.reduce(NSMutableAttributedString()) { fullString, sura in
-            if fullString.length > 0 {
-                fullString.append(NSAttributedString(string: " - "))
-            }
-            let suraString = attributedString(of: sura, fontSize: 14)
-            fullString.append(suraString)
-            return fullString
-        }
-    }
-
     public func suraNames() -> MultipartText {
         let suras = verses.map(\.sura).orderedUnique()
         let textArray: [MultipartText] = suras.map { "\(sura: $0)" }
@@ -34,7 +20,7 @@ extension Page {
             if index == 0 {
                 result.append(text)
             } else {
-                result.append(" - \(text)")
+                result.append(" · \(text)")
             }
         }
         return result

--- a/Features/QuranTranslationFeature/Sources/TranslationItem+View.swift
+++ b/Features/QuranTranslationFeature/Sources/TranslationItem+View.swift
@@ -26,7 +26,7 @@ extension TranslationPageFooter: View {
 extension TranslationSuraName: View {
     var body: some View {
         QuranSuraName(
-            suraName: sura.localizedName(withPrefix: false),
+            sura: sura,
             besmAllah: sura.startsWithBesmAllah ? sura.quran.arabicBesmAllah : "",
             besmAllahFontSize: arabicFontSize
         )

--- a/Features/QuranViewFeature/Sources/QuranViewController.swift
+++ b/Features/QuranViewFeature/Sources/QuranViewController.swift
@@ -368,6 +368,7 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         if pages.isEmpty {
             titleView?.firstLine = ""
             titleView?.secondLine = ""
+            titleView?.isAccessibilityElement = false
             return
         }
         let suras = pages.map(\.startSura)
@@ -379,8 +380,12 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
             pageNumbers,
             NumberFormatter.shared.format(juzs.min()!.juzNumber)
         )
-        titleView?.firstLine = suras.min()!.localizedName(withPrefix: true)
+        let sura = suras.min()!
+        let suraReference: MultipartText = "\(sura: sura)"
+        titleView?.firstLineAttributedText = suraReference.attributedString(ofSize: .subheadline)
         titleView?.secondLine = pageDescription
+        titleView?.isAccessibilityElement = true
+        titleView?.accessibilityLabel = "\(suraReference.accessibilityText), \(pageDescription)"
     }
 
     private func updateRightBarItems(animated: Bool, isBookmarked: Bool) {

--- a/Features/QuranViewFeature/Sources/ReadingBookmarkUndoToast.swift
+++ b/Features/QuranViewFeature/Sources/ReadingBookmarkUndoToast.swift
@@ -48,7 +48,7 @@ enum ReadingBookmarkUndoToast {
     private static func location(of bookmark: ReadingPositionBookmark) -> MultipartText {
         switch bookmark.location {
         case .ayah(let ayah):
-            return "\(ayah: ayah, format: .compact)"
+            return "\(ayah: ayah)"
         case .page(let page):
             return .text(page.localizedName)
         }

--- a/Features/QuranViewFeature/Tests/ReadingBookmarkUndoToastTests.swift
+++ b/Features/QuranViewFeature/Tests/ReadingBookmarkUndoToastTests.swift
@@ -12,7 +12,10 @@ final class ReadingBookmarkUndoToastTests: XCTestCase {
 
         let toast = ReadingBookmarkUndoToast.saved(bookmark)
 
-        XCTAssertEqual(toast.message.rawValue, "Reading bookmark saved at Al-Baqarah 2:255 \u{E905}")
+        XCTAssertEqual(
+            toast.message.rawValue(locale: Locale(identifier: "en")),
+            "Reading bookmark saved at Al-Baqarah \u{E905} · 2:255"
+        )
         XCTAssertNil(toast.action)
     }
 
@@ -21,7 +24,7 @@ final class ReadingBookmarkUndoToastTests: XCTestCase {
 
         let toast = ReadingBookmarkUndoToast.saved(bookmark)
 
-        XCTAssertEqual(toast.message.rawValue, "Reading bookmark saved at Page 42")
+        XCTAssertEqual(toast.message.rawValue(locale: Locale(identifier: "en")), "Reading bookmark saved at Page 42")
         XCTAssertNil(toast.action)
     }
 
@@ -35,8 +38,8 @@ final class ReadingBookmarkUndoToastTests: XCTestCase {
         }
 
         XCTAssertEqual(
-            toast.message.rawValue,
-            "Reading bookmark moved from Page 42 to Al-Baqarah 2:255 \u{E905}"
+            toast.message.rawValue(locale: Locale(identifier: "en")),
+            "Reading bookmark moved from Page 42 to Al-Baqarah \u{E905} · 2:255"
         )
         XCTAssertEqual(toast.action?.title, "Undo")
         toast.action?.handler()
@@ -51,7 +54,10 @@ final class ReadingBookmarkUndoToastTests: XCTestCase {
             didUndo = true
         }
 
-        XCTAssertEqual(toast.message.rawValue, "Reading bookmark removed from Al-Baqarah 2:255 \u{E905}")
+        XCTAssertEqual(
+            toast.message.rawValue(locale: Locale(identifier: "en")),
+            "Reading bookmark removed from Al-Baqarah \u{E905} · 2:255"
+        )
         XCTAssertEqual(toast.action?.title, "Undo")
         toast.action?.handler()
         XCTAssertTrue(didUndo)
@@ -65,7 +71,7 @@ final class ReadingBookmarkUndoToastTests: XCTestCase {
             didUndo = true
         }
 
-        XCTAssertEqual(toast.message.rawValue, "Reading bookmark removed from Page 42")
+        XCTAssertEqual(toast.message.rawValue(locale: Locale(identifier: "en")), "Reading bookmark removed from Page 42")
         XCTAssertEqual(toast.action?.title, "Undo")
         toast.action?.handler()
         XCTAssertTrue(didUndo)

--- a/Features/SearchFeature/Sources/SearchView.swift
+++ b/Features/SearchFeature/Sources/SearchView.swift
@@ -8,6 +8,7 @@
 import Localization
 import NoorUI
 import QuranKit
+import QuranLocalization
 import QuranText
 import SwiftUI
 import UIx
@@ -124,9 +125,12 @@ private struct SearchViewUI: View {
                     let title = lFormat("search.result.count", plainTitle, result.items.count)
                     NoorSection(title: title, result.items) { item in
                         NoorListItem(
-                            subheading: "(\(String(item.ayah.sura.suraNumber))) \(ayah: item.ayah)",
+                            subheading: "\(ayah: item.ayah)",
                             title: searchResultText(of: item),
-                            accessory: .text(NumberFormatter.shared.format(item.ayah.page.pageNumber))
+                            accessory: .text(
+                                item.ayah.page.localizedNumber,
+                                accessibilityLabel: item.ayah.page.localizedName
+                            )
                         ) {
                             selectSearchResult((item, result.source))
                         }

--- a/Features/SettingsFeature/Sources/SettingsRootView.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootView.swift
@@ -115,7 +115,7 @@ private struct SettingsRootViewUI: View {
                 NoorListItem(
                     image: .init(.audio),
                     title: .text(l("audio.download-play-amount")),
-                    subtitle: .init(text: audioEnd, location: .trailing),
+                    subtitle: .init(text: .text(audioEnd), location: .trailing),
                     accessory: .disclosureIndicator,
                     action: navigateToAudioEndSelector
                 )

--- a/Features/TranslationVerseFeature/Sources/TranslationVerseViewController.swift
+++ b/Features/TranslationVerseFeature/Sources/TranslationVerseViewController.swift
@@ -141,19 +141,28 @@ class TranslationVerseViewController: UIHostingController<TranslationVerseView> 
     }
 
     private func updateTitle() {
+        let verse = viewModel.currentVerse
+        let suraReference: MultipartText = "\(sura: verse.sura)"
         updateTitle(
-            firstLine: viewModel.currentVerse.sura.localizedName(withNumber: true),
-            secondLine: viewModel.currentVerse.localizedAyahNumber
+            firstLine: suraReference,
+            secondLine: verse.localizedAyahNumber,
+            accessibilityLabel: verse.localizedName
         )
     }
 
-    private func updateTitle(firstLine: String, secondLine: String) {
+    private func updateTitle(
+        firstLine: MultipartText,
+        secondLine: String,
+        accessibilityLabel: String
+    ) {
         let titleView = navigationItem.titleView as? TwoLineNavigationTitleView ?? TwoLineNavigationTitleView(
             firstLineFont: .systemFont(ofSize: 15, weight: .light),
             secondLineFont: .boldSystemFont(ofSize: 15)
         )
-        titleView.firstLine = firstLine
+        titleView.firstLineAttributedText = firstLine.attributedString(ofSize: .subheadline)
         titleView.secondLine = secondLine
+        titleView.isAccessibilityElement = true
+        titleView.accessibilityLabel = accessibilityLabel
         if navigationItem.titleView == nil {
             navigationItem.titleView = titleView
         }

--- a/Features/TranslationsFeature/Sources/TranslationsListView.swift
+++ b/Features/TranslationsFeature/Sources/TranslationsListView.swift
@@ -168,8 +168,8 @@ private struct TranslationsListViewUI: View {
     func subtitle(of translation: Translation) -> NoorListItem.Subtitle? {
         if let translatorDisplayName = translation.translatorDisplayName, !translatorDisplayName.isEmpty {
             return .init(
-                label: l("translation.translator"),
-                text: translatorDisplayName,
+                label: .text(l("translation.translator")),
+                text: .text(translatorDisplayName),
                 location: .bottom
             )
         } else {

--- a/Model/QuranLocalization/Sources/QuranKit+Localization.swift
+++ b/Model/QuranLocalization/Sources/QuranKit+Localization.swift
@@ -12,18 +12,15 @@ import QuranKit
 extension AyahNumber {
     public var localizedAyahNumber: String { lFormat("quran_ayah", table: .android, ayah) }
 
-    public var localizedCompactName: String {
-        "\(sura.localizedName()) \(sura.localizedSuraNumber):\(NumberFormatter.shared.format(ayah))"
+    public func localizedCoordinate(locale: Locale = .preferredLanguageLocale) -> String {
+        let formatter = NumberFormatter()
+        formatter.locale = locale.fixedLocaleNumbers()
+        return "\(formatter.format(sura.suraNumber)):\(formatter.format(ayah))"
     }
 
     public var localizedName: String {
         let suraName = sura.localizedName()
         return "\(suraName), \(localizedAyahNumber)"
-    }
-
-    public var localizedNameWithSuraNumber: String {
-        let localizedSura = sura.localizedName(withNumber: true)
-        return "\(localizedSura) - \(localizedAyahNumber)"
     }
 }
 
@@ -81,13 +78,10 @@ extension Sura {
         NumberFormatter.shared.format(suraNumber)
     }
 
-    public func localizedName(withPrefix: Bool = false, withNumber: Bool = false, language: Language? = nil) -> String {
+    public func localizedName(withPrefix: Bool = false, language: Language? = nil) -> String {
         var suraName = l("sura_names[\(suraNumber - 1)]", table: .suras, language: language)
         if withPrefix {
             suraName = lFormat("quran_sura_title", table: .android, language: language, suraName)
-        }
-        if withNumber {
-            suraName = "\(localizedSuraNumber). \(suraName)"
         }
         return suraName
     }

--- a/Model/QuranLocalization/Tests/QuranKitLocalizationTests.swift
+++ b/Model/QuranLocalization/Tests/QuranKitLocalizationTests.swift
@@ -12,8 +12,11 @@ import XCTest
 final class QuranKitLocalizationTests: XCTestCase {
     // MARK: Internal
 
-    func testAyahCompactLocalization() {
-        XCTAssertEqual("Al-Baqarah 2:255", quran.suras[1].verses[254].localizedCompactName)
+    func testAyahCoordinateLocalization() {
+        let ayah = quran.suras[1].verses[254]
+
+        XCTAssertEqual("2:255", ayah.localizedCoordinate(locale: Locale(identifier: "en-CA")))
+        XCTAssertEqual("٢:٢٥٥", ayah.localizedCoordinate(locale: Locale(identifier: "ar-SA")))
     }
 
     func testQuarterLocalization() {

--- a/Package.swift
+++ b/Package.swift
@@ -598,6 +598,7 @@ private func featuresTargets() -> [[Target]] {
         ]),
 
         target(type, name: "AdvancedAudioOptionsFeature", dependencies: [
+            "NoorUI",
             "ReciterListFeature",
             "QuranAudioKit",
             "QuranLocalization",
@@ -724,6 +725,7 @@ private func featuresTargets() -> [[Target]] {
 
         target(type, name: "TranslationVerseFeature", hasTests: false, dependencies: [
             "AppDependencies",
+            "NoorUI",
             "MoreMenuFeature",
             "TranslationsFeature",
             "QuranTranslationFeature",
@@ -735,6 +737,7 @@ private func featuresTargets() -> [[Target]] {
         target(type, name: "SearchFeature", hasTests: false, dependencies: [
             "AppDependencies",
             "QuranTextKit",
+            "QuranLocalization",
             "FeaturesSupport",
             "ReadingService",
             "NoorUI",
@@ -761,6 +764,7 @@ private func featuresTargets() -> [[Target]] {
             "TranslationVerseFeature",
             "FeaturesSupport",
             "BookmarksFeature",
+            "NoorUI",
             "QuranLocalization",
         ], testDependencies: [
             "MobileSyncTestSupport",

--- a/UI/NoorUI/Sources/Components/List/NoorListItem.swift
+++ b/UI/NoorUI/Sources/Components/List/NoorListItem.swift
@@ -14,7 +14,7 @@ public struct NoorListItem: View {
     public struct Subtitle {
         // MARK: Lifecycle
 
-        public init(label: String? = nil, text: String, location: SubtitleLocation) {
+        public init(label: MultipartText? = nil, text: MultipartText, location: SubtitleLocation) {
             self.label = label
             self.text = text
             self.location = location
@@ -22,8 +22,8 @@ public struct NoorListItem: View {
 
         // MARK: Internal
 
-        let label: String?
-        let text: String
+        let label: MultipartText?
+        let text: MultipartText
         let location: SubtitleLocation
     }
 
@@ -84,7 +84,7 @@ public struct NoorListItem: View {
     }
 
     public enum Accessory {
-        case text(String)
+        case text(String, accessibilityLabel: String? = nil)
         case disclosureIndicator
         case download(DownloadType, action: AsyncAction)
         case image(NoorSystemImage, color: Color? = nil)
@@ -157,7 +157,7 @@ public struct NoorListItem: View {
                 ("rightPretitle", rightPretitle?.rawValue),
                 ("title", title.rawValue),
                 ("rightSubtitle", rightSubtitle?.rawValue),
-                ("subtitle", subtitle?.label),
+                ("subtitle", subtitle?.label?.rawValue),
             ]
             let description = properties.compactMap { p in p.1.map { "\(p.0)=\($0)" } }.joined()
             logger.info("NoorListItem tapped. {\(description)}")
@@ -247,10 +247,11 @@ public struct NoorListItem: View {
     @ViewBuilder
     private func accessoryView(_ accessory: Accessory) -> some View {
         switch accessory {
-        case .text(let text):
+        case .text(let text, let accessibilityLabel):
             Text(text)
                 .foregroundColor(.secondaryLabel)
                 .fontWeight(.light)
+                .accessibilityLabel(accessibilityLabel ?? text)
         case .disclosureIndicator:
             DisclosureIndicator()
         case let .download(type, action):
@@ -282,19 +283,25 @@ public struct NoorListItem: View {
     }
 
     @ViewBuilder
-    private func subtitleText(_ subtitle: Subtitle, textFont: Font) -> Text {
-        Text(subtitle.text)
+    private func subtitleText(_ subtitle: Subtitle, textFont: MultipartText.FontSize) -> some View {
+        subtitle.text.view(ofSize: textFont)
             .foregroundColor(.secondaryLabel)
-            .font(textFont)
     }
 
     @ViewBuilder
-    private func subtitleView(_ subtitle: Subtitle, textFont: Font) -> some View {
+    private func subtitleView(_ subtitle: Subtitle, textFont: MultipartText.FontSize) -> some View {
         if let label = subtitle.label {
-            Text(label)
-                .foregroundColor(.secondaryLabel)
-                .font(textFont.bold()) +
+            HStack {
+                if #available(iOS 16.0, *) {
+                    label.view(ofSize: textFont)
+                        .foregroundColor(.secondaryLabel)
+                        .bold()
+                } else {
+                    label.view(ofSize: textFont)
+                        .foregroundColor(.secondaryLabel)
+                }
                 subtitleText(subtitle, textFont: textFont)
+            }
         } else {
             subtitleText(subtitle, textFont: textFont)
         }
@@ -349,7 +356,7 @@ struct NoorListItem_Previews: PreviewProvider {
 
                     NoorListItem(
                         image: .init(.bookmark, color: .red),
-                        title: "\(sura: quran.suras[0], format: .numbered)",
+                        title: "\(quran.suras[0].localizedSuraNumber). \(sura: quran.suras[0])",
                         subtitle: .init(text: "Just now", location: .bottom),
                         accessory: .text("44")
                     ) {

--- a/UI/NoorUI/Sources/Components/MultipartText+UIKit.swift
+++ b/UI/NoorUI/Sources/Components/MultipartText+UIKit.swift
@@ -1,0 +1,60 @@
+//
+//  MultipartText+UIKit.swift
+//
+
+import Foundation
+import Localization
+import SwiftUI
+import UIKit
+
+extension MultipartText {
+    public func attributedString(ofSize size: FontSize) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        for part in parts {
+            result.append(part.attributedString(ofSize: size, locale: .preferredLanguageLocale))
+        }
+        return result
+    }
+}
+
+private extension TextPart {
+    func attributedString(ofSize size: MultipartText.FontSize, locale: Locale) -> NSAttributedString {
+        switch self {
+        case .plain(let text):
+            NSAttributedString(string: text, attributes: [.font: size.plainUIFont])
+        case .highlighting(let text, let ranges, _):
+            highlightedAttributedString(text: text, ranges: ranges, size: size)
+        case .sura(let sura):
+            QuranReference.sura(sura).attributedString(size: size, locale: locale)
+        case .ayah(let ayah, let emphasizesSura):
+            QuranReference.ayah(ayah).attributedString(
+                size: size,
+                locale: locale,
+                emphasizesSura: emphasizesSura
+            )
+        case .quran(let text, let color, _):
+            NSAttributedString(string: text, attributes: [
+                .backgroundColor: UIColor(color),
+                .font: size.quranUIFont,
+            ])
+        }
+    }
+
+    func highlightedAttributedString(
+        text: String,
+        ranges: [HighlightingRange],
+        size: MultipartText.FontSize
+    ) -> NSAttributedString {
+        let result = NSMutableAttributedString(string: text, attributes: [.font: size.plainUIFont])
+        for highlight in ranges {
+            let range = NSRange(highlight.range, in: text)
+            if let foregroundColor = highlight.foregroundColor {
+                result.addAttribute(.foregroundColor, value: UIColor(foregroundColor), range: range)
+            }
+            if highlight.fontWeight != nil {
+                result.addAttribute(.font, value: size.plainUIFont(emphasized: true), range: range)
+            }
+        }
+        return result
+    }
+}

--- a/UI/NoorUI/Sources/Components/MultipartText.swift
+++ b/UI/NoorUI/Sources/Components/MultipartText.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Localization
 import QuranKit
 import QuranLocalization
 import SwiftUI
@@ -42,12 +43,13 @@ private struct TextPartView: View {
             highlighting(text: text, ranges: ranges)
                 .lineLimit(lineLimit)
                 .font(size.plainFont)
-        case .sura(let sura, let format):
-            referenceText(Text(sura.referenceName(format: format)), sura: sura)
-        case .ayah(let ayah, let format, let ranges):
-            referenceText(
-                highlighting(text: ayah.referenceName(format: format), ranges: ranges),
-                sura: ayah.sura
+        case .sura(let sura):
+            QuranReferenceView(reference: .sura(sura), size: size)
+        case .ayah(let ayah, let emphasizesSura):
+            QuranReferenceView(
+                reference: .ayah(ayah),
+                size: size,
+                emphasizesSura: emphasizesSura
             )
         case .quran(let text, let color, let lineLimit):
             Text(text)
@@ -61,20 +63,6 @@ private struct TextPartView: View {
     // MARK: Private
 
     @ScaledMetric private var quranTextPadding = 5
-
-    @ViewBuilder
-    private func referenceText(_ text: Text, sura: Sura) -> some View {
-        HStack {
-            text
-                .font(size.plainFont)
-            if NSLocale.preferredLanguages.first != "ar" {
-                Text(sura.decoratedSuraNameGlyph)
-                    .padding(.top, 5)
-                    .frame(alignment: .center)
-                    .font(size.suraFont)
-            }
-        }
-    }
 
     private func highlighting(text: String, ranges: [HighlightingRange]) -> Text {
         var attributedString = AttributedString(text)
@@ -94,23 +82,36 @@ private struct TextPartView: View {
     }
 }
 
-private enum TextPart {
+enum TextPart {
     case plain(text: String)
     case highlighting(text: String, ranges: [HighlightingRange], lineLimit: Int?)
-    case sura(Sura, format: MultipartText.SuraReferenceFormat)
-    case ayah(AyahNumber, format: MultipartText.AyahReferenceFormat, highlighting: [HighlightingRange])
+    case sura(Sura)
+    case ayah(AyahNumber, emphasizesSura: Bool)
     case quran(text: String, color: Color, lineLimit: Int?)
 
     // MARK: Internal
 
-    var rawValue: String {
+    func rawValue(locale: Locale) -> String {
         switch self {
         case .plain(let text), .highlighting(let text, _, _):
             text
-        case .sura(let sura, let format):
-            "\(sura.referenceName(format: format)) \(sura.decoratedSuraNameGlyph)"
-        case .ayah(let ayah, let format, _):
-            "\(ayah.referenceName(format: format)) \(ayah.sura.decoratedSuraNameGlyph)"
+        case .sura(let sura):
+            QuranReference.sura(sura).rawValue(locale: locale)
+        case .ayah(let ayah, _):
+            QuranReference.ayah(ayah).rawValue(locale: locale)
+        case .quran(let text, _, _):
+            text
+        }
+    }
+
+    var accessibilityText: String {
+        switch self {
+        case .plain(let text), .highlighting(let text, _, _):
+            text
+        case .sura(let sura):
+            QuranReference.sura(sura).accessibilityText
+        case .ayah(let ayah, _):
+            QuranReference.ayah(ayah).accessibilityText
         case .quran(let text, _, _):
             text
         }
@@ -129,19 +130,15 @@ public struct MultipartText: ExpressibleByStringInterpolation {
             parts.append(.plain(text: literal))
         }
 
-        public mutating func appendInterpolation(
-            sura: Sura,
-            format: SuraReferenceFormat = .name
-        ) {
-            parts.append(.sura(sura, format: format))
+        public mutating func appendInterpolation(sura: Sura) {
+            parts.append(.sura(sura))
         }
 
         public mutating func appendInterpolation(
             ayah: AyahNumber,
-            format: AyahReferenceFormat = .descriptive,
-            highlighting: [HighlightingRange] = []
+            emphasizingSura: Bool = false
         ) {
-            parts.append(.ayah(ayah, format: format, highlighting: highlighting))
+            parts.append(.ayah(ayah, emphasizesSura: emphasizingSura))
         }
 
         public mutating func appendInterpolation(
@@ -185,19 +182,10 @@ public struct MultipartText: ExpressibleByStringInterpolation {
 
     // MARK: Public
 
-    public enum SuraReferenceFormat {
-        case name
-        case numbered
-    }
-
-    public enum AyahReferenceFormat {
-        case compact
-        case descriptive
-        case numberedSura
-    }
-
     public enum FontSize {
+        case title3
         case body
+        case subheadline
         case caption
         case footnote
 
@@ -205,7 +193,9 @@ public struct MultipartText: ExpressibleByStringInterpolation {
 
         var plainFont: Font {
             switch self {
+            case .title3: return .title3
             case .body: return .body
+            case .subheadline: return .subheadline
             case .footnote: return .footnote
             case .caption: return .caption
             }
@@ -213,7 +203,9 @@ public struct MultipartText: ExpressibleByStringInterpolation {
 
         var suraFont: Font {
             switch self {
+            case .title3: return .custom(.suraNames, size: 24, relativeTo: .title3)
             case .body: return .custom(.suraNames, size: 20, relativeTo: .body)
+            case .subheadline: return .custom(.suraNames, size: 19, relativeTo: .subheadline)
             case .footnote: return .custom(.suraNames, size: 16, relativeTo: .footnote)
             case .caption: return .custom(.suraNames, size: 15, relativeTo: .caption)
             }
@@ -221,7 +213,9 @@ public struct MultipartText: ExpressibleByStringInterpolation {
 
         var quranFont: Font {
             switch self {
+            case .title3: return .custom(.quran, size: 24, relativeTo: .title3)
             case .body: return .custom(.quran, size: 20, relativeTo: .body)
+            case .subheadline: return .custom(.quran, size: 18, relativeTo: .subheadline)
             case .footnote: return .custom(.quran, size: 16, relativeTo: .footnote)
             case .caption: return .custom(.quran, size: 15, relativeTo: .caption)
             }
@@ -240,70 +234,29 @@ public struct MultipartText: ExpressibleByStringInterpolation {
         MultiPartTextView(text: self, size: size, alignment: alignment, allowsWrapping: allowsWrapping)
     }
 
+    // MARK: Public
+
+    public var accessibilityText: String {
+        parts.map(\.accessibilityText).joined()
+    }
+
     // MARK: Internal
 
     var rawValue: String {
-        parts.map(\.rawValue).joined()
+        rawValue(locale: .preferredLanguageLocale)
     }
 
-    // MARK: Fileprivate
+    func rawValue(locale: Locale) -> String {
+        parts.map { $0.rawValue(locale: locale) }.joined()
+    }
 
-    fileprivate var parts: [TextPart]
+    var parts: [TextPart]
 }
 
 extension MultipartText {
     public static func text(_ plain: String) -> MultipartText {
         MultipartText(stringLiteral: plain)
     }
-}
-
-private extension Sura {
-    func referenceName(format: MultipartText.SuraReferenceFormat) -> String {
-        switch format {
-        case .name: localizedName()
-        case .numbered: localizedName(withNumber: true)
-        }
-    }
-}
-
-private extension AyahNumber {
-    func referenceName(format: MultipartText.AyahReferenceFormat) -> String {
-        switch format {
-        case .compact: localizedCompactName
-        case .descriptive: localizedName
-        case .numberedSura: localizedNameWithSuraNumber
-        }
-    }
-}
-
-extension Sura {
-    // TODO: make private
-    var decoratedSuraNameGlyph: String {
-        let codePoint = Self.decoratedSuraNameCodePoints[suraNumber - 1]
-        return String(UnicodeScalar(codePoint)!)
-    }
-
-    private static let decoratedSuraNameCodePoints = [
-        0xE904, 0xE905, 0xE906, 0xE907, 0xE908, 0xE90B,
-        0xE90C, 0xE90D, 0xE90E, 0xE90F, 0xE910, 0xE911,
-        0xE912, 0xE913, 0xE914, 0xE915, 0xE916, 0xE917,
-        0xE918, 0xE919, 0xE91A, 0xE91B, 0xE91C, 0xE91D,
-        0xE91E, 0xE91F, 0xE920, 0xE921, 0xE922, 0xE923,
-        0xE924, 0xE925, 0xE926, 0xE92E, 0xE92F, 0xE930,
-        0xE931, 0xE909, 0xE90A, 0xE927, 0xE928, 0xE929,
-        0xE92A, 0xE92B, 0xE92C, 0xE92D, 0xE932, 0xE902,
-        0xE933, 0xE934, 0xE935, 0xE936, 0xE937, 0xE938,
-        0xE939, 0xE93A, 0xE93B, 0xE93C, 0xE900, 0xE901,
-        0xE941, 0xE942, 0xE943, 0xE944, 0xE945, 0xE946,
-        0xE947, 0xE948, 0xE949, 0xE94A, 0xE94B, 0xE94C,
-        0xE94D, 0xE94E, 0xE94F, 0xE950, 0xE951, 0xE952,
-        0xE93D, 0xE93E, 0xE93F, 0xE940, 0xE953, 0xE954,
-        0xE955, 0xE956, 0xE957, 0xE958, 0xE959, 0xE95A,
-        0xE95B, 0xE95C, 0xE95D, 0xE95E, 0xE95F, 0xE960,
-        0xE961, 0xE962, 0xE963, 0xE964, 0xE965, 0xE966,
-        0xE967, 0xE968, 0xE969, 0xE96A, 0xE96B, 0xE96C,
-        0xE96D, 0xE96E, 0xE96F, 0xE970, 0xE971, 0xE972,
-    ]
 }
 
 private struct MultiPartTextView: View {
@@ -320,6 +273,8 @@ private struct MultiPartTextView: View {
                 TextPartView(part: text.parts[i], size: size)
             }
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(text.accessibilityText)
     }
 
     @ViewBuilder

--- a/UI/NoorUI/Sources/Components/QuranReference.swift
+++ b/UI/NoorUI/Sources/Components/QuranReference.swift
@@ -1,0 +1,222 @@
+//
+//  QuranReference.swift
+//
+
+import Foundation
+import Localization
+import NoorFont
+import QuranKit
+import QuranLocalization
+import SwiftUI
+import UIKit
+
+enum QuranReference {
+    case sura(Sura)
+    case ayah(AyahNumber)
+
+    // MARK: Internal
+
+    var accessibilityText: String {
+        switch self {
+        case .sura(let sura):
+            sura.localizedName()
+        case .ayah(let ayah):
+            ayah.localizedName
+        }
+    }
+
+    fileprivate var decoratedGlyph: String {
+        let codePoint = Self.decoratedSuraNameCodePoints[sura.suraNumber - 1]
+        return String(UnicodeScalar(codePoint)!)
+    }
+
+    fileprivate func localizedName(locale: Locale) -> String? {
+        locale.isArabicLanguage ? nil : sura.localizedName()
+    }
+
+    fileprivate func coordinate(locale: Locale) -> String? {
+        switch self {
+        case .sura:
+            nil
+        case .ayah(let ayah):
+            ayah.localizedCoordinate(locale: locale)
+        }
+    }
+
+    func rawValue(locale: Locale) -> String {
+        var components = [String]()
+        if let localizedName = localizedName(locale: locale) {
+            components.append(localizedName)
+        }
+        components.append(decoratedGlyph)
+
+        let suraReference = components.joined(separator: " ")
+        if let coordinate = coordinate(locale: locale) {
+            return "\(suraReference) · \(coordinate)"
+        }
+        return suraReference
+    }
+
+    func attributedString(
+        size: MultipartText.FontSize,
+        locale: Locale,
+        emphasizesSura: Bool = false
+    ) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        if let localizedName = localizedName(locale: locale) {
+            result.append(NSAttributedString(
+                string: localizedName,
+                attributes: [.font: size.plainUIFont(emphasized: emphasizesSura)]
+            ))
+            result.append(NSAttributedString(string: " "))
+        }
+
+        let glyphAttributes: [NSAttributedString.Key: Any] = [
+            .font: size.suraUIFont,
+            .baselineOffset: -2,
+        ]
+        result.append(NSAttributedString(string: decoratedGlyph, attributes: glyphAttributes))
+
+        if let coordinate = coordinate(locale: locale) {
+            result.append(NSAttributedString(
+                string: " · \(coordinate)",
+                attributes: [.font: size.plainUIFont]
+            ))
+        }
+        return result
+    }
+
+    // MARK: Private
+
+    private var sura: Sura {
+        switch self {
+        case .sura(let sura):
+            sura
+        case .ayah(let ayah):
+            ayah.sura
+        }
+    }
+
+    private static let decoratedSuraNameCodePoints = [
+        0xE904, 0xE905, 0xE906, 0xE907, 0xE908, 0xE90B,
+        0xE90C, 0xE90D, 0xE90E, 0xE90F, 0xE910, 0xE911,
+        0xE912, 0xE913, 0xE914, 0xE915, 0xE916, 0xE917,
+        0xE918, 0xE919, 0xE91A, 0xE91B, 0xE91C, 0xE91D,
+        0xE91E, 0xE91F, 0xE920, 0xE921, 0xE922, 0xE923,
+        0xE924, 0xE925, 0xE926, 0xE92E, 0xE92F, 0xE930,
+        0xE931, 0xE909, 0xE90A, 0xE927, 0xE928, 0xE929,
+        0xE92A, 0xE92B, 0xE92C, 0xE92D, 0xE932, 0xE902,
+        0xE933, 0xE934, 0xE935, 0xE936, 0xE937, 0xE938,
+        0xE939, 0xE93A, 0xE93B, 0xE93C, 0xE900, 0xE901,
+        0xE941, 0xE942, 0xE943, 0xE944, 0xE945, 0xE946,
+        0xE947, 0xE948, 0xE949, 0xE94A, 0xE94B, 0xE94C,
+        0xE94D, 0xE94E, 0xE94F, 0xE950, 0xE951, 0xE952,
+        0xE93D, 0xE93E, 0xE93F, 0xE940, 0xE953, 0xE954,
+        0xE955, 0xE956, 0xE957, 0xE958, 0xE959, 0xE95A,
+        0xE95B, 0xE95C, 0xE95D, 0xE95E, 0xE95F, 0xE960,
+        0xE961, 0xE962, 0xE963, 0xE964, 0xE965, 0xE966,
+        0xE967, 0xE968, 0xE969, 0xE96A, 0xE96B, 0xE96C,
+        0xE96D, 0xE96E, 0xE96F, 0xE970, 0xE971, 0xE972,
+    ]
+}
+
+struct QuranReferenceView: View {
+    // MARK: Lifecycle
+
+    init(
+        reference: QuranReference,
+        size: MultipartText.FontSize,
+        emphasizesSura: Bool = false
+    ) {
+        self.reference = reference
+        self.size = size
+        self.emphasizesSura = emphasizesSura
+    }
+
+    // MARK: Internal
+
+    let reference: QuranReference
+    let size: MultipartText.FontSize
+    let emphasizesSura: Bool
+
+    @Environment(\.locale) private var locale
+    @ScaledMetric private var spacing = 4
+    @ScaledMetric private var glyphTopPadding = 5
+
+    var body: some View {
+        HStack(spacing: spacing) {
+            if let localizedName = reference.localizedName(locale: locale) {
+                Text(localizedName)
+                    .font(size.plainFont)
+                    .fontWeight(emphasizesSura ? .heavy : nil)
+            }
+
+            Text(reference.decoratedGlyph)
+                .font(size.suraFont)
+                .padding(.top, glyphTopPadding)
+
+            if let coordinate = reference.coordinate(locale: locale) {
+                Text("·")
+                    .font(size.plainFont)
+                Text(coordinate)
+                    .font(size.plainFont)
+                    .environment(\.layoutDirection, .leftToRight)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(reference.accessibilityText)
+    }
+}
+
+extension MultipartText.FontSize {
+    var plainUIFont: UIFont {
+        UIFont.preferredFont(forTextStyle: uiTextStyle)
+    }
+
+    var suraUIFont: UIFont {
+        UIFontMetrics(forTextStyle: uiTextStyle).scaledFont(
+            for: UIFont(.suraNames, size: suraPointSize)
+        )
+    }
+
+    var quranUIFont: UIFont {
+        UIFontMetrics(forTextStyle: uiTextStyle).scaledFont(
+            for: UIFont(.quran, size: quranPointSize)
+        )
+    }
+
+    func plainUIFont(emphasized: Bool) -> UIFont {
+        guard emphasized else { return plainUIFont }
+        return UIFont.systemFont(ofSize: plainUIFont.pointSize, weight: .heavy)
+    }
+
+    private var uiTextStyle: UIFont.TextStyle {
+        switch self {
+        case .title3: .title3
+        case .body: .body
+        case .subheadline: .subheadline
+        case .caption: .caption1
+        case .footnote: .footnote
+        }
+    }
+
+    private var suraPointSize: CGFloat {
+        switch self {
+        case .title3: 24
+        case .body: 20
+        case .subheadline: 19
+        case .caption: 15
+        case .footnote: 16
+        }
+    }
+
+    private var quranPointSize: CGFloat {
+        switch self {
+        case .title3: 24
+        case .body: 20
+        case .subheadline: 18
+        case .caption: 15
+        case .footnote: 16
+        }
+    }
+}

--- a/UI/NoorUI/Sources/Features/Quran/QuranSuraName.swift
+++ b/UI/NoorUI/Sources/Features/Quran/QuranSuraName.swift
@@ -5,6 +5,7 @@
 //  Created by Mohamed Afifi on 2024-02-10.
 //
 
+import QuranKit
 import QuranText
 import SwiftUI
 
@@ -12,12 +13,12 @@ public struct QuranSuraName: View {
     @ScaledMetric var bottomPadding = 5
     @ScaledMetric var topPadding = 10
 
-    let suraName: String
+    let sura: Sura
     let besmAllah: String
     let besmAllahFontSize: FontSize
 
-    public init(suraName: String, besmAllah: String, besmAllahFontSize: FontSize) {
-        self.suraName = suraName
+    public init(sura: Sura, besmAllah: String, besmAllahFontSize: FontSize) {
+        self.sura = sura
         self.besmAllah = besmAllah
         self.besmAllahFontSize = besmAllahFontSize
     }
@@ -27,8 +28,8 @@ public struct QuranSuraName: View {
             NoorImage.suraHeader.image.resizable()
                 .aspectRatio(contentMode: .fit)
                 .overlay {
-                    Text(suraName)
-                        .font(.title3)
+                    let name: MultipartText = "\(sura: sura)"
+                    name.view(ofSize: .title3, alignment: .center, allowsWrapping: false)
                         .lineLimit(1)
                         .minimumScaleFactor(0.3)
                 }

--- a/UI/NoorUI/Sources/Font/FontName++.swift
+++ b/UI/NoorUI/Sources/Font/FontName++.swift
@@ -9,8 +9,6 @@
 //
 
 import NoorFont
-import QuranKit
-import QuranLocalization
 import QuranText
 import SwiftUI
 
@@ -27,16 +25,4 @@ public extension Font {
     static func arabicTafseer() -> Font {
         custom(.arabic, size: arabicTafseerTextFontSize)
     }
-}
-
-public func attributedString(of sura: Sura, fontSize: CGFloat) -> NSAttributedString {
-    let systemFont = UIFont.systemFont(ofSize: fontSize)
-    let text = NSMutableAttributedString(string: sura.localizedName(), attributes: [.font: systemFont])
-    if NSLocale.preferredLanguages.first == "ar" {
-        return text
-    }
-    text.append(NSAttributedString(string: " "))
-    let decoratedFont = UIFont(.suraNames, size: fontSize + 4)
-    text.append(NSAttributedString(string: sura.decoratedSuraNameGlyph, attributes: [.font: decoratedFont]))
-    return text
 }

--- a/UI/NoorUI/Tests/MultipartTextLayoutTests.swift
+++ b/UI/NoorUI/Tests/MultipartTextLayoutTests.swift
@@ -17,7 +17,7 @@ final class MultipartTextLayoutTests: XCTestCase {
 
         let heights = await MainActor.run {
             let sura = Quran.hafsMadani1405.suras[15]
-            let text: MultipartText = "At An-Nahl 16:30 \(sura: sura) • Move here"
+            let text: MultipartText = "At \(ayah: sura.verses[29]) • Move here"
 
             let wrappingHeight = fittingHeight(
                 text.view(ofSize: .footnote)

--- a/UI/NoorUI/Tests/MultipartTextLocalizationTests.swift
+++ b/UI/NoorUI/Tests/MultipartTextLocalizationTests.swift
@@ -13,9 +13,8 @@ import XCTest
 
 final class MultipartTextLocalizationTests: XCTestCase {
     func test_localizedFormat_insertsMultipartTextArguments() {
-        let sura = Quran.hafsMadani1405.suras[1]
-        let start: MultipartText = "Al-Baqarah 2:255 \(sura: sura)"
-        let end: MultipartText = "Al-Baqarah 2:256"
+        let start: MultipartText = "\(ayah: Quran.hafsMadani1405.suras[1].verses[254])"
+        let end: MultipartText = "\(ayah: Quran.hafsMadani1405.suras[1].verses[255])"
 
         let result = MultipartText.localizedFormat(
             "audio.playing.message",
@@ -25,8 +24,8 @@ final class MultipartTextLocalizationTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            result.rawValue,
-            "Playing audio from Al-Baqarah 2:255 \(sura.localizedName()) \u{E905} to Al-Baqarah 2:256"
+            result.rawValue(locale: Locale(identifier: "en")),
+            "Playing audio from Al-Baqarah \u{E905} · 2:255 to Al-Baqarah \u{E905} · 2:256"
         )
     }
 
@@ -39,6 +38,6 @@ final class MultipartTextLocalizationTests: XCTestCase {
             arguments: [first, second]
         )
 
-        XCTAssertEqual(result.rawValue, "second / first / second")
+        XCTAssertEqual(result.rawValue(locale: Locale(identifier: "en")), "second / first / second")
     }
 }

--- a/UI/NoorUI/Tests/MultipartTextQuranTests.swift
+++ b/UI/NoorUI/Tests/MultipartTextQuranTests.swift
@@ -8,37 +8,42 @@ import XCTest
 @testable import NoorUI
 
 final class MultipartTextQuranTests: XCTestCase {
-    func test_suraReference_usesLocalizedNameAndDecoratedGlyph() {
+    func test_suraReference_inNonArabicLocale_usesLocalizedNameAndDecoratedGlyph() {
         let text: MultipartText = "\(sura: sura)"
 
-        XCTAssertEqual(text.rawValue, "\(sura.localizedName()) \u{E905}")
+        XCTAssertEqual(text.rawValue(locale: english), "\(sura.localizedName()) \u{E905}")
     }
 
-    func test_numberedSuraReference_includesSuraNumber() {
-        let text: MultipartText = "\(sura: sura, format: .numbered)"
+    func test_suraReference_inArabicLocale_usesOnlyDecoratedGlyph() {
+        let text: MultipartText = "\(sura: sura)"
 
-        XCTAssertEqual(text.rawValue, "\(sura.localizedName(withNumber: true)) \u{E905}")
+        XCTAssertEqual(text.rawValue(locale: arabic), "\u{E905}")
     }
 
-    func test_ayahReference_usesLocalizedNameAndDecoratedSuraGlyph() {
+    func test_suraReference_inNonArabicRightToLeftLocale_keepsLocalizedName() {
+        let text: MultipartText = "\(sura: sura)"
+
+        XCTAssertEqual(text.rawValue(locale: Locale(identifier: "fa-IR")), "\(sura.localizedName()) \u{E905}")
+    }
+
+    func test_ayahReference_inNonArabicLocale_usesCanonicalReference() {
         let text: MultipartText = "\(ayah: ayah)"
 
-        XCTAssertEqual(text.rawValue, "\(ayah.localizedName) \u{E905}")
+        XCTAssertEqual(text.rawValue(locale: english), "\(sura.localizedName()) \u{E905} · 2:255")
     }
 
-    func test_numberedSuraAyahReference_includesSuraNumber() {
-        let text: MultipartText = "\(ayah: ayah, format: .numberedSura)"
+    func test_ayahReference_inArabicLocale_usesGlyphAndLocalizedCoordinate() {
+        let text: MultipartText = "\(ayah: ayah)"
 
-        XCTAssertEqual(text.rawValue, "\(ayah.localizedNameWithSuraNumber) \u{E905}")
+        XCTAssertEqual(text.rawValue(locale: arabic), "\u{E905} · ٢:٢٥٥")
     }
 
-    func test_compactAyahReference_usesSuraAndAyahNumbers() {
-        let text: MultipartText = "\(ayah: ayah, format: .compact)"
+    func test_references_useSemanticAccessibilityText() {
+        let suraText: MultipartText = "\(sura: sura)"
+        let ayahText: MultipartText = "\(ayah: ayah)"
 
-        XCTAssertEqual(
-            text.rawValue,
-            "\(ayah.localizedCompactName) \u{E905}"
-        )
+        XCTAssertEqual(suraText.accessibilityText, sura.localizedName())
+        XCTAssertEqual(ayahText.accessibilityText, ayah.localizedName)
     }
 
     func test_quranText_preservesText() {
@@ -58,4 +63,6 @@ final class MultipartTextQuranTests: XCTestCase {
 
     private let sura = Quran.hafsMadani1405.suras[1]
     private let ayah = Quran.hafsMadani1405.suras[1].verses[254]
+    private let english = Locale(identifier: "en-CA")
+    private let arabic = Locale(identifier: "ar-SA")
 }

--- a/UI/UIx/Sources/UIKit/Views/TwoLineNavigationTitleView.swift
+++ b/UI/UIx/Sources/UIKit/Views/TwoLineNavigationTitleView.swift
@@ -25,6 +25,12 @@ public class TwoLineNavigationTitleView: UIView {
     // MARK: Public
 
     public var firstLine: String = "" {
+        didSet {
+            firstLineAttributedText = nil
+        }
+    }
+
+    public var firstLineAttributedText: NSAttributedString? {
         didSet { updateAttributedText() }
     }
 
@@ -68,9 +74,8 @@ public class TwoLineNavigationTitleView: UIView {
     }
 
     private func updateAttributedText() {
-        let string = NSMutableAttributedString(string: firstLine, attributes: [
-            .font: firstLineFont,
-        ])
+        let string = firstLineAttributedText.map(NSMutableAttributedString.init(attributedString:))
+            ?? NSMutableAttributedString(string: firstLine, attributes: [.font: firstLineFont])
         if !isCompressed {
             string.append(NSAttributedString(string: "\n"))
         } else {


### PR DESCRIPTION
## Summary

- Add typed `QuranReference` rendering for canonical Sura and Ayah references.
- Standardize reference displays across NoorUI and feature consumers.
- Show localized Sura names plus decorated glyphs outside Arabic locales; show only decorated glyphs in Arabic locales.
- Keep the advanced audio verse picker as one sectioned list while extracting Sura sections and Ayah rows into custom SwiftUI views for lazy rendering.

## Display format

- Sura: localized name + decorated glyph
- Ayah: localized name + decorated glyph + `· sura:ayah`
- Arabic locales: decorated glyph only, plus the canonical Ayah suffix when applicable

## Stack

- Base: #910 (`afifi/multipart-text-toast`)

## Checks

- `make format-lint`
- `make build-no-sync TARGET=AdvancedAudioOptionsFeature`
- `make build-sync TARGET=AdvancedAudioOptionsFeature`
- `make test-no-sync TARGET=AdvancedAudioOptionsFeatureTests` (20 tests)
- `make test-sync TARGET=AdvancedAudioOptionsFeatureTests` (20 tests)