### PR TITLE
Confirm deletion of non-empty collections

### DIFF
--- a/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -131,6 +131,8 @@
 "bookmarks.collections.new" = "مجموعة جديدة...";
 "bookmarks.collections.new.placeholder" = "اسم المجموعة";
 "bookmarks.collections.rename" = "إعادة التسمية";
+"bookmarks.collections.delete.confirmation.title" = "هل تريد حذف المجموعة؟";
+"bookmarks.collections.delete.confirmation.message" = "تحتوي هذه المجموعة على إشارات مرجعية. هل أنت متأكد من رغبتك في حذفها؟";
 "bookmarks.collections.no-data.title" = "لا توجد مجموعات حتى الآن";
 "bookmarks.collections.no-data.text" = "أنشئ مجموعة لتنظيم الآيات حسب الموضوع أو الدعاء أو خطة الحفظ.";
 "bookmarks.collections.ayah-count" = "%d إشارات مرجعية للآيات";

--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -150,6 +150,8 @@
 "bookmarks.collections.new" = "New Collection...";
 "bookmarks.collections.new.placeholder" = "Collection name";
 "bookmarks.collections.rename" = "Rename";
+"bookmarks.collections.delete.confirmation.title" = "Delete Collection?";
+"bookmarks.collections.delete.confirmation.message" = "This collection contains bookmarks. Are you sure you want to delete it?";
 "bookmarks.collections.no-data.title" = "No collections yet";
 "bookmarks.collections.no-data.text" = "Create a collection to organize ayahs by theme, dua, or memorization plan.";
 "bookmarks.collections.ayah-count" = "%d ayah bookmarks";

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
@@ -28,6 +28,10 @@ struct AyahBookmarkCollectionsView: View {
         AyahBookmarkCollectionDetails(viewModel: viewModel, collection: viewModel.collection)
             .task { await viewModel.start() }
             .renameCollectionAlert(viewModel: viewModel)
+            .collectionDeleteConfirmation(
+                isPresented: $viewModel.isPresentingDeleteCollectionConfirmation,
+                delete: { await viewModel.deleteCollection() }
+            )
             .errorAlert(error: $viewModel.error)
             .environment(\.editMode, $viewModel.editMode)
     }

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
@@ -29,8 +29,8 @@ struct AyahBookmarkCollectionsView: View {
             .task { await viewModel.start() }
             .renameCollectionAlert(viewModel: viewModel)
             .collectionDeleteConfirmation(
-                isPresented: $viewModel.isPresentingDeleteCollectionConfirmation,
-                delete: { await viewModel.deleteCollection() }
+                item: $viewModel.collectionPendingDeletion,
+                delete: { await viewModel.deleteCollection($0) }
             )
             .errorAlert(error: $viewModel.error)
             .environment(\.editMode, $viewModel.editMode)

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
@@ -143,7 +143,7 @@ private final class AyahBookmarkCollectionMenuController {
                     guard let self else {
                         return
                     }
-                    Task { await self.viewModel.deleteCollection() }
+                    Task { await self.viewModel.requestDeleteCollection() }
                 }
             )
         }

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
@@ -35,9 +35,9 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
 
     @Published private(set) var collection: AyahBookmarkCollection
     @Published private(set) var ayahTexts: [AyahNumber: String] = [:]
+    @Published var collectionPendingDeletion: AyahBookmarkCollection?
     @Published var editMode: EditMode = .inactive
     @Published var error: Error?
-    @Published var isPresentingDeleteCollectionConfirmation = false
     @Published var isPresentingRenameCollection = false
     @Published var pendingCollectionName = ""
 
@@ -102,13 +102,13 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
             return
         }
         guard !collection.bookmarks.isEmpty else {
-            await deleteCollection()
+            await deleteCollection(collection)
             return
         }
-        isPresentingDeleteCollectionConfirmation = true
+        collectionPendingDeletion = collection
     }
 
-    func deleteCollection() async {
+    func deleteCollection(_ collection: AyahBookmarkCollection) async {
         guard collection.kind.canDelete else {
             return
         }

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
@@ -37,6 +37,7 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
     @Published private(set) var ayahTexts: [AyahNumber: String] = [:]
     @Published var editMode: EditMode = .inactive
     @Published var error: Error?
+    @Published var isPresentingDeleteCollectionConfirmation = false
     @Published var isPresentingRenameCollection = false
     @Published var pendingCollectionName = ""
 
@@ -96,11 +97,21 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
         }
     }
 
+    func requestDeleteCollection() async {
+        guard collection.kind.canDelete else {
+            return
+        }
+        guard !collection.bookmarks.isEmpty else {
+            await deleteCollection()
+            return
+        }
+        isPresentingDeleteCollectionConfirmation = true
+    }
+
     func deleteCollection() async {
         guard collection.kind.canDelete else {
             return
         }
-
         do {
             try await ayahBookmarkCollectionService.removeCollection(
                 id: collection.collection.id

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
@@ -97,15 +97,8 @@ private struct BookmarkCollectionsContent: View {
         .task { await viewModel.start() }
         .addCollectionAlert(viewModel: viewModel)
         .collectionDeleteConfirmation(
-            isPresented: Binding(
-                get: { viewModel.collectionPendingDeletion != nil },
-                set: { isPresented in
-                    if !isPresented {
-                        viewModel.collectionPendingDeletion = nil
-                    }
-                }
-            ),
-            delete: { await viewModel.deletePendingCollection() }
+            item: $viewModel.collectionPendingDeletion,
+            delete: { await viewModel.deleteCollection($0) }
         )
         .errorAlert(error: $viewModel.error)
         .environment(\.editMode, $viewModel.editMode)

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
@@ -80,7 +80,7 @@ private struct BookmarkCollectionsContent: View {
                     let collections = offsets.map { viewModel.displayedCollections[$0] }
                     Task {
                         for collection in collections {
-                            await viewModel.deleteCollection(collection)
+                            await viewModel.requestDeleteCollection(collection)
                         }
                     }
                 }
@@ -96,6 +96,17 @@ private struct BookmarkCollectionsContent: View {
         }
         .task { await viewModel.start() }
         .addCollectionAlert(viewModel: viewModel)
+        .collectionDeleteConfirmation(
+            isPresented: Binding(
+                get: { viewModel.collectionPendingDeletion != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        viewModel.collectionPendingDeletion = nil
+                    }
+                }
+            ),
+            delete: { await viewModel.deletePendingCollection() }
+        )
         .errorAlert(error: $viewModel.error)
         .environment(\.editMode, $viewModel.editMode)
     }

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -38,6 +38,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     // MARK: Internal
 
     @Published var collections: [AyahBookmarkCollection] = []
+    @Published var collectionPendingDeletion: AyahBookmarkCollection?
     @Published var editMode: EditMode = .inactive
     @Published var error: Error?
     @Published var isAuthenticated = false
@@ -145,6 +146,25 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         } catch {
             self.error = error
         }
+    }
+
+    func requestDeleteCollection(_ collection: AyahBookmarkCollection) async {
+        guard collection.kind.canDelete else {
+            return
+        }
+        guard !collection.bookmarks.isEmpty else {
+            await deleteCollection(collection)
+            return
+        }
+        collectionPendingDeletion = collection
+    }
+
+    func deletePendingCollection() async {
+        guard let collection = collectionPendingDeletion else {
+            return
+        }
+        collectionPendingDeletion = nil
+        await deleteCollection(collection)
     }
 
     func deleteCollection(_ collection: AyahBookmarkCollection) async {

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -159,14 +159,6 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         collectionPendingDeletion = collection
     }
 
-    func deletePendingCollection() async {
-        guard let collection = collectionPendingDeletion else {
-            return
-        }
-        collectionPendingDeletion = nil
-        await deleteCollection(collection)
-    }
-
     func deleteCollection(_ collection: AyahBookmarkCollection) async {
         guard collection.kind.canDelete else {
             return

--- a/Features/BookmarksFeature/Sources/CollectionDeleteConfirmation.swift
+++ b/Features/BookmarksFeature/Sources/CollectionDeleteConfirmation.swift
@@ -4,19 +4,27 @@ import SwiftUI
 
 extension View {
     @MainActor
-    func collectionDeleteConfirmation(
-        isPresented: Binding<Bool>,
-        delete: @escaping @MainActor () async -> Void
+    func collectionDeleteConfirmation<Item>(
+        item: Binding<Item?>,
+        delete: @escaping @MainActor (Item) async -> Void
     ) -> some View {
         alert(
             l("bookmarks.collections.delete.confirmation.title"),
-            isPresented: isPresented
-        ) {
+            isPresented: Binding(
+                get: { item.wrappedValue != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        item.wrappedValue = nil
+                    }
+                }
+            ),
+            presenting: item.wrappedValue
+        ) { item in
             Button(lAndroid("cancel"), role: .cancel) {}
             Button(l("button.delete"), role: .destructive) {
-                Task { await delete() }
+                Task { await delete(item) }
             }
-        } message: {
+        } message: { _ in
             Text(l("bookmarks.collections.delete.confirmation.message"))
         }
     }

--- a/Features/BookmarksFeature/Sources/CollectionDeleteConfirmation.swift
+++ b/Features/BookmarksFeature/Sources/CollectionDeleteConfirmation.swift
@@ -1,0 +1,24 @@
+#if QURAN_SYNC
+import Localization
+import SwiftUI
+
+extension View {
+    @MainActor
+    func collectionDeleteConfirmation(
+        isPresented: Binding<Bool>,
+        delete: @escaping @MainActor () async -> Void
+    ) -> some View {
+        alert(
+            l("bookmarks.collections.delete.confirmation.title"),
+            isPresented: isPresented
+        ) {
+            Button(lAndroid("cancel"), role: .cancel) {}
+            Button(l("button.delete"), role: .destructive) {
+                Task { await delete() }
+            }
+        } message: {
+            Text(l("bookmarks.collections.delete.confirmation.message"))
+        }
+    }
+}
+#endif

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
@@ -122,7 +122,7 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
         XCTAssertNil(sut.error)
     }
 
-    func test_deleteCollection_removesCollectionAndNotifiesListener() async throws {
+    func test_requestDeleteCollection_deletesEmptyCollectionAndNotifiesListener() async throws {
         let service = makeService()
         try await service.createCollection(named: "Favorites")
         let collection = try await firstCollection()
@@ -133,7 +133,7 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
             collectionDeleted: { didDeleteCollection = true }
         )
 
-        await sut.deleteCollection()
+        await sut.requestDeleteCollection()
 
         let stored = try await storedCollections {
             $0.count == 1 && $0[0].collection.isDefault
@@ -141,6 +141,38 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
         XCTAssertEqual(stored.map(\.collection.name), ["Default"])
         XCTAssertTrue(stored[0].collection.isDefault)
         XCTAssertTrue(didDeleteCollection)
+        XCTAssertFalse(sut.isPresentingDeleteCollectionConfirmation)
+        XCTAssertNil(sut.error)
+    }
+
+    func test_requestDeleteCollection_requiresConfirmationForNonEmptyCollection() async throws {
+        let service = makeService()
+        try await service.createCollection(named: "Favorites")
+        let storedCollection = try await firstCollection()
+        try await service.addAyahBookmarkToCollection(
+            collectionId: storedCollection.collection.id,
+            ayah: AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
+        )
+        let stored = try await storedCollections {
+            $0.first { $0.collection.name == "Favorites" }?.bookmarks.count == 1
+        }
+        let collection = try XCTUnwrap(
+            AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405)
+                .first { $0.collection.name == "Favorites" }
+        )
+        var didDeleteCollection = false
+        let sut = makeSUT(
+            collection: collection,
+            service: service,
+            collectionDeleted: { didDeleteCollection = true }
+        )
+
+        await sut.requestDeleteCollection()
+
+        XCTAssertTrue(sut.isPresentingDeleteCollectionConfirmation)
+        let unchangedCollections = try await storedCollections()
+        XCTAssertTrue(unchangedCollections.contains { $0.collection.id == collection.id })
+        XCTAssertFalse(didDeleteCollection)
         XCTAssertNil(sut.error)
     }
 

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
@@ -141,7 +141,7 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
         XCTAssertEqual(stored.map(\.collection.name), ["Default"])
         XCTAssertTrue(stored[0].collection.isDefault)
         XCTAssertTrue(didDeleteCollection)
-        XCTAssertFalse(sut.isPresentingDeleteCollectionConfirmation)
+        XCTAssertNil(sut.collectionPendingDeletion)
         XCTAssertNil(sut.error)
     }
 
@@ -169,7 +169,7 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
 
         await sut.requestDeleteCollection()
 
-        XCTAssertTrue(sut.isPresentingDeleteCollectionConfirmation)
+        XCTAssertEqual(sut.collectionPendingDeletion?.id, collection.id)
         let unchangedCollections = try await storedCollections()
         XCTAssertTrue(unchangedCollections.contains { $0.collection.id == collection.id })
         XCTAssertFalse(didDeleteCollection)
@@ -189,7 +189,7 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
         sut.pendingCollectionName = "Renamed"
 
         await sut.renamePendingCollection()
-        await sut.deleteCollection()
+        await sut.deleteCollection(collection)
 
         let storedCollection = try await firstCollection()
         XCTAssertEqual(storedCollection.collection.name, "Red")

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -341,13 +341,12 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         let unchangedCollections = try await storedCollections()
         XCTAssertTrue(unchangedCollections.contains { $0.collection.id == collection.id })
 
-        await sut.deletePendingCollection()
+        await sut.deleteCollection(collection)
 
         let collectionsAfterConfirmation = try await storedCollections {
             !$0.contains { $0.collection.id == collection.id }
         }
         XCTAssertFalse(collectionsAfterConfirmation.contains { $0.collection.id == collection.id })
-        XCTAssertNil(sut.collectionPendingDeletion)
         XCTAssertNil(sut.error)
     }
 

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -292,7 +292,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         XCTAssertNil(sut.error)
     }
 
-    func test_deleteCollection_removesFromRealMobileSyncDatabase() async throws {
+    func test_requestDeleteCollection_deletesEmptyCollectionWithoutConfirmation() async throws {
         let service = makeService()
         try await service.createCollection(named: "Favorites")
         let stored = try await storedCollections()
@@ -302,13 +302,52 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         )
         let sut = makeSUT(collectionService: service)
 
-        await sut.deleteCollection(collection)
+        await sut.requestDeleteCollection(collection)
 
         let collections = try await storedCollections {
             $0.count == 1 && $0[0].collection.isDefault
         }
         XCTAssertEqual(collections.map(\.collection.name), ["Default"])
         XCTAssertTrue(collections[0].collection.isDefault)
+        XCTAssertNil(sut.collectionPendingDeletion)
+        XCTAssertNil(sut.error)
+    }
+
+    func test_requestDeleteCollection_requiresConfirmationBeforeDeletingNonEmptyCollection() async throws {
+        let service = makeService()
+        try await service.createCollection(named: "Favorites")
+        var stored = try await storedCollections {
+            $0.contains { $0.collection.name == "Favorites" }
+        }
+        let storedCollection = try XCTUnwrap(
+            stored.first { $0.collection.name == "Favorites" }
+        )
+        try await service.addAyahBookmarkToCollection(
+            collectionId: storedCollection.collection.id,
+            ayah: AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
+        )
+        stored = try await storedCollections {
+            $0.first { $0.collection.name == "Favorites" }?.bookmarks.count == 1
+        }
+        let collection = try XCTUnwrap(
+            AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405)
+                .first { $0.collection.name == "Favorites" }
+        )
+        let sut = makeSUT(collectionService: service)
+
+        await sut.requestDeleteCollection(collection)
+
+        XCTAssertEqual(sut.collectionPendingDeletion?.id, collection.id)
+        let unchangedCollections = try await storedCollections()
+        XCTAssertTrue(unchangedCollections.contains { $0.collection.id == collection.id })
+
+        await sut.deletePendingCollection()
+
+        let collectionsAfterConfirmation = try await storedCollections {
+            !$0.contains { $0.collection.id == collection.id }
+        }
+        XCTAssertFalse(collectionsAfterConfirmation.contains { $0.collection.id == collection.id })
+        XCTAssertNil(sut.collectionPendingDeletion)
         XCTAssertNil(sut.error)
     }
 


### PR DESCRIPTION
## Summary

- require destructive confirmation before deleting a collection that contains bookmarks
- pass the pending collection through item-driven alert state so confirmation deletes the exact requested collection
- apply the same confirmation from the collection list and collection detail menu
- keep empty collection deletion immediate
- add English and Arabic confirmation copy
- cover both paths with MobileSync-backed regression tests

## Why

Collection delete actions previously called persistence directly regardless of collection contents. A swipe or menu action could therefore remove a populated collection without a chance to cancel.

## Impact

Users now receive a clear Cancel/Delete alert when a collection contains bookmarks. Empty collections retain the existing one-step deletion behavior. The pending collection is the single source of truth for alert presentation and the destructive action.

## Validation

- `make format-lint`
- `make test-sync TARGET=BookmarksFeature` — 48 tests passed
- `make build-no-sync TARGET=BookmarksFeature`
- `git diff --check`