### PR TITLE
feat: show ayah range when saving

### DIFF
--- a/Features/BookmarksFeature/Sources/BookmarkAyahsViewController.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsViewController.swift
@@ -5,6 +5,7 @@
 
 import Localization
 import NoorUI
+import QuranKit
 import SwiftUI
 import UIKit
 
@@ -14,7 +15,7 @@ final class BookmarkAyahsViewController: UIHostingController<BookmarkAyahsView> 
 
     init(viewModel: BookmarkAyahsViewModel) {
         super.init(rootView: BookmarkAyahsView(viewModel: viewModel))
-        title = viewModel.title
+        configureTitle(for: viewModel.verses)
         navigationItem.largeTitleDisplayMode = .never
         configureDoneButton()
     }
@@ -24,7 +25,27 @@ final class BookmarkAyahsViewController: UIHostingController<BookmarkAyahsView> 
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: Internal
+
+    static func title(for verses: [AyahNumber]) -> MultipartText? {
+        guard let start = verses.first, let end = verses.last else {
+            return nil
+        }
+        return "\(ayahRange: start ... end)"
+    }
+
     // MARK: Private
+
+    private func configureTitle(for verses: [AyahNumber]) {
+        guard let title = Self.title(for: verses) else {
+            return
+        }
+
+        let label = UILabel()
+        label.attributedText = title.attributedString(ofSize: .body)
+        label.accessibilityLabel = title.accessibilityText
+        navigationItem.titleView = label
+    }
 
     private func configureDoneButton() {
         let doneButton = UIBarButtonItem(

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsViewModel.swift
@@ -6,7 +6,6 @@
 import AnnotationsService
 import Combine
 import Foundation
-import Localization
 import QuranAnnotations
 import QuranKit
 import VLogging
@@ -48,9 +47,7 @@ final class BookmarkAyahsViewModel: ObservableObject {
     @Published var isPresentingAddCollection = false
     @Published var newCollectionName = ""
 
-    var title: String {
-        lFormat("bookmarks.editor.title", verses.count)
-    }
+    let verses: [AyahNumber]
 
     var displayedCollections: [AyahBookmarkCollection] {
         BookmarkCollectionsViewModel.displayedCollections(from: collections)
@@ -173,7 +170,6 @@ final class BookmarkAyahsViewModel: ObservableObject {
 
     // MARK: Private
 
-    private let verses: [AyahNumber]
     private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
 
     private func updateCollections(_ collections: [AyahBookmarkCollection]) {

--- a/Features/BookmarksFeature/Tests/BookmarkAyahsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkAyahsViewModelTests.swift
@@ -1,6 +1,7 @@
 #if QURAN_SYNC
 import MobileSync
 import MobileSyncTestSupport
+import NoorUI
 import QuranAnnotations
 import QuranKit
 import XCTest
@@ -101,6 +102,21 @@ final class BookmarkAyahsViewModelTests: XCTestCase {
 
         XCTAssertEqual(sut.highlightSelection, .mixed([.red, .green]))
         XCTAssertEqual(sut.partiallySelectedHighlightColors, [.red, .green])
+    }
+
+    func test_titleShowsSingleAyah() {
+        let title = BookmarkAyahsViewController.title(for: [verses[0]])
+
+        XCTAssertEqual(title?.accessibilityText, verses[0].localizedName)
+    }
+
+    func test_titleShowsAyahRange() {
+        let title = BookmarkAyahsViewController.title(for: verses)
+
+        XCTAssertEqual(
+            title?.accessibilityText,
+            "\(verses[0].localizedName) - \(verses[1].localizedName)"
+        )
     }
 
     private var verses: [AyahNumber] {


### PR DESCRIPTION
## Summary

- show the selected ayah or ayah range in the sync-enabled Save Ayah sheet title
- reuse the localized, decorated `MultipartText` range presentation used by the ayah notes list
- cover single-ayah and cross-sura range titles

## Screenshot

<img width="300" alt="Save Ayah range sheet showing An-Naḥl 16:27–16:28" src="https://github.com/user-attachments/assets/9915c7ea-0fa2-4f31-a5a8-21c10d8db605" />

## Validation

- `make format-lint`
- `make test-sync TARGET=BookmarksFeatureTests/BookmarkAyahsViewModelTests` — 7 tests passed
- `make build-no-sync TARGET=BookmarksFeature` — passed
- sync-enabled example app build, launch, and Save Ayah range verification on iPhone 17 Pro simulator — passed

A broader `BookmarksFeatureTests` run encountered shared `MobileSyncTestDatabase` rollback failures across unrelated test classes; the focused suite passes when run in isolation.