### PR TITLE
docs: document PR screenshot sizing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,10 @@ Keeping these commands green locally should keep the CI workflow green as well.
 - Avoid drive-by cleanup in unrelated modules.
 - Use SwiftFormat; do not hand-format around it.
 
+## Pull requests
+
+- When uploading a screenshot to a PR description, edit its width to around 300 px and remove the height.
+
 ## Dependencies
 
 - New third-party dependencies need a quick health check and should be added only when they remove meaningful complexity.


### PR DESCRIPTION
## Summary

- add PR screenshot guidance to `AGENTS.md`
- recommend resizing uploaded screenshots to around 300 px wide
- recommend removing the height attribute to preserve the aspect ratio

## Why

Keeps screenshots compact and consistent in pull request descriptions.

## Validation

- `git diff --check`
- confirmed the branch starts from the latest `origin/main`