### PR TITLE
feat: show synced note count in ayah menu

### DIFF
--- a/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -181,6 +181,7 @@
 "ayah.menu.highlight-select-color" = "اختر لون";
 "ayah.menu.add-note" = "اضف ملاحظة";
 "ayah.menu.edit-note" = "تحرير الملاحظة";
+"ayah.menu.notes-count" = "الملاحظات (%d)";
 "ayah.menu.delete-note" = "حذف الملاحظة";
 "ayah.menu.delete-highlight" = "حذف التحديد";
 

--- a/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -155,6 +155,7 @@
 "notes.no-data.title" = "إضافة آيات مرجعية...";
 "notes.no-data.text" = "اضغط مع الاستمرار على الآيات. يمكنك تمديد التحديد ليشمل عدة آيات ، ثم اضغط على زر الإشارة المرجعية.";
 "notes.verses-count" = "(+%d آيات)";
+"notes.new" = "ملاحظة جديدة";
 "notes.delete.alert.title" = "حذف الإشارة المرجعية";
 "notes.delete.alert.body" = "سيتم حذف الملاحظة أيضًا.";
 "notes.delete-note.alert.title" = "حذف الملاحظة";

--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -168,6 +168,7 @@
 "notes.no-data.title" = "Adding Ayah Highlights...";
 "notes.no-data.text" = "Tap and hold on an Ayah. You can extend the selection to include multiple Ayat, then tap the Bookmark button.";
 "notes.verses-count" = "(+%d ayat)";
+"notes.new" = "New Note";
 "notes.delete.alert.title" = "Delete Highlight";
 "notes.delete.alert.body" = "The associated note will also be deleted.";
 "notes.delete-note.alert.title" = "Delete Note";

--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -194,6 +194,7 @@
 "ayah.menu.highlight-select-color" = "select color";
 "ayah.menu.add-note" = "Add Note";
 "ayah.menu.edit-note" = "Edit Note";
+"ayah.menu.notes-count" = "Notes (%d)";
 "ayah.menu.delete-note" = "Delete Note";
 "ayah.menu.delete-highlight" = "Delete Highlight";
 "ayah.menu.reading-bookmark.title" = "Reading Bookmark";

--- a/Features/AyahMenuFeature/Sources/AyahMenuViewController.swift
+++ b/Features/AyahMenuFeature/Sources/AyahMenuViewController.swift
@@ -66,6 +66,7 @@ final class AyahMenuViewController: UIViewController {
             highlightingColor: highlightingColor,
             state: viewModel.noteState,
             bookmarkTitle: viewModel.bookmarkTitle,
+            notesTitle: viewModel.notesTitle,
             bookmarkState: viewModel.bookmarkState,
             playSubtitle: viewModel.playSubtitle,
             repeatSubtitle: viewModel.repeatSubtitle,

--- a/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
@@ -95,6 +95,10 @@ final class AyahMenuViewModel {
         lFormat("bookmarks.editor.title", deps.verses.count)
     }
 
+    var notesTitle: String {
+        lFormat("ayah.menu.notes-count", deps.notes.count)
+    }
+
     var bookmarkState: AyahMenuUI.BookmarkState {
         let colors = deps.verses.compactMap { deps.highlightVerses[$0] }
         guard !colors.isEmpty else {

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -62,6 +62,17 @@ final class AyahMenuViewModelTests: XCTestCase {
         XCTAssertEqual(lFormat("bookmarks.editor.title", language: .english, 2), "Save Ayahs...")
     }
 
+    func test_notesTitle_showsLocalizedNumberOfNotes() {
+        let sut = makeSUT(notes: [
+            note(id: "first"),
+            note(id: "second"),
+        ])
+
+        XCTAssertEqual(sut.notesTitle, lFormat("ayah.menu.notes-count", 2))
+        XCTAssertEqual(lFormat("ayah.menu.notes-count", language: .english, 2), "Notes (2)")
+        XCTAssertEqual(lFormat("ayah.menu.notes-count", language: .arabic, 2), "الملاحظات (2)")
+    }
+
     func test_readingBookmarkCopy_describesEachLocationState() {
         XCTAssertEqual(l("ayah.menu.reading-bookmark.save-here"), "Save your place here")
         XCTAssertEqual(l("ayah.menu.reading-bookmark.saved-here"), "Saved here • Tap to delete")
@@ -181,6 +192,7 @@ final class AyahMenuViewModelTests: XCTestCase {
 
     private func makeSUT(
         verses: [AyahNumber]? = nil,
+        notes: [Note] = [],
         highlightVerses: [AyahNumber: HighlightColor] = [:],
         bookmarkedVerses: Set<AyahNumber> = [],
         readingBookmark: ReadingPositionBookmark? = nil
@@ -194,7 +206,7 @@ final class AyahMenuViewModelTests: XCTestCase {
                 databasesURL: unavailableDatabase,
                 quranFileURL: unavailableDatabase
             ),
-            notes: [],
+            notes: notes,
             highlightVerses: highlightVerses,
             bookmarkedVerses: bookmarkedVerses,
             readingBookmark: readingBookmark
@@ -203,6 +215,16 @@ final class AyahMenuViewModelTests: XCTestCase {
 
     private func readingBookmark(at location: ReadingPositionBookmark.Location) -> ReadingPositionBookmark {
         ReadingPositionBookmark(id: "reading-bookmark", location: location, modifiedOn: .distantPast)
+    }
+
+    private func note(id: String) -> Note {
+        Note(
+            id: id,
+            text: "Note",
+            startAyah: verses[0],
+            endAyah: verses[0],
+            modifiedDate: .distantPast
+        )
     }
 }
 

--- a/Features/NotesFeature/Sources/AyahNotesBuilder.swift
+++ b/Features/NotesFeature/Sources/AyahNotesBuilder.swift
@@ -1,0 +1,54 @@
+#if QURAN_SYNC
+//
+//  AyahNotesBuilder.swift
+//
+
+import AppDependencies
+import NoorUI
+import NoteEditorFeature
+import QuranKit
+import UIKit
+
+@MainActor
+public struct AyahNotesBuilder {
+    // MARK: Lifecycle
+
+    public init(container: AppDependencies) {
+        self.container = container
+    }
+
+    // MARK: Public
+
+    public func build(verses: [AyahNumber]) -> UIViewController {
+        let viewControllerReference = AyahNotesViewControllerReference()
+        let viewModel = AyahNotesViewModel(
+            verses: verses,
+            noteService: container.mobileSyncNoteService()
+        )
+        let viewController = AyahNotesViewController(
+            viewModel: viewModel,
+            noteEditorBuilder: .init(container: container),
+            addAction: { [viewControllerReference] in
+                viewControllerReference.value?.addNote()
+            },
+            editAction: { [viewControllerReference] note in
+                viewControllerReference.value?.editNote(note)
+            }
+        )
+        viewControllerReference.value = viewController
+
+        let navigationController = BaseNavigationController(rootViewController: viewController)
+        navigationController.modalPresentationStyle = .pageSheet
+        return navigationController
+    }
+
+    // MARK: Private
+
+    private let container: AppDependencies
+}
+
+@MainActor
+private final class AyahNotesViewControllerReference {
+    weak var value: AyahNotesViewController?
+}
+#endif

--- a/Features/NotesFeature/Sources/AyahNotesView.swift
+++ b/Features/NotesFeature/Sources/AyahNotesView.swift
@@ -1,0 +1,144 @@
+#if QURAN_SYNC
+//
+//  AyahNotesView.swift
+//
+
+import Foundation
+import Localization
+import NoorUI
+import QuranAnnotations
+import QuranKit
+import SwiftUI
+import UIx
+
+@MainActor
+struct AyahNotesView: View {
+    // MARK: Lifecycle
+
+    init(
+        viewModel: AyahNotesViewModel,
+        addAction: @escaping @MainActor @Sendable () -> Void,
+        editAction: @escaping @MainActor @Sendable (Note) -> Void
+    ) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+        self.addAction = addAction
+        self.editAction = editAction
+    }
+
+    // MARK: Internal
+
+    @StateObject var viewModel: AyahNotesViewModel
+
+    var body: some View {
+        AyahNotesContent(
+            editMode: $viewModel.editMode,
+            notes: viewModel.notes,
+            addAction: addAction,
+            editAction: editAction,
+            deleteAction: { await viewModel.deleteNote($0) }
+        )
+        .task { await viewModel.start() }
+        .errorAlert(error: $viewModel.error)
+    }
+
+    // MARK: Private
+
+    private let addAction: @MainActor @Sendable () -> Void
+    private let editAction: @MainActor @Sendable (Note) -> Void
+}
+
+@MainActor
+private struct AyahNotesContent: View {
+    @Binding var editMode: EditMode
+
+    let notes: [Note]
+    let addAction: @MainActor @Sendable () -> Void
+    let editAction: @MainActor @Sendable (Note) -> Void
+    let deleteAction: @MainActor @Sendable (Note) async -> Void
+
+    var body: some View {
+        VStack {
+            NoorList {
+                NoorSection(notes) { note in
+                    NoteItemView(note: note, editAction: editAction)
+                }
+                .onDelete(action: deleteAction)
+            }
+
+            ProminentRoundedButton(label: l("notes.new"), image: .plus) {
+                addAction()
+            }
+            .padding()
+            .background(Color.systemGroupedBackground)
+        }
+        .background(Color.systemGroupedBackground)
+        .environment(\.editMode, $editMode)
+    }
+}
+
+@MainActor
+private struct NoteItemView: View {
+    let note: Note
+    let editAction: @MainActor @Sendable (Note) -> Void
+
+    var body: some View {
+        NoorListItem(
+            title: .text(note.text),
+            subtitle: .init(
+                text: .text(note.modifiedDate.timeAgo()),
+                location: .bottom
+            ),
+            accessory: .disclosureIndicator,
+            action: { editAction(note) }
+        )
+        .lineLimit(2)
+    }
+}
+
+@MainActor
+private struct AyahNotesPreview: View {
+    @State private var editMode = EditMode.inactive
+
+    var body: some View {
+        let quran = Quran.hafsMadani1405
+        let verses = Array(quran.suras[15].verses[34 ... 35])
+        let notes = [
+            Note(
+                id: "first",
+                text: "The “if Allah willed” excuse — the same argument every nation made.",
+                startAyah: verses[0],
+                endAyah: verses[1],
+                modifiedDate: Date().addingTimeInterval(-2 * 60 * 60)
+            ),
+            Note(
+                id: "second",
+                text: "Khutbah idea: the psychology of blaming destiny.",
+                startAyah: verses[0],
+                endAyah: verses[1],
+                modifiedDate: Date().addingTimeInterval(-24 * 60 * 60)
+            ),
+        ]
+
+        NavigationView {
+            AyahNotesContent(
+                editMode: $editMode,
+                notes: notes,
+                addAction: {},
+                editAction: { _ in },
+                deleteAction: { _ in }
+            )
+            .navigationTitle("An-Nahl, Ayah 35–36")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    EditButton()
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    AyahNotesPreview()
+}
+#endif

--- a/Features/NotesFeature/Sources/AyahNotesViewController.swift
+++ b/Features/NotesFeature/Sources/AyahNotesViewController.swift
@@ -1,0 +1,94 @@
+#if QURAN_SYNC
+//
+//  AyahNotesViewController.swift
+//
+
+import Combine
+import NoorUI
+import NoteEditorFeature
+import QuranAnnotations
+import SwiftUI
+import UIKit
+import UIx
+
+@MainActor
+final class AyahNotesViewController: UIHostingController<AyahNotesView>, NoteEditorListener {
+    // MARK: Lifecycle
+
+    init(
+        viewModel: AyahNotesViewModel,
+        noteEditorBuilder: NoteEditorBuilder,
+        addAction: @escaping @MainActor @Sendable () -> Void,
+        editAction: @escaping @MainActor @Sendable (Note) -> Void
+    ) {
+        self.viewModel = viewModel
+        self.noteEditorBuilder = noteEditorBuilder
+        super.init(rootView: AyahNotesView(
+            viewModel: viewModel,
+            addAction: addAction,
+            editAction: editAction
+        ))
+
+        configureTitle()
+        navigationItem.largeTitleDisplayMode = .never
+        configureEditButton()
+    }
+
+    @available(*, unavailable)
+    dynamic required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Internal
+
+    func addNote() {
+        presentNoteEditor(mode: .create(verses: viewModel.verses))
+    }
+
+    func editNote(_ note: Note) {
+        presentNoteEditor(mode: .edit(note))
+    }
+
+    func dismissNoteEditor() {
+        dismiss(animated: true)
+    }
+
+    // MARK: Private
+
+    private let viewModel: AyahNotesViewModel
+    private let noteEditorBuilder: NoteEditorBuilder
+    private var editController: EditController?
+
+    private var currentEditMode: EditMode? {
+        viewModel.notes.isEmpty ? nil : viewModel.editMode
+    }
+
+    private func configureEditButton() {
+        editController = EditController(
+            navigationItem: navigationItem,
+            reload: viewModel.objectWillChange.eraseToAnyPublisher(),
+            editMode: Binding(
+                get: { [weak self] in self?.currentEditMode },
+                set: { [weak self] value in self?.viewModel.editMode = value ?? .inactive }
+            )
+        )
+    }
+
+    private func configureTitle() {
+        guard let start = viewModel.verses.first, let end = viewModel.verses.last else {
+            return
+        }
+
+        let title: MultipartText = "\(ayahRange: start ... end)"
+        let label = UILabel()
+        label.attributedText = title.attributedString(ofSize: .body)
+        label.accessibilityLabel = title.accessibilityText
+        navigationItem.titleView = label
+    }
+
+    private func presentNoteEditor(mode: NoteEditorMode) {
+        let viewController = noteEditorBuilder.build(withListener: self, mode: mode)
+        present(viewController, animated: true)
+    }
+}
+#endif

--- a/Features/NotesFeature/Sources/AyahNotesViewModel.swift
+++ b/Features/NotesFeature/Sources/AyahNotesViewModel.swift
@@ -1,0 +1,72 @@
+#if QURAN_SYNC
+//
+//  AyahNotesViewModel.swift
+//
+
+import AnnotationsService
+import Foundation
+import QuranAnnotations
+import QuranKit
+import SwiftUI
+import VLogging
+
+@MainActor
+final class AyahNotesViewModel: ObservableObject {
+    // MARK: Lifecycle
+
+    init(
+        verses: [AyahNumber],
+        noteService: MobileSyncNoteService
+    ) {
+        self.verses = Array(Set(verses)).sorted()
+        self.noteService = noteService
+    }
+
+    // MARK: Internal
+
+    @Published private(set) var notes: [Note] = []
+    @Published var editMode: EditMode = .inactive
+    @Published var error: Error?
+
+    let verses: [AyahNumber]
+
+    func start() async {
+        await observeNotes()
+    }
+
+    func deleteNote(_ note: Note) async {
+        do {
+            try await noteService.removeNote(note)
+        } catch is CancellationError {
+        } catch {
+            logger.error("Ayah notes: failed to delete note: \(error)")
+            self.error = error
+        }
+    }
+
+    // MARK: Private
+
+    private let noteService: MobileSyncNoteService
+
+    private func observeNotes() async {
+        guard let quran = verses.first?.quran else {
+            notes = []
+            return
+        }
+
+        do {
+            for try await notes in noteService.notesSequence(quran: quran) {
+                let matchingNotes = notes.filter { $0.intersects(verses: verses) }
+                self.notes = matchingNotes
+                if matchingNotes.isEmpty {
+                    editMode = .inactive
+                }
+            }
+        } catch is CancellationError {
+        } catch {
+            logger.error("Ayah notes: failed to observe notes: \(error)")
+            self.error = error
+        }
+    }
+}
+#endif

--- a/Features/NotesFeature/Tests/AyahNotesViewModelTests.swift
+++ b/Features/NotesFeature/Tests/AyahNotesViewModelTests.swift
@@ -1,0 +1,80 @@
+#if QURAN_SYNC
+import AnnotationsService
+import Combine
+import MobileSyncTestSupport
+import QuranAnnotations
+import QuranKit
+import XCTest
+@testable import NotesFeature
+
+@MainActor
+final class AyahNotesViewModelTests: XCTestCase {
+    private let database = MobileSyncTestDatabase.shared
+    private var noteService: MobileSyncNoteService!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try await database.reset()
+        noteService = MobileSyncNoteService(quranDataService: database.quranDataService)
+    }
+
+    override func tearDown() async throws {
+        try await database.reset()
+        noteService = nil
+        try await super.tearDown()
+    }
+
+    func test_start_observesEveryNoteIntersectingTheSelectedAyahs() async throws {
+        try await noteService.createNote(body: "First", startAyah: ayah(1), endAyah: ayah(2))
+        try await noteService.createNote(body: "Second", startAyah: ayah(2), endAyah: ayah(3))
+        try await noteService.createNote(body: "Unrelated", startAyah: ayah(4), endAyah: ayah(4))
+        let sut = makeSUT(verses: [ayah(2)])
+        let observed = expectation(description: "Observes intersecting notes")
+        var didFulfill = false
+        let observation = sut.$notes.sink { notes in
+            guard !didFulfill, Set(notes.map(\.text)) == ["First", "Second"] else {
+                return
+            }
+            didFulfill = true
+            observed.fulfill()
+        }
+
+        let task = Task { await sut.start() }
+        await fulfillment(of: [observed], timeout: 2)
+
+        XCTAssertEqual(Set(sut.notes.map(\.text)), ["First", "Second"])
+        task.cancel()
+        observation.cancel()
+    }
+
+    func test_deleteNote_removesOnlyTheSelectedNote() async throws {
+        try await noteService.createNote(body: "Keep", startAyah: ayah(1), endAyah: ayah(1))
+        try await noteService.createNote(body: "Delete", startAyah: ayah(1), endAyah: ayah(1))
+        let notes = try await storedNotes()
+        let noteToDelete = try XCTUnwrap(notes.first { $0.text == "Delete" })
+        let sut = makeSUT(verses: [ayah(1)])
+
+        await sut.deleteNote(noteToDelete)
+
+        let remainingNotes = try await storedNotes()
+        XCTAssertEqual(remainingNotes.map(\.text), ["Keep"])
+        XCTAssertNil(sut.error)
+    }
+
+    private func makeSUT(verses: some Sequence<AyahNumber>) -> AyahNotesViewModel {
+        AyahNotesViewModel(
+            verses: Array(verses),
+            noteService: noteService
+        )
+    }
+
+    private func storedNotes() async throws -> [Note] {
+        var iterator = noteService.notesSequence(quran: .hafsMadani1405).makeAsyncIterator()
+        return try await iterator.next() ?? []
+    }
+
+    private func ayah(_ number: Int) -> AyahNumber {
+        AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: number)!
+    }
+}
+#endif

--- a/Features/QuranViewFeature/Sources/QuranBuilder.swift
+++ b/Features/QuranViewFeature/Sources/QuranBuilder.swift
@@ -15,6 +15,9 @@ import BookmarksFeature
 #endif
 import MoreMenuFeature
 import NoteEditorFeature
+#if QURAN_SYNC
+import NotesFeature
+#endif
 import QuranContentFeature
 import QuranKit
 import ReadingService
@@ -59,7 +62,7 @@ public struct QuranBuilder {
             translationVerseBuilder: TranslationVerseBuilder(container: container),
             resources: container.readingResources,
             notesObserver: notesObserver,
-            noteEditorBuilder: NoteEditorBuilder(container: container),
+            ayahNotesBuilder: AyahNotesBuilder(container: container),
             bookmarkAyahsBuilder: BookmarkAyahsBuilder(container: container),
             syncedHighlightsObserver: syncedHighlightsObserver,
             readingBookmarkObserver: readingBookmarkObserver

--- a/Features/QuranViewFeature/Sources/QuranInteractor.swift
+++ b/Features/QuranViewFeature/Sources/QuranInteractor.swift
@@ -19,6 +19,9 @@ import FeaturesSupport
 import MoreMenuFeature
 import NoorUI
 import NoteEditorFeature
+#if QURAN_SYNC
+import NotesFeature
+#endif
 import QuranAnnotations
 import QuranContentFeature
 import QuranKit
@@ -49,6 +52,7 @@ protocol QuranPresentable: UIViewController {
     func presentAyahMenu(_ viewController: UIViewController, in sourceView: UIView, at point: CGPoint)
     #if QURAN_SYNC
     func presentBookmarkAyahs(_ viewController: UIViewController)
+    func presentAyahNotes(_ viewController: UIViewController)
     #endif
     func presentTranslatedVerse(_ viewController: UIViewController, didDismiss: @escaping () -> Void)
     func presentAudioBanner(_ audioBanner: UIViewController)
@@ -77,12 +81,13 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         let translationVerseBuilder: TranslationVerseBuilder
         let resources: ReadingResourcesService
         let notesObserver: QuranNotesObserver
-        let noteEditorBuilder: NoteEditorBuilder
         #if QURAN_SYNC
+        let ayahNotesBuilder: AyahNotesBuilder
         let bookmarkAyahsBuilder: BookmarkAyahsBuilder
         let syncedHighlightsObserver: QuranSyncedHighlightsObserver
         let readingBookmarkObserver: QuranReadingBookmarkObserver
         #else
+        let noteEditorBuilder: NoteEditorBuilder
         let analytics: AnalyticsLibrary
         let pageBookmarkService: PageBookmarkService
         let noteService: NoteService
@@ -243,15 +248,18 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     }
 
     func showNoteEditor(for verses: [AyahNumber]) async {
-        let notes = notesInteractingVerses(verses)
         #if QURAN_SYNC
-        let mode: NoteEditorMode = if let note = notes.first {
-            .edit(note)
-        } else {
-            .create(verses: verses)
+        logger.info("Quran: show ayah notes. Verses: \(verses)")
+        contentViewModel?.removeAyahMenuHighlight()
+        presenter?.dismissPresentedViewController { [weak self] in
+            guard let self else {
+                return
+            }
+            let viewController = deps.ayahNotesBuilder.build(verses: verses)
+            presenter?.presentAyahNotes(viewController)
         }
-        presentNoteEditor(mode: mode)
         #else
+        let notes = notesInteractingVerses(verses)
         if let note = notes.first {
             presentNoteEditor(note: note)
             return
@@ -556,14 +564,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         deps.notesObserver.notes(interacting: verses)
     }
 
-    #if QURAN_SYNC
-    private func presentNoteEditor(mode: NoteEditorMode) {
-        dismissAyahMenu()
-        presenter?.rotateToPortraitIfPhone()
-        let viewController = deps.noteEditorBuilder.build(withListener: self, mode: mode)
-        presenter?.present(viewController, animated: true)
-    }
-    #else
+    #if !QURAN_SYNC
     private func presentNoteEditor(note: Note) {
         dismissAyahMenu()
         presenter?.rotateToPortraitIfPhone()

--- a/Features/QuranViewFeature/Sources/QuranViewController.swift
+++ b/Features/QuranViewFeature/Sources/QuranViewController.swift
@@ -205,6 +205,14 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
 
     #if QURAN_SYNC
     func presentBookmarkAyahs(_ viewController: UIViewController) {
+        presentPageSheet(viewController)
+    }
+
+    func presentAyahNotes(_ viewController: UIViewController) {
+        presentPageSheet(viewController)
+    }
+
+    private func presentPageSheet(_ viewController: UIViewController) {
         if let sheet = viewController.sheetPresentationController {
             sheet.detents = [.medium(), .large()]
             sheet.prefersGrabberVisible = true

--- a/Package.swift
+++ b/Package.swift
@@ -762,6 +762,7 @@ private func featuresTargets() -> [[Target]] {
             "AyahMenuFeature",
             "MoreMenuFeature",
             "NoteEditorFeature",
+            "NotesFeature",
             "WordPointerFeature",
             "TranslationsFeature",
             "TranslationVerseFeature",

--- a/UI/NoorUI/Sources/Components/MultipartText+UIKit.swift
+++ b/UI/NoorUI/Sources/Components/MultipartText+UIKit.swift
@@ -32,6 +32,11 @@ private extension TextPart {
                 locale: locale,
                 emphasizesSura: emphasizesSura
             )
+        case .ayahCoordinate(let ayah):
+            NSAttributedString(
+                string: ayah.localizedCoordinate(locale: locale),
+                attributes: [.font: size.plainUIFont]
+            )
         case .quran(let text, let color, _):
             NSAttributedString(string: text, attributes: [
                 .backgroundColor: UIColor(color),

--- a/UI/NoorUI/Sources/Components/MultipartText.swift
+++ b/UI/NoorUI/Sources/Components/MultipartText.swift
@@ -34,6 +34,8 @@ private struct TextPartView: View {
     let part: TextPart
     let size: MultipartText.FontSize
 
+    @Environment(\.locale) private var locale
+
     var body: some View {
         switch part {
         case .plain(let text):
@@ -51,6 +53,10 @@ private struct TextPartView: View {
                 size: size,
                 emphasizesSura: emphasizesSura
             )
+        case .ayahCoordinate(let ayah):
+            Text(ayah.localizedCoordinate(locale: locale))
+                .font(size.plainFont)
+                .environment(\.layoutDirection, .leftToRight)
         case .quran(let text, let color, let lineLimit):
             Text(text)
                 .optionalLineLimit(lineLimit)
@@ -106,6 +112,7 @@ enum TextPart {
     case highlighting(text: String, ranges: [HighlightingRange], lineLimit: Int?)
     case sura(Sura)
     case ayah(AyahNumber, emphasizesSura: Bool)
+    case ayahCoordinate(AyahNumber)
     case quran(text: String, color: Color, lineLimit: Int?)
 
     // MARK: Internal
@@ -118,6 +125,8 @@ enum TextPart {
             QuranReference.sura(sura).rawValue(locale: locale)
         case .ayah(let ayah, _):
             QuranReference.ayah(ayah).rawValue(locale: locale)
+        case .ayahCoordinate(let ayah):
+            ayah.localizedCoordinate(locale: locale)
         case .quran(let text, _, _):
             text
         }
@@ -131,6 +140,8 @@ enum TextPart {
             QuranReference.sura(sura).accessibilityText
         case .ayah(let ayah, _):
             QuranReference.ayah(ayah).accessibilityText
+        case .ayahCoordinate(let ayah):
+            ayah.localizedCoordinate()
         case .quran(let text, _, _):
             text
         }
@@ -158,6 +169,23 @@ public struct MultipartText: ExpressibleByStringInterpolation {
             emphasizingSura: Bool = false
         ) {
             parts.append(.ayah(ayah, emphasizesSura: emphasizingSura))
+        }
+
+        public mutating func appendInterpolation(ayahRange range: ClosedRange<AyahNumber>) {
+            let start = range.lowerBound
+            let end = range.upperBound
+            parts.append(.ayah(start, emphasizesSura: false))
+
+            guard start != end else {
+                return
+            }
+
+            parts.append(.plain(text: " - "))
+            if start.sura == end.sura {
+                parts.append(.ayahCoordinate(end))
+            } else {
+                parts.append(.ayah(end, emphasizesSura: false))
+            }
         }
 
         public mutating func appendInterpolation(

--- a/UI/NoorUI/Sources/Components/ProminentRoundedButton.swift
+++ b/UI/NoorUI/Sources/Components/ProminentRoundedButton.swift
@@ -11,16 +11,18 @@ public struct ProminentRoundedButton: View {
     @ScaledMetric private var verticalPadding = 10.0
 
     let label: String
+    let image: NoorSystemImage?
     let action: AsyncAction
 
-    public init(label: String, action: @escaping AsyncAction) {
+    public init(label: String, image: NoorSystemImage? = nil, action: @escaping AsyncAction) {
         self.label = label
+        self.image = image
         self.action = action
     }
 
     public var body: some View {
         AsyncButton(action: action) {
-            Text(label)
+            buttonLabel
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(Color.white)
                 .frame(maxWidth: .infinity)
@@ -31,5 +33,18 @@ public struct ProminentRoundedButton: View {
                 )
         }
         .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var buttonLabel: some View {
+        if let image {
+            Label {
+                Text(label)
+            } icon: {
+                image.image
+            }
+        } else {
+            Text(label)
+        }
     }
 }

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuUI.swift
@@ -86,6 +86,7 @@ public enum AyahMenuUI {
             highlightingColor: HighlightColor,
             state: NoteState,
             bookmarkTitle: String,
+            notesTitle: String,
             bookmarkState: BookmarkState = .unhighlighted,
             playSubtitle: String,
             repeatSubtitle: String,
@@ -97,6 +98,7 @@ public enum AyahMenuUI {
             self.highlightingColor = highlightingColor
             self.state = state
             self.bookmarkTitle = bookmarkTitle
+            self.notesTitle = notesTitle
             self.bookmarkState = bookmarkState
             self.playSubtitle = playSubtitle
             self.repeatSubtitle = repeatSubtitle
@@ -132,6 +134,7 @@ public enum AyahMenuUI {
         let actions: Actions
         #if QURAN_SYNC
         let bookmarkTitle: String
+        let notesTitle: String
         let bookmarkState: BookmarkState
         #endif
         let playSubtitle: String

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -95,9 +95,15 @@ private struct AyahMenuViewList: View {
     }
 
     var editNote: some View {
+        #if QURAN_SYNC
+        Row(title: dataObject.notesTitle, action: dataObject.actions.addNote) {
+            noteIcon
+        }
+        #else
         Row(title: l("ayah.menu.edit-note"), action: dataObject.actions.addNote) {
             noteIcon
         }
+        #endif
     }
 
     var addNote: some View {
@@ -557,6 +563,7 @@ private func previewDataObject(
         highlightingColor: highlightingColor,
         state: state,
         bookmarkTitle: bookmarkTitle,
+        notesTitle: "Notes (3)",
         bookmarkState: bookmarkState,
         playSubtitle: "To the end of Juz'",
         repeatSubtitle: "selected verses",

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -181,6 +181,7 @@ private struct AyahMenuViewList: View {
                     editNote
                 }
 
+                #if !QURAN_SYNC
                 if dataObject.state != .noHighlight {
                     Divider()
                         .padding(.leading)
@@ -190,6 +191,7 @@ private struct AyahMenuViewList: View {
                             .foregroundColor(Color.red)
                     }
                 }
+                #endif
 
                 Divider()
             }

--- a/UI/NoorUI/Sources/Images/NoorSystemImage.swift
+++ b/UI/NoorUI/Sources/Images/NoorSystemImage.swift
@@ -26,6 +26,7 @@ public enum NoorSystemImage: String {
     case book
     case folder = "folder.fill"
     case folderOutline = "folder"
+    case plus
     case plusCircle = "plus.circle"
     case note = "text.justify.leading"
     case lastPage = "clock"

--- a/UI/NoorUI/Tests/MultipartTextQuranTests.swift
+++ b/UI/NoorUI/Tests/MultipartTextQuranTests.swift
@@ -38,12 +38,44 @@ final class MultipartTextQuranTests: XCTestCase {
         XCTAssertEqual(text.rawValue(locale: arabic), "\u{E905} · ٢:٢٥٥")
     }
 
+    func test_singleAyahRange_usesStartReference() {
+        let text: MultipartText = "\(ayahRange: ayah ... ayah)"
+
+        XCTAssertEqual(text.rawValue(locale: english), "\(sura.localizedName()) \u{E905} · 2:255")
+    }
+
+    func test_sameSuraAyahRange_usesEndCoordinate() {
+        let end = sura.verses[255]
+        let text: MultipartText = "\(ayahRange: ayah ... end)"
+
+        XCTAssertEqual(text.rawValue(locale: english), "\(sura.localizedName()) \u{E905} · 2:255 - 2:256")
+        XCTAssertEqual(text.rawValue(locale: arabic), "\u{E905} · ٢:٢٥٥ - ٢:٢٥٦")
+    }
+
+    func test_crossSuraAyahRange_usesBothReferences() {
+        let start = Quran.hafsMadani1405.suras[0].verses[6]
+        let end = Quran.hafsMadani1405.suras[1].verses[0]
+        let text: MultipartText = "\(ayahRange: start ... end)"
+
+        XCTAssertEqual(
+            text.rawValue(locale: english),
+            "\(start.sura.localizedName()) \u{E904} · 1:7 - \(end.sura.localizedName()) \u{E905} · 2:1"
+        )
+    }
+
     func test_references_useSemanticAccessibilityText() {
         let suraText: MultipartText = "\(sura: sura)"
         let ayahText: MultipartText = "\(ayah: ayah)"
 
         XCTAssertEqual(suraText.accessibilityText, sura.localizedName())
         XCTAssertEqual(ayahText.accessibilityText, ayah.localizedName)
+    }
+
+    func test_ayahRange_usesSemanticAccessibilityText() {
+        let end = sura.verses[255]
+        let text: MultipartText = "\(ayahRange: ayah ... end)"
+
+        XCTAssertEqual(text.accessibilityText, "\(ayah.localizedName) - \(end.localizedCoordinate())")
     }
 
     func test_quranText_preservesText() {


### PR DESCRIPTION
## Stack
Depends on #915, which depends on #914.

## Summary
- show `Notes (count)` instead of `Edit Note` in the sync-enabled ayah menu
- localize the count label in English and Arabic
- preserve the legacy no-sync `Edit Note` wording
- add regression coverage for the note count and localized copy

## Why
With multiple synced notes per ayah or range, the menu should communicate how many notes will open rather than implying a single note editor.

## Validation
- `make format-lint`
- `make test-sync TARGET=AyahMenuFeatureTests` (19 tests)
- `make test-no-sync TARGET=AyahMenuFeatureTests` (1 test)

## Screenshot

<img width="306" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-23 at 11 12 46" src="https://github.com/user-attachments/assets/dc8227b1-677e-4eb1-9d9c-ba7afb2ffb79" />
