### PR TITLE
Fix legacy highlight controls and sync boundaries

### DIFF
--- a/Features/AyahMenuFeature/Sources/AyahMenuBuilder.swift
+++ b/Features/AyahMenuFeature/Sources/AyahMenuBuilder.swift
@@ -39,16 +39,12 @@ public struct AyahMenuInput {
         sourceView: UIView,
         pointInView: CGPoint,
         verses: [AyahNumber],
-        notes: [QuranAnnotations.Note],
-        highlightVerses: [AyahNumber: HighlightColor] = [:],
-        bookmarkedVerses: Set<AyahNumber> = []
+        notes: [QuranAnnotations.Note]
     ) {
         self.sourceView = sourceView
         self.pointInView = pointInView
         self.verses = verses
         self.notes = notes
-        self.highlightVerses = highlightVerses
-        self.bookmarkedVerses = bookmarkedVerses
     }
     #endif
 
@@ -58,9 +54,9 @@ public struct AyahMenuInput {
     let pointInView: CGPoint
     let verses: [AyahNumber]
     let notes: [QuranAnnotations.Note]
+    #if QURAN_SYNC
     let highlightVerses: [AyahNumber: HighlightColor]
     let bookmarkedVerses: Set<AyahNumber>
-    #if QURAN_SYNC
     let readingBookmark: ReadingPositionBookmark?
     #endif
 }
@@ -98,8 +94,6 @@ public struct AyahMenuBuilder {
             verses: input.verses,
             textRetriever: textRetriever,
             notes: input.notes,
-            highlightVerses: input.highlightVerses,
-            bookmarkedVerses: input.bookmarkedVerses,
             noteService: container.noteService()
         )
         #endif

--- a/Features/AyahMenuFeature/Sources/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/Sources/AyahMenuViewController.swift
@@ -52,7 +52,7 @@ final class AyahMenuViewController: UIViewController {
         let actions = AyahMenuUI.Actions(
             play: { [weak self] in self?.viewModel.play() },
             repeatVerses: { [weak self] in self?.viewModel.repeatVerses() },
-            bookmark: { [weak self] in self?.viewModel.bookmark() },
+            highlight: { [weak self] color in await self?.viewModel.updateHighlight(color: color) },
             addNote: { [weak self] in await self?.viewModel.editNote() },
             deleteNote: { [weak self] in await self?.viewModel.deleteNotes() },
             showTranslation: { [weak self] in self?.viewModel.showTranslation() },
@@ -78,8 +78,6 @@ final class AyahMenuViewController: UIViewController {
         let dataObject = AyahMenuUI.DataObject(
             highlightingColor: highlightingColor,
             state: viewModel.noteState,
-            bookmarkTitle: viewModel.bookmarkTitle,
-            bookmarkState: viewModel.bookmarkState,
             playSubtitle: viewModel.playSubtitle,
             repeatSubtitle: viewModel.repeatSubtitle,
             actions: actions,

--- a/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
@@ -27,10 +27,10 @@ public protocol AyahMenuListener: AnyObject {
 
     func shareText(_ lines: [String], in sourceView: UIView, at point: CGPoint)
     func showTranslation(_ verses: [AyahNumber])
-    func showBookmarkEditor(for verses: [AyahNumber])
     func showNoteEditor(for verses: [AyahNumber]) async
     func deleteNotes(in verses: [AyahNumber]) async
     #if QURAN_SYNC
+    func showCollectionEditor(for verses: [AyahNumber])
     func setReadingBookmark(at ayah: AyahNumber, replacing bookmark: ReadingPositionBookmark?) async
     func removeReadingBookmark(_ bookmark: ReadingPositionBookmark) async
     #endif
@@ -46,9 +46,9 @@ final class AyahMenuViewModel {
         let verses: [AyahNumber]
         let textRetriever: ShareableVerseTextRetriever
         let notes: [QuranAnnotations.Note]
+        #if QURAN_SYNC
         let highlightVerses: [AyahNumber: HighlightColor]
         let bookmarkedVerses: Set<AyahNumber>
-        #if QURAN_SYNC
         let readingBookmark: ReadingPositionBookmark?
         #else
         let noteService: NoteService
@@ -90,6 +90,7 @@ final class AyahMenuViewModel {
         }
     }
 
+    #if QURAN_SYNC
     var bookmarkTitle: String {
         lFormat("bookmarks.editor.title", deps.verses.count)
     }
@@ -105,6 +106,7 @@ final class AyahMenuViewModel {
         }
         return .highlighted(color)
     }
+    #endif
 
     var repeatSubtitle: String {
         if deps.verses.count == 1 {
@@ -168,10 +170,29 @@ final class AyahMenuViewModel {
         listener?.playAudio(verses[0], to: verses.last, repeatVerses: true)
     }
 
+    #if QURAN_SYNC
     func bookmark() {
         logger.info("AyahMenu: bookmark tapped. Verses: \(deps.verses)")
-        listener?.showBookmarkEditor(for: deps.verses)
+        listener?.showCollectionEditor(for: deps.verses)
     }
+
+    #else
+    func updateHighlight(color: HighlightColor) async {
+        logger.info("AyahMenu: update verse highlights. Verses: \(deps.verses)")
+        listener?.dismissAyahMenu()
+
+        do {
+            _ = try await deps.noteService.updateHighlight(
+                verses: deps.verses,
+                color: color,
+                quran: ReadingPreferences.shared.reading.quran
+            )
+            logger.info("AyahMenu: notes updated")
+        } catch {
+            crasher.recordError(error, reason: "Failed to update highlights")
+        }
+    }
+    #endif
 
     #if QURAN_SYNC
     func setReadingBookmark() async {

--- a/Features/AyahMenuFeature/Tests/AyahMenuLegacyViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuLegacyViewModelTests.swift
@@ -1,0 +1,104 @@
+#if !QURAN_SYNC
+import Analytics
+import AnnotationsService
+import Combine
+import QuranAnnotations
+import QuranKit
+import QuranTextKit
+import UIKit
+import XCTest
+@testable import AyahMenuFeature
+@testable import NotePersistence
+
+@MainActor
+final class AyahMenuLegacyViewModelTests: XCTestCase {
+    func test_updateHighlightPersistsSelectedColorAndDismissesMenu() async {
+        let persistence = NotePersistenceSpy()
+        let sut = makeSUT(persistence: persistence)
+        let listener = ListenerSpy()
+        sut.listener = listener
+
+        await sut.updateHighlight(color: .blue)
+
+        XCTAssertEqual(persistence.setNoteCall, .init(
+            note: nil,
+            verses: [
+                VersePersistenceModel(ayah: 7, sura: 1),
+                VersePersistenceModel(ayah: 1, sura: 2),
+            ],
+            color: HighlightColor.blue.rawValue
+        ))
+        XCTAssertTrue(listener.didDismiss)
+    }
+
+    private func makeSUT(persistence: NotePersistence) -> AyahMenuViewModel {
+        let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-quran-database")
+        let verses = [
+            AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 7)!,
+            AyahNumber(quran: .hafsMadani1405, sura: 2, ayah: 1)!,
+        ]
+        return AyahMenuViewModel(deps: .init(
+            sourceView: UIView(),
+            pointInView: .zero,
+            verses: verses,
+            textRetriever: ShareableVerseTextRetriever(
+                databasesURL: unavailableDatabase,
+                quranFileURL: unavailableDatabase
+            ),
+            notes: [],
+            noteService: NoteService(persistence: persistence, analytics: NoopAnalytics())
+        ))
+    }
+}
+
+private final class NotePersistenceSpy: NotePersistence {
+    struct SetNoteCall: Equatable {
+        let note: String?
+        let verses: [VersePersistenceModel]
+        let color: Int
+    }
+
+    private(set) var setNoteCall: SetNoteCall?
+
+    func notes() -> AnyPublisher<[NotePersistenceModel], Never> {
+        Just([]).eraseToAnyPublisher()
+    }
+
+    func setNote(
+        _ note: String?,
+        verses: [VersePersistenceModel],
+        color: Int
+    ) async throws -> NotePersistenceModel {
+        setNoteCall = .init(note: note, verses: verses, color: color)
+        return NotePersistenceModel(
+            verses: Set(verses),
+            modifiedDate: .distantPast,
+            note: note,
+            color: color
+        )
+    }
+
+    func removeNotes(with verses: [VersePersistenceModel]) async throws -> [NotePersistenceModel] {
+        []
+    }
+}
+
+private struct NoopAnalytics: AnalyticsLibrary {
+    func logEvent(_ name: String, value: String) {}
+}
+
+@MainActor
+private final class ListenerSpy: AyahMenuListener {
+    private(set) var didDismiss = false
+
+    func dismissAyahMenu() {
+        didDismiss = true
+    }
+
+    func playAudio(_ from: AyahNumber, to: AyahNumber?, repeatVerses: Bool) {}
+    func shareText(_ lines: [String], in sourceView: UIView, at point: CGPoint) {}
+    func showTranslation(_ verses: [AyahNumber]) {}
+    func showNoteEditor(for verses: [AyahNumber]) async {}
+    func deleteNotes(in verses: [AyahNumber]) async {}
+}
+#endif

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -227,7 +227,7 @@ private final class BookmarkListenerSpy: AyahMenuListener {
         removedReadingBookmark = bookmark
     }
 
-    func showBookmarkEditor(for verses: [AyahNumber]) {
+    func showCollectionEditor(for verses: [AyahNumber]) {
         bookmarkedVerses = verses
     }
 }

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsBuilder.swift
@@ -1,10 +1,10 @@
+#if QURAN_SYNC
 //
 //  BookmarkAyahsBuilder.swift
 //
 
 import AppDependencies
 import NoorUI
-import QuranAnnotations
 import QuranKit
 import UIKit
 
@@ -18,7 +18,6 @@ public struct BookmarkAyahsBuilder {
 
     // MARK: Public
 
-    #if QURAN_SYNC
     public func build(
         verses: [AyahNumber],
         collections: [AyahBookmarkCollection]
@@ -32,19 +31,6 @@ public struct BookmarkAyahsBuilder {
         )
         return navigationController(viewModel: viewModel)
     }
-    #else
-    public func build(
-        verses: [AyahNumber],
-        notes: [QuranAnnotations.Note]
-    ) -> UIViewController {
-        let viewModel = BookmarkAyahsViewModel(
-            verses: verses,
-            notes: notes,
-            noteService: container.noteService()
-        )
-        return navigationController(viewModel: viewModel)
-    }
-    #endif
 
     // MARK: Private
 
@@ -57,3 +43,4 @@ public struct BookmarkAyahsBuilder {
         return navigationController
     }
 }
+#endif

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsView.swift
@@ -1,10 +1,10 @@
+#if QURAN_SYNC
 //
 //  BookmarkAyahsView.swift
 //
 
 import Localization
 import NoorUI
-import QuranAnnotations
 import SwiftUI
 import UIx
 
@@ -15,7 +15,6 @@ struct BookmarkAyahsView: View {
     var body: some View {
         NoorList {
             NoorBasicSection(title: l("ayah.menu.highlight")) {
-                #if QURAN_SYNC
                 HighlightColorPicker(
                     selectedColor: viewModel.selectedHighlightColor,
                     partiallySelectedColors: viewModel.partiallySelectedHighlightColors,
@@ -25,16 +24,8 @@ struct BookmarkAyahsView: View {
                         : { await viewModel.selectHighlight(nil) }
                 )
                 .disabled(viewModel.isUpdatingHighlight)
-                #else
-                HighlightColorPicker(
-                    selectedColor: viewModel.selectedHighlightColor,
-                    onSelect: { await viewModel.selectHighlight($0) }
-                )
-                .disabled(viewModel.isUpdatingHighlight)
-                #endif
             }
 
-            #if QURAN_SYNC
             NoorBasicSection(title: l("bookmarks.collections.mine")) {
                 ForEach(viewModel.displayedCollections, id: \.collection.id) { collection in
                     collectionRow(collection)
@@ -47,16 +38,12 @@ struct BookmarkAyahsView: View {
                     action: { viewModel.presentAddCollection() }
                 )
             }
-            #endif
         }
-        #if QURAN_SYNC
         .task { await viewModel.start() }
-            .addBookmarkCollectionAlert(viewModel: viewModel)
-        #endif
-            .errorAlert(error: $viewModel.error)
+        .addBookmarkCollectionAlert(viewModel: viewModel)
+        .errorAlert(error: $viewModel.error)
     }
 
-    #if QURAN_SYNC
     private func collectionRow(_ collection: AyahBookmarkCollection) -> some View {
         let selection = viewModel.collectionSelection(for: collection)
         return NoorListItem(
@@ -94,10 +81,8 @@ struct BookmarkAyahsView: View {
             l("bookmarks.editor.collection.selected")
         }
     }
-    #endif
 }
 
-#if QURAN_SYNC
 private extension View {
     @MainActor
     func addBookmarkCollectionAlert(viewModel: BookmarkAyahsViewModel) -> some View {

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsViewController.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsViewController.swift
@@ -1,3 +1,4 @@
+#if QURAN_SYNC
 //
 //  BookmarkAyahsViewController.swift
 //
@@ -36,3 +37,4 @@ final class BookmarkAyahsViewController: UIHostingController<BookmarkAyahsView> 
         navigationItem.rightBarButtonItem = doneButton
     }
 }
+#endif

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsViewModel.swift
@@ -1,3 +1,4 @@
+#if QURAN_SYNC
 //
 //  BookmarkAyahsViewModel.swift
 //
@@ -8,10 +9,8 @@ import Foundation
 import Localization
 import QuranAnnotations
 import QuranKit
-import ReadingService
 import VLogging
 
-#if QURAN_SYNC
 @MainActor
 final class BookmarkAyahsViewModel: ObservableObject {
     enum HighlightSelection: Equatable {
@@ -241,60 +240,5 @@ final class BookmarkAyahsViewModel: ObservableObject {
         var seen = Set<AyahNumber>()
         return verses.filter { seen.insert($0).inserted }
     }
-}
-#else
-@MainActor
-final class BookmarkAyahsViewModel: ObservableObject {
-    // MARK: Lifecycle
-
-    init(
-        verses: [AyahNumber],
-        notes: [QuranAnnotations.Note],
-        noteService: NoteService
-    ) {
-        self.verses = verses
-        self.noteService = noteService
-        selectedHighlightColor = noteService.color(from: notes)
-    }
-
-    // MARK: Internal
-
-    @Published private(set) var isUpdatingHighlight = false
-    @Published var error: Error?
-    @Published private(set) var selectedHighlightColor: HighlightColor
-
-    var title: String {
-        lFormat("bookmarks.editor.title", verses.count)
-    }
-
-    func selectHighlight(_ color: HighlightColor?) async {
-        guard let color, color != selectedHighlightColor, !isUpdatingHighlight else {
-            return
-        }
-
-        let previousColor = selectedHighlightColor
-        selectedHighlightColor = color
-        isUpdatingHighlight = true
-        defer { isUpdatingHighlight = false }
-
-        do {
-            _ = try await noteService.updateHighlight(
-                verses: verses,
-                color: color,
-                quran: ReadingPreferences.shared.reading.quran
-            )
-        } catch is CancellationError {
-            selectedHighlightColor = previousColor
-        } catch {
-            logger.error("Bookmarks: failed to update highlight: \(error)")
-            selectedHighlightColor = previousColor
-            self.error = error
-        }
-    }
-
-    // MARK: Private
-
-    private let verses: [AyahNumber]
-    private let noteService: NoteService
 }
 #endif

--- a/Features/NoteEditorFeature/Sources/NoteEditorViewModel.swift
+++ b/Features/NoteEditorFeature/Sources/NoteEditorViewModel.swift
@@ -115,14 +115,20 @@ final class NoteEditorViewModel {
     @discardableResult
     func commitEditsAndExit(dismissOnSave: Bool) async -> Bool {
         logger.info("NoteEditor: done tapped")
+        #if QURAN_SYNC
         guard hasNoteText else {
             if dismissOnSave {
                 listener?.dismissNoteEditor()
             }
             return dismissOnSave
         }
+        #else
+        guard hasNoteText || dismissOnSave else {
+            return false
+        }
+        #endif
 
-        guard canSubmitNote else {
+        guard !hasNoteText || canSubmitNote else {
             return false
         }
 

--- a/Features/NoteEditorFeature/Tests/NoteEditorViewModelTests.swift
+++ b/Features/NoteEditorFeature/Tests/NoteEditorViewModelTests.swift
@@ -199,16 +199,19 @@ final class NoteEditorViewModelTests: XCTestCase {
         XCTAssertFalse(sut.listener.didDismiss)
     }
 
-    func test_emptyNote_doneDismissesWithoutSavingInLegacy() async throws {
-        let sut = makeLegacySUT(noteBody: "")
-        _ = try await sut.viewModel.fetchNote()
+    func test_emptyNote_doneSavesLegacyHighlightColorAndDismisses() async throws {
+        let sut = makeLegacySUT(noteBody: "", color: .blue)
+        let editableNote = try await sut.viewModel.fetchNote()
+        editableNote.selectedColor = .green
 
         let didFinish = await sut.viewModel.commitEditsAndExit(dismissOnSave: true)
 
         XCTAssertTrue(sut.viewModel.canDismissNote)
         XCTAssertFalse(sut.viewModel.shouldAutoSaveOnDismiss)
         XCTAssertTrue(didFinish)
-        XCTAssertTrue(sut.noteService.setNoteCalls.isEmpty)
+        XCTAssertEqual(sut.noteService.setNoteCalls, [
+            .init(note: "", verses: [ayah(1), ayah(2)], color: .green),
+        ])
         XCTAssertTrue(sut.listener.didDismiss)
     }
 

--- a/Features/QuranViewFeature/Sources/QuranBuilder.swift
+++ b/Features/QuranViewFeature/Sources/QuranBuilder.swift
@@ -10,7 +10,9 @@ import AnnotationsService
 import AppDependencies
 import AudioBannerFeature
 import AyahMenuFeature
+#if QURAN_SYNC
 import BookmarksFeature
+#endif
 import MoreMenuFeature
 import NoteEditorFeature
 import QuranContentFeature
@@ -49,7 +51,6 @@ public struct QuranBuilder {
             quran: quran,
             highlightsService: highlightsService,
             ayahMenuBuilder: AyahMenuBuilder(container: container),
-            bookmarkAyahsBuilder: BookmarkAyahsBuilder(container: container),
             moreMenuBuilder: MoreMenuBuilder(),
             audioBannerBuilder: AudioBannerBuilder(container: container),
             wordPointerBuilder: WordPointerBuilder(container: container),
@@ -59,6 +60,7 @@ public struct QuranBuilder {
             resources: container.readingResources,
             notesObserver: notesObserver,
             noteEditorBuilder: NoteEditorBuilder(container: container),
+            bookmarkAyahsBuilder: BookmarkAyahsBuilder(container: container),
             syncedHighlightsObserver: syncedHighlightsObserver,
             readingBookmarkObserver: readingBookmarkObserver
         )
@@ -70,7 +72,6 @@ public struct QuranBuilder {
             quran: quran,
             highlightsService: highlightsService,
             ayahMenuBuilder: AyahMenuBuilder(container: container),
-            bookmarkAyahsBuilder: BookmarkAyahsBuilder(container: container),
             moreMenuBuilder: MoreMenuBuilder(),
             audioBannerBuilder: AudioBannerBuilder(container: container),
             wordPointerBuilder: WordPointerBuilder(container: container),

--- a/Features/QuranViewFeature/Sources/QuranInteractor.swift
+++ b/Features/QuranViewFeature/Sources/QuranInteractor.swift
@@ -10,7 +10,9 @@ import Analytics
 import AnnotationsService
 import AudioBannerFeature
 import AyahMenuFeature
+#if QURAN_SYNC
 import BookmarksFeature
+#endif
 import Combine
 import Crashing
 import FeaturesSupport
@@ -45,7 +47,9 @@ protocol QuranPresentable: UIViewController {
 
     func presentMoreMenu(_ viewController: UIViewController)
     func presentAyahMenu(_ viewController: UIViewController, in sourceView: UIView, at point: CGPoint)
+    #if QURAN_SYNC
     func presentBookmarkAyahs(_ viewController: UIViewController)
+    #endif
     func presentTranslatedVerse(_ viewController: UIViewController, didDismiss: @escaping () -> Void)
     func presentAudioBanner(_ audioBanner: UIViewController)
     func presentWordPointer(_ viewController: UIViewController)
@@ -65,7 +69,6 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let quran: Quran
         let highlightsService: QuranHighlightsService
         let ayahMenuBuilder: AyahMenuBuilder
-        let bookmarkAyahsBuilder: BookmarkAyahsBuilder
         let moreMenuBuilder: MoreMenuBuilder
         let audioBannerBuilder: AudioBannerBuilder
         let wordPointerBuilder: WordPointerBuilder
@@ -76,6 +79,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let notesObserver: QuranNotesObserver
         let noteEditorBuilder: NoteEditorBuilder
         #if QURAN_SYNC
+        let bookmarkAyahsBuilder: BookmarkAyahsBuilder
         let syncedHighlightsObserver: QuranSyncedHighlightsObserver
         let readingBookmarkObserver: QuranReadingBookmarkObserver
         #else
@@ -261,29 +265,22 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         #endif
     }
 
-    func showBookmarkEditor(for verses: [AyahNumber]) {
+    #if QURAN_SYNC
+    func showCollectionEditor(for verses: [AyahNumber]) {
         logger.info("Quran: show bookmark editor. Verses: \(verses)")
         contentViewModel?.removeAyahMenuHighlight()
         presenter?.dismissPresentedViewController { [weak self] in
             guard let self else {
                 return
             }
-            #if QURAN_SYNC
             let viewController = deps.bookmarkAyahsBuilder.build(
                 verses: verses,
                 collections: deps.syncedHighlightsObserver.collections
             )
-            #else
-            let viewController = deps.bookmarkAyahsBuilder.build(
-                verses: verses,
-                notes: notesInteractingVerses(verses)
-            )
-            #endif
             presenter?.presentBookmarkAyahs(viewController)
         }
     }
 
-    #if QURAN_SYNC
     func setReadingBookmark(at ayah: AyahNumber, replacing previousBookmark: ReadingPositionBookmark?) async {
         if await performReadingBookmarkAction(
             .set(location: .ayah(ayah), replacing: previousBookmark)
@@ -329,9 +326,6 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let bookmarkedVerses = Set(deps.syncedHighlightsObserver.collections.flatMap { collection in
             collection.bookmarks.map(\.ayah)
         })
-        #else
-        let highlightVerses = deps.highlightsService.highlights.noteVerses.mapValues(\.color)
-        let bookmarkedVerses: Set<AyahNumber> = []
         #endif
         #if QURAN_SYNC
         let input = AyahMenuInput(
@@ -348,9 +342,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
             sourceView: sourceView,
             pointInView: point,
             verses: verses,
-            notes: notesInteractingVerses(verses),
-            highlightVerses: highlightVerses,
-            bookmarkedVerses: bookmarkedVerses
+            notes: notesInteractingVerses(verses)
         )
         #endif
         let ayahMenuViewController = deps.ayahMenuBuilder.build(withListener: self, input: input)

--- a/Features/QuranViewFeature/Sources/QuranViewController.swift
+++ b/Features/QuranViewFeature/Sources/QuranViewController.swift
@@ -203,6 +203,7 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         )
     }
 
+    #if QURAN_SYNC
     func presentBookmarkAyahs(_ viewController: UIViewController) {
         if let sheet = viewController.sheetPresentationController {
             sheet.detents = [.medium(), .large()]
@@ -210,6 +211,7 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         }
         present(viewController, animated: true)
     }
+    #endif
 
     func presentQuranContent(_ viewController: UIViewController) {
         addContent(viewController)

--- a/Package.swift
+++ b/Package.swift
@@ -573,6 +573,9 @@ private func featuresTargets() -> [[Target]] {
             "AnnotationsService",
             "NoorUI",
             "QuranLocalization",
+        ], testDependencies: [
+            "Analytics",
+            "NotePersistence",
         ]),
 
         target(type, name: "WhatsNewFeature", hasTests: false, dependencies: [

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuUI.swift
@@ -40,7 +40,7 @@ public enum AyahMenuUI {
         public init(
             play: @escaping AsyncAction,
             repeatVerses: @escaping AsyncAction,
-            bookmark: @escaping AsyncAction,
+            highlight: @Sendable @escaping (HighlightColor) async -> Void,
             addNote: @escaping AsyncAction,
             deleteNote: @escaping AsyncAction,
             showTranslation: @escaping AsyncAction,
@@ -49,7 +49,7 @@ public enum AyahMenuUI {
         ) {
             self.play = play
             self.repeatVerses = repeatVerses
-            self.bookmark = bookmark
+            self.highlight = highlight
             self.addNote = addNote
             self.deleteNote = deleteNote
             self.showTranslation = showTranslation
@@ -62,7 +62,11 @@ public enum AyahMenuUI {
 
         let play: AsyncAction
         let repeatVerses: AsyncAction
+        #if QURAN_SYNC
         let bookmark: AsyncAction
+        #else
+        let highlight: @Sendable (HighlightColor) async -> Void
+        #endif
         let addNote: AsyncAction
         let deleteNote: AsyncAction
         let showTranslation: AsyncAction
@@ -105,8 +109,6 @@ public enum AyahMenuUI {
         public init(
             highlightingColor: HighlightColor,
             state: NoteState,
-            bookmarkTitle: String,
-            bookmarkState: BookmarkState = .unhighlighted,
             playSubtitle: String,
             repeatSubtitle: String,
             actions: Actions,
@@ -115,8 +117,6 @@ public enum AyahMenuUI {
         ) {
             self.highlightingColor = highlightingColor
             self.state = state
-            self.bookmarkTitle = bookmarkTitle
-            self.bookmarkState = bookmarkState
             self.playSubtitle = playSubtitle
             self.repeatSubtitle = repeatSubtitle
             self.actions = actions
@@ -130,8 +130,10 @@ public enum AyahMenuUI {
         let highlightingColor: HighlightColor
         let state: NoteState
         let actions: Actions
+        #if QURAN_SYNC
         let bookmarkTitle: String
         let bookmarkState: BookmarkState
+        #endif
         let playSubtitle: String
         let repeatSubtitle: String
         let isTranslationView: Bool
@@ -149,12 +151,14 @@ public enum AyahMenuUI {
         case noted
     }
 
+    #if QURAN_SYNC
     public enum BookmarkState: Equatable {
         case unhighlighted
         case bookmarked
         case partiallyHighlighted
         case highlighted(HighlightColor)
     }
+    #endif
 
     #if QURAN_SYNC
     public enum ReadingBookmarkState {

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -11,6 +11,13 @@ import QuranAnnotations
 import SwiftUI
 import UIx
 
+#if !QURAN_SYNC
+private enum MenuState {
+    case list
+    case highlights
+}
+#endif
+
 public struct AyahMenuView: View {
     // MARK: Lifecycle
 
@@ -21,21 +28,60 @@ public struct AyahMenuView: View {
     // MARK: Public
 
     public var body: some View {
+        #if QURAN_SYNC
         ScrollView {
             AyahMenuViewList(dataObject: dataObject)
         }
         .preferredContentSizeMatchesScrollView()
+        #else
+        switch state {
+        case .list:
+            ScrollView {
+                AyahMenuViewList(dataObject: dataObject) {
+                    withAnimation {
+                        state = .highlights
+                    }
+                }
+            }
+            .preferredContentSizeMatchesScrollView()
+            .transition(.opacity)
+        case .highlights:
+            ScrollView {
+                NoteCircles(selectedColor: existingHighlightedColor, tapped: dataObject.actions.highlight)
+            }
+            .preferredContentSizeMatchesScrollView()
+            .transition(.scale(scale: 2).combined(with: .opacity))
+        }
+        #endif
     }
 
     // MARK: Internal
 
     let dataObject: AyahMenuUI.DataObject
+
+    // MARK: Private
+
+    #if !QURAN_SYNC
+    @State private var state: MenuState = .list
+
+    private var existingHighlightedColor: HighlightColor? {
+        switch dataObject.state {
+        case .highlighted, .noted:
+            return dataObject.highlightingColor
+        case .noHighlight:
+            return nil
+        }
+    }
+    #endif
 }
 
 private struct AyahMenuViewList: View {
     // MARK: Internal
 
     let dataObject: AyahMenuUI.DataObject
+    #if !QURAN_SYNC
+    let showHighlights: AsyncAction
+    #endif
 
     var noteDeleteText: String {
         switch dataObject.state {
@@ -100,9 +146,31 @@ private struct AyahMenuViewList: View {
                     .padding(.leading)
                 #endif
 
+                #if QURAN_SYNC
                 Row(title: dataObject.bookmarkTitle, action: dataObject.actions.bookmark) {
                     bookmarkIcon
                 }
+                #else
+                if dataObject.state == .noHighlight {
+                    Row(
+                        title: l("ayah.menu.highlight"),
+                        action: {
+                            await dataObject.actions.highlight(dataObject.highlightingColor)
+                        }
+                    ) {
+                        IconCircle(color: dataObject.highlightingColor)
+                    }
+                    Divider()
+                        .padding(.leading)
+                }
+                Row(
+                    title: l("ayah.menu.highlight"),
+                    subtitle: .text(l("ayah.menu.highlight-select-color")),
+                    action: showHighlights
+                ) {
+                    HighlightPaletteIcon()
+                }
+                #endif
                 Divider()
                     .padding(.leading)
 
@@ -148,6 +216,7 @@ private struct AyahMenuViewList: View {
 
     // MARK: Private
 
+    #if QURAN_SYNC
     @ViewBuilder private var bookmarkIcon: some View {
         switch dataObject.bookmarkState {
         case .unhighlighted:
@@ -159,6 +228,7 @@ private struct AyahMenuViewList: View {
                 .foregroundColor(color.color)
         }
     }
+    #endif
 
     #if QURAN_SYNC
     @ViewBuilder
@@ -352,109 +422,154 @@ private struct MenuGroup<Content: View>: View {
     }
 }
 
-struct AyahMenuView_Previews: PreviewProvider {
+#if !QURAN_SYNC
+private struct IconCircle: View {
+    @ScaledMetric private var minLength = 20.0
+
+    let color: HighlightColor
+
+    var body: some View {
+        ColoredCircle(color: color.color, selected: false, minLength: minLength)
+    }
+}
+
+private struct NoteCircles: View {
+    let selectedColor: HighlightColor?
+    let tapped: @Sendable (HighlightColor) async -> Void
+
+    var body: some View {
+        HStack {
+            ForEach(HighlightColor.sortedColors, id: \.self) { color in
+                AsyncButton(
+                    action: { await tapped(color) },
+                    label: { NoteCircle(color: color.color, selected: color == selectedColor) }
+                )
+                .shadow(color: Color.tertiarySystemGroupedBackground, radius: 1)
+                .accessibilityLabel(color.localizedName)
+                .accessibilityAddTraits(color == selectedColor ? .isSelected : [])
+            }
+        }
+        .padding()
+    }
+}
+#endif
+
+#if QURAN_SYNC
+private let previewActions = AyahMenuUI.Actions(
+    play: {},
+    repeatVerses: {},
+    bookmark: {},
+    addNote: {},
+    deleteNote: {},
+    showTranslation: {},
+    copy: {},
+    share: {},
+    setReadingBookmark: {},
+    removeReadingBookmark: {}
+)
+#else
+private let previewActions = AyahMenuUI.Actions(
+    play: {},
+    repeatVerses: {},
+    highlight: { _ in },
+    addNote: {},
+    deleteNote: {},
+    showTranslation: {},
+    copy: {},
+    share: {}
+)
+#endif
+
+#Preview("Noted") {
+    VStack {
+        Spacer()
+        AyahMenuView(dataObject: previewDataObject(
+            highlightingColor: .green,
+            state: .noted,
+            isTranslationView: true
+        ))
+        Spacer()
+    }
+    .frame(width: 320, height: 470)
+    .background(Color.systemGroupedBackground)
+}
+
+#Preview("Highlighted · Dark") {
+    VStack {
+        Spacer()
+        AyahMenuView(dataObject: previewDataObject(
+            highlightingColor: .red,
+            state: .highlighted,
+            isTranslationView: true
+        ))
+        Spacer()
+    }
+    .frame(width: 320, height: 470)
+    .background(Color.systemGroupedBackground)
+    .colorScheme(.dark)
+}
+
+#Preview("No Highlight · XXXL") {
+    VStack {
+        Spacer()
+        AyahMenuView(dataObject: previewDataObject(
+            highlightingColor: .green,
+            state: .noHighlight,
+            isTranslationView: true
+        ))
+        Spacer()
+    }
+    .frame(width: 320, height: 470)
+    .background(Color.systemGroupedBackground)
+    .environment(\.sizeCategory, .extraExtraExtraLarge)
+}
+
+#if !QURAN_SYNC
+#Preview("Highlight Colors") {
+    NoteCircles(selectedColor: .blue, tapped: { _ in })
+        .background(Color.secondarySystemGroupedBackground)
+}
+#endif
+
+private func previewDataObject(
+    highlightingColor: HighlightColor,
+    state: AyahMenuUI.NoteState,
+    isTranslationView: Bool
+) -> AyahMenuUI.DataObject {
     #if QURAN_SYNC
-    static let actions = AyahMenuUI.Actions(
-        play: {},
-        repeatVerses: {},
-        bookmark: {},
-        addNote: {},
-        deleteNote: {},
-        showTranslation: {},
-        copy: {},
-        share: {},
-        setReadingBookmark: {},
-        removeReadingBookmark: {}
+    let bookmarkState: AyahMenuUI.BookmarkState = switch state {
+    case .noHighlight:
+        .unhighlighted
+    case .highlighted:
+        .partiallyHighlighted
+    case .noted:
+        .highlighted(highlightingColor)
+    }
+    let bookmarkTitle = switch state {
+    case .highlighted:
+        "Save Ayahs..."
+    case .noHighlight, .noted:
+        "Save Ayah..."
+    }
+    return AyahMenuUI.DataObject(
+        highlightingColor: highlightingColor,
+        state: state,
+        bookmarkTitle: bookmarkTitle,
+        bookmarkState: bookmarkState,
+        playSubtitle: "To the end of Juz'",
+        repeatSubtitle: "selected verses",
+        actions: previewActions,
+        isTranslationView: isTranslationView,
+        readingBookmarkState: .unset
     )
     #else
-    static let actions = AyahMenuUI.Actions(
-        play: {},
-        repeatVerses: {},
-        bookmark: {},
-        addNote: {},
-        deleteNote: {},
-        showTranslation: {},
-        copy: {},
-        share: {}
+    return AyahMenuUI.DataObject(
+        highlightingColor: highlightingColor,
+        state: state,
+        playSubtitle: "To the end of Juz'",
+        repeatSubtitle: "selected verses",
+        actions: previewActions,
+        isTranslationView: isTranslationView
     )
     #endif
-
-    static var previews: some View {
-        Group {
-            VStack {
-                Spacer()
-                AyahMenuView(dataObject: dataObject(
-                    highlightingColor: .green,
-                    state: .noted,
-                    bookmarkTitle: "Save Ayah...",
-                    bookmarkState: .highlighted(.green),
-                    isTranslationView: true
-                ))
-                Spacer()
-            }
-            .background(Color.systemGroupedBackground)
-
-            VStack {
-                Spacer()
-                AyahMenuView(dataObject: dataObject(
-                    highlightingColor: .red,
-                    state: .highlighted,
-                    bookmarkTitle: "Save Ayahs...",
-                    bookmarkState: .partiallyHighlighted,
-                    isTranslationView: true
-                ))
-                Spacer()
-            }
-            .background(Color.systemGroupedBackground)
-            .colorScheme(.dark)
-
-            VStack {
-                Spacer()
-                AyahMenuView(dataObject: dataObject(
-                    highlightingColor: .green,
-                    state: .noHighlight,
-                    bookmarkTitle: "Save Ayah...",
-                    bookmarkState: .unhighlighted,
-                    isTranslationView: true
-                ))
-                Spacer()
-            }
-            .background(Color.systemGroupedBackground)
-            .environment(\.sizeCategory, .extraExtraExtraLarge)
-        }
-        .previewLayout(.fixed(width: 320, height: 470))
-    }
-
-    private static func dataObject(
-        highlightingColor: HighlightColor,
-        state: AyahMenuUI.NoteState,
-        bookmarkTitle: String,
-        bookmarkState: AyahMenuUI.BookmarkState,
-        isTranslationView: Bool
-    ) -> AyahMenuUI.DataObject {
-        #if QURAN_SYNC
-        AyahMenuUI.DataObject(
-            highlightingColor: highlightingColor,
-            state: state,
-            bookmarkTitle: bookmarkTitle,
-            bookmarkState: bookmarkState,
-            playSubtitle: "To the end of Juz'",
-            repeatSubtitle: "selected verses",
-            actions: actions,
-            isTranslationView: isTranslationView,
-            readingBookmarkState: .unset
-        )
-        #else
-        AyahMenuUI.DataObject(
-            highlightingColor: highlightingColor,
-            state: state,
-            bookmarkTitle: bookmarkTitle,
-            bookmarkState: bookmarkState,
-            playSubtitle: "To the end of Juz'",
-            repeatSubtitle: "selected verses",
-            actions: actions,
-            isTranslationView: isTranslationView
-        )
-        #endif
-    }
 }


### PR DESCRIPTION
## Summary

- restore the attached inline highlight color picker for `!QURAN_SYNC`
- persist legacy highlight changes when saving an empty note
- keep `BookmarkAyahs` and collection-only Ayah menu state behind `QURAN_SYNC`
- replace the Ayah menu preview provider with `#Preview` variants

## Why

The legacy Ayah menu still routed its highlight action through the bookmark editor after that editor became sync-only. This left dead collection APIs in no-sync builds and prevented the original inline color workflow. Empty legacy notes also exited before persisting their selected highlight color.

## Validation

- `make format-lint`
- `make build-no-sync`
- `make build-sync`
- `make test-no-sync TARGET=AyahMenuFeature`
- `make test-sync TARGET=AyahMenuFeature`
- `make test-sync TARGET=BookmarksFeature`
- `make test-sync TARGET=QuranViewFeature`
