### PR TITLE
Redesign note cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Keeping these commands green locally should keep the CI workflow green as well.
 - Inject concrete data services through builders and view models; do not wrap them in closure-based adapters.
 - Use `@ScaledMetric` for explicit UI dimensions that should scale with Dynamic Type; avoid fixed numeric layout metrics.
 - Prefer default `.padding()` spacing; specify edges or values only when the design requires custom spacing.
+- Always use `#Preview` for SwiftUI previews; do not use `PreviewProvider`.
 - Preserve localized strings; do not hardcode user-facing text unless existing nearby code does.
 
 ## Concurrency

--- a/Features/AppStructureFeature/Sources/Tabs/NotesTab.swift
+++ b/Features/AppStructureFeature/Sources/Tabs/NotesTab.swift
@@ -50,8 +50,8 @@ private class NotesTabViewController: TabViewController {
     override func getTabBarItem() -> UITabBarItem {
         UITabBarItem(
             title: l("tab.notes"),
-            image: .symbol("text.badge.star"),
-            selectedImage: .symbol("text.badge.star", withConfiguration: UIImage.SymbolConfiguration(weight: .bold))
+            image: .symbol("text.justify.leading"),
+            selectedImage: .symbol("text.justify.leading", withConfiguration: UIImage.SymbolConfiguration(weight: .bold))
         )
     }
 }

--- a/Features/NotesFeature/Sources/NoteCard.swift
+++ b/Features/NotesFeature/Sources/NoteCard.swift
@@ -1,0 +1,158 @@
+//
+//  NoteCard.swift
+//
+
+import NoorUI
+import QuranKit
+import QuranLocalization
+import SwiftUI
+import UIx
+
+@MainActor
+struct NoteCard: View {
+    // MARK: Internal
+
+    let reference: MultipartText
+    let location: String
+    let quranText: MultipartText?
+    let noteText: MultipartText?
+    let modifiedDate: String
+    let noteColor: Color?
+    let editAccessibilityHint: String
+    let selectAction: @MainActor @Sendable () -> Void
+    let editAction: @MainActor @Sendable () -> Void
+
+    @ScaledMetric private var cardCornerRadius = 20.0
+    @ScaledMetric private var cardPadding = 18.0
+    @ScaledMetric private var contentSpacing = 16.0
+    @ScaledMetric private var metadataSpacing = 2.0
+    @ScaledMetric private var footerSpacing = 8.0
+    @ScaledMetric private var colorIndicatorWidth = 4.0
+    @ScaledMetric private var colorIndicatorInset = 12.0
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Button(action: selectAction) {
+                VStack(alignment: .leading, spacing: contentSpacing) {
+                    header
+
+                    if let quranText {
+                        HStack {
+                            quranText.view(ofSize: .caption, alignment: .trailing)
+                                .foregroundColor(.secondaryLabel)
+                            Spacer(minLength: 0)
+                        }
+                        .environment(\.layoutDirection, .rightToLeft)
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+                }
+                .padding(.horizontal, cardPadding)
+                .padding(.top, cardPadding)
+                .padding(.bottom, contentSpacing)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(BackgroundHighlightingStyle())
+
+            Divider()
+                .padding(.horizontal, cardPadding)
+                .accessibilityHidden(true)
+
+            Button(action: editAction) {
+                VStack(alignment: .leading, spacing: contentSpacing) {
+                    if let noteText {
+                        noteText.view(ofSize: .body)
+                            .foregroundColor(.label)
+                            .lineLimit(3)
+                            .truncationMode(.tail)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    footer
+                }
+                .padding(.horizontal, cardPadding)
+                .padding(.top, contentSpacing)
+                .padding(.bottom, cardPadding)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(BackgroundHighlightingStyle())
+            .accessibilityHint(editAccessibilityHint)
+        }
+        .background(Color.secondarySystemGroupedBackground)
+        .clipShape(RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous))
+        #if !QURAN_SYNC
+            .overlay(alignment: .leading) {
+                if let noteColor {
+                    Capsule()
+                        .fill(noteColor)
+                        .frame(width: colorIndicatorWidth)
+                        .padding(.vertical, colorIndicatorInset)
+                        .accessibilityHidden(true)
+                        .allowsHitTesting(false)
+                }
+            }
+        #endif
+    }
+
+    // MARK: Private
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: metadataSpacing) {
+                reference
+                    .view(ofSize: .footnote, allowsWrapping: false)
+
+                Text(location)
+                    .font(.footnote)
+                    .foregroundColor(.secondaryLabel)
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: footerSpacing) {
+            Text(modifiedDate)
+                .font(.footnote)
+                .foregroundColor(.secondaryLabel)
+
+            Spacer(minLength: 0)
+
+            Image(systemName: "chevron.right")
+                .font(.subheadline.weight(.semibold))
+                .foregroundColor(.tertiaryLabel)
+                .flipsForRightToLeftLayoutDirection(true)
+                .accessibilityHidden(true)
+        }
+    }
+}
+
+@MainActor
+private struct NoteCardPreview: View {
+    var body: some View {
+        let ayah = Quran.hafsMadani1405.suras[15].verses[26]
+        let reference: MultipartText = "\(ayah: ayah)"
+        let quranText: MultipartText = "\(quran: "ثُمَّ يَوْمَ الْقِيَامَةِ يُخْزِيهِمْ وَيَقُولُ أَيْنَ شُرَكَائِيَ الَّذِينَ كُنتُمْ تُشَاقُّونَ فِيهِمْ", color: .clear, lineLimit: 2)"
+
+        NoteCard(
+            reference: reference,
+            location: "\(ayah.page.startJuz.localizedName) · \(ayah.page.localizedName)",
+            quranText: quranText,
+            noteText: .text("“Where are My partners?” — the question itself is the humiliation."),
+            modifiedDate: "Yesterday",
+            noteColor: .green,
+            editAccessibilityHint: "Edit note",
+            selectAction: {},
+            editAction: {}
+        )
+        .padding()
+        .frame(width: 390)
+        .background(Color.systemGroupedBackground)
+    }
+}
+
+#Preview {
+    NoteCardPreview()
+}

--- a/Features/NotesFeature/Sources/NotesView.swift
+++ b/Features/NotesFeature/Sources/NotesView.swift
@@ -56,6 +56,9 @@ private struct NotesViewUI: View {
                 NoorList {
                     NoorSection(notes) { note in
                         listItem(note)
+                            .listRowInsets(.init(top: 6, leading: 0, bottom: 6, trailing: 0))
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
                     }
                     .onDelete(action: deleteAction)
                 }
@@ -93,25 +96,22 @@ private struct NotesViewUI: View {
         let ayah = note.startAyah
         let page = ayah.page
         #if QURAN_SYNC
-        let color = Color.clear
+        let noteColor: Color? = nil
         #else
-        let color = note.color.color.opacity(QuranHighlights.opacity)
+        let noteColor: Color? = note.color.color
         #endif
         let noteText = item.noteText.trimmingCharacters(in: .whitespacesAndNewlines)
-        return NoorListItem(
-            subheading: subheadingText(ayah: ayah, ayahCount: note.verses.count),
-            headerAccessory: .button(
-                image: .edit,
-                accessibilityLabel: l("ayah.menu.edit-note"),
-                action: { editAction(item) }
-            ),
-            rightPretitle: quranText(item, color: color),
-            title: titleText(for: noteText),
-            subtitle: .init(text: .text(note.modifiedDate.timeAgo()), location: .bottom),
-            accessory: .text(page.localizedNumber, accessibilityLabel: page.localizedName)
-        ) {
-            selectAction(item)
-        }
+        return NoteCard(
+            reference: subheadingText(ayah: ayah, ayahCount: note.verses.count),
+            location: "\(page.startJuz.localizedName) · \(page.localizedName)",
+            quranText: quranText(item),
+            noteText: noteText.isEmpty ? nil : titleText(for: noteText),
+            modifiedDate: note.modifiedDate.timeAgo(),
+            noteColor: noteColor,
+            editAccessibilityHint: l("ayah.menu.edit-note"),
+            selectAction: { selectAction(item) },
+            editAction: { editAction(item) }
+        )
     }
 
     private func highlightRanges(in text: String) -> [HighlightingRange] {
@@ -142,11 +142,11 @@ private struct NotesViewUI: View {
         }
     }
 
-    private func quranText(_ item: NoteItem, color: Color) -> MultipartText? {
+    private func quranText(_ item: NoteItem) -> MultipartText? {
         guard let text = item.quranText else {
             return nil
         }
-        return "\(quran: text, color: color, lineLimit: 2)"
+        return "\(quran: text, color: .clear, lineLimit: 2)"
     }
 }
 

--- a/UI/NoorUI/Sources/Components/MultipartText.swift
+++ b/UI/NoorUI/Sources/Components/MultipartText.swift
@@ -41,7 +41,7 @@ private struct TextPartView: View {
                 .font(size.plainFont)
         case .highlighting(let text, let ranges, let lineLimit):
             highlighting(text: text, ranges: ranges)
-                .lineLimit(lineLimit)
+                .optionalLineLimit(lineLimit)
                 .font(size.plainFont)
         case .sura(let sura):
             QuranReferenceView(reference: .sura(sura), size: size)
@@ -53,7 +53,7 @@ private struct TextPartView: View {
             )
         case .quran(let text, let color, let lineLimit):
             Text(text)
-                .lineLimit(lineLimit)
+                .optionalLineLimit(lineLimit)
                 .font(size.quranFont)
                 .padding(quranTextPadding)
                 .background(color)
@@ -79,6 +79,25 @@ private struct TextPartView: View {
             }
         }
         return Text(attributedString)
+    }
+}
+
+private struct OptionalLineLimitModifier: ViewModifier {
+    let lineLimit: Int?
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if let lineLimit {
+            content.lineLimit(lineLimit)
+        } else {
+            content
+        }
+    }
+}
+
+private extension View {
+    func optionalLineLimit(_ lineLimit: Int?) -> some View {
+        modifier(OptionalLineLimitModifier(lineLimit: lineLimit))
     }
 }
 

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -50,13 +50,13 @@ private struct AyahMenuViewList: View {
 
     var editNote: some View {
         Row(title: l("ayah.menu.edit-note"), action: dataObject.actions.addNote) {
-            noteIcon(legacySystemName: "text.bubble.fill")
+            noteIcon
         }
     }
 
     var addNote: some View {
         Row(title: l("ayah.menu.add-note"), action: dataObject.actions.addNote) {
-            noteIcon(legacySystemName: "plus.bubble.fill")
+            noteIcon
         }
     }
 
@@ -207,12 +207,12 @@ private struct AyahMenuViewList: View {
 
     #endif
 
-    private func noteIcon(legacySystemName: String) -> some View {
+    private var noteIcon: some View {
         Group {
             if dataObject.usesSyncedNotesIcon {
                 NoorSystemImage.note.image
             } else {
-                Image(systemName: legacySystemName)
+                NoorSystemImage.note.image
                     .foregroundColor(dataObject.highlightingColor.color)
             }
         }

--- a/UI/NoorUI/Sources/Images/NoorSystemImage.swift
+++ b/UI/NoorUI/Sources/Images/NoorSystemImage.swift
@@ -27,7 +27,7 @@ public enum NoorSystemImage: String {
     case folder = "folder.fill"
     case folderOutline = "folder"
     case plusCircle = "plus.circle"
-    case note = "text.badge.star"
+    case note = "text.justify.leading"
     case lastPage = "clock"
     case profile = "person.crop.circle"
     case settings = "gearshape"

--- a/UI/NoorUI/Tests/MultipartTextLayoutTests.swift
+++ b/UI/NoorUI/Tests/MultipartTextLayoutTests.swift
@@ -12,6 +12,29 @@ import XCTest
 @testable import NoorUI
 
 final class MultipartTextLayoutTests: XCTestCase {
+    func test_view_highlightedText_respectsInheritedLineLimit() async {
+        guard #available(iOS 16.0, *) else { return }
+
+        let value = String(repeating: "A long note that should be truncated. ", count: 10)
+        let range = value.startIndex ..< value.index(value.startIndex, offsetBy: 6)
+        let plain = MultipartText.text(value)
+        let highlighted: MultipartText = "\(value, highlighting: [HighlightingRange(range, fontWeight: .heavy)])"
+
+        let heights = await MainActor.run {
+            let plainHeight = fittingHeight(
+                plain.view(ofSize: .body)
+                    .lineLimit(3)
+            )
+            let highlightedHeight = fittingHeight(
+                highlighted.view(ofSize: .body)
+                    .lineLimit(3)
+            )
+            return (plainHeight, highlightedHeight)
+        }
+
+        XCTAssertEqual(heights.1, heights.0, accuracy: 1)
+    }
+
     func test_view_whenWrappingIsDisabled_keepsMultipartContentOnOneLine() async {
         guard #available(iOS 16.0, *) else { return }
 


### PR DESCRIPTION
## Summary

- Redesign Notes rows as rounded cards with clearer Quran, metadata, note, and date hierarchy.
- Split each card into two independently highlighted actions: the top opens the Quran and the bottom opens the note editor.
- Show a leading legacy note-color indicator when `QURAN_SYNC` is disabled.
- Standardize note symbols on `text.justify.leading`.
- Fix highlighted `MultipartText` content overriding inherited line limits, with regression coverage.
- Use `#Preview` for the new note-card preview and document that convention.

## Why

The previous row had one ambiguous touch target and did not preserve legacy note colors after the visual redesign. Filtered note text also expanded past its three-line limit because the highlighted multipart part applied `.lineLimit(nil)`, overriding the card's inherited limit.

## Impact

Notes are easier to scan, Quran navigation and note editing are distinct, press feedback is localized to the selected action, and filtered results remain consistently truncated.

## Validation

- `make format-lint`
- `make build-no-sync TARGET=NotesFeature`
- `make build-sync TARGET=NotesFeature`
- `make test-no-sync TARGET=NoorUITests`
- `make test-sync TARGET=NoorUITests`


## Screenshots

<img width="306" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-22 at 20 02 17" src="https://github.com/user-attachments/assets/97c09d68-300b-4ec8-ab7d-75bdc16c4399" />

<img width="306" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-22 at 20 00 22" src="https://github.com/user-attachments/assets/00104334-aaea-4343-a82b-c33711a60e43" />
<img width="306" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-22 at 20 00 30" src="https://github.com/user-attachments/assets/6e1982e4-4ea4-4d95-a7d8-2caa805af317" />
<img width="306" alt="Simulator Screenshot - iPhone 17 - 2026-07-22 at 20 00 38" src="https://github.com/user-attachments/assets/44ea64af-9fd5-4989-83b1-68d0262d40ae" />

