### PR TITLE
feat: add advanced audio range wheel picker

### DIFF
--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
@@ -15,6 +15,7 @@ import QuranLocalization
 import SwiftUI
 import UIx
 
+@MainActor
 struct AdvancedAudioOptionsView: View {
     @StateObject var viewModel: AdvancedAudioOptionsViewModel
 
@@ -27,6 +28,7 @@ struct AdvancedAudioOptionsView: View {
     }
 }
 
+@MainActor
 private struct AdvancedAudioOptionsRootView: View {
     @StateObject var viewModel: AdvancedAudioOptionsViewModel
 
@@ -52,6 +54,7 @@ private struct AdvancedAudioOptionsRootView: View {
     }
 }
 
+@MainActor
 struct AdvancedAudioOptionsRootViewUI: View {
     // MARK: Internal
 
@@ -85,23 +88,13 @@ struct AdvancedAudioOptionsRootViewUI: View {
             }
 
             Section(header: Text(l("audio.playback-ayah-range"))) {
-                FromRow(verse: fromVerse) {
-                    showVerseSelection(
-                        title: l("audio.select-start-verse"),
-                        selected: fromVerse,
-                        onSelection: updateFromVerseTo
-                    )
-                }
+                AyahRangePicker(
+                    fromVerse: fromVerse,
+                    toVerse: toVerse,
+                    updateFromVerseTo: updateFromVerseTo,
+                    updateToVerseTo: updateToVerseTo
+                )
                 EndAtRow(selection: endAtBinding)
-                if endAt == .custom {
-                    ToRow(verse: toVerse) {
-                        showVerseSelection(
-                            title: l("audio.select-end-verse"),
-                            selected: toVerse,
-                            onSelection: updateToVerseTo
-                        )
-                    }
-                }
             }
 
             PlaybackSpeedSection(
@@ -141,22 +134,6 @@ struct AdvancedAudioOptionsRootViewUI: View {
             get: { endAt },
             set: { setEndAt($0) }
         )
-    }
-
-    private func showVerseSelection(
-        title: String,
-        selected: AyahNumber,
-        onSelection: @escaping ItemAction<AyahNumber>
-    ) {
-        navigator?.push(configuration: .init(title: title)) {
-            AdvancedAudioVersesView(
-                suras: selected.quran.suras,
-                selected: selected
-            ) { ayah in
-                onSelection(ayah)
-                navigator?.pop()
-            }
-        }
     }
 }
 
@@ -292,50 +269,34 @@ private struct ReciterRow: View {
     }
 }
 
-private struct FromRow: View {
-    let verse: AyahNumber
-    let action: AsyncAction
-
-    var body: some View {
-        NoorListItem(
-            title: .text(lAndroid("from")),
-            subtitle: .init(text: "\(ayah: verse)", location: .trailing),
-            accessory: .disclosureIndicator,
-            action: action
-        )
-    }
-}
-
-private struct ToRow: View {
-    let verse: AyahNumber
-    let action: AsyncAction
-
-    var body: some View {
-        NoorListItem(
-            title: .text(lAndroid("to")),
-            subtitle: .init(text: "\(ayah: verse)", location: .trailing),
-            accessory: .disclosureIndicator,
-            action: action
-        )
-    }
-}
-
 private struct EndAtRow: View {
     @Binding var selection: EndAtChoice
 
+    @ScaledMetric private var spacing: CGFloat = 8
+
     var body: some View {
-        HStack {
+        HStack(spacing: spacing) {
             Text(l("audio.end-at"))
-            Spacer()
-            Picker(l("audio.end-at"), selection: $selection) {
-                ForEach(EndAtChoice.allCases, id: \.self) { choice in
-                    Text(choice.localizedName).tag(choice)
-                }
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize()
+
+            SegmentedChoicesPicker(
+                title: l("audio.end-at"),
+                items: EndAtChoice.pickerChoices,
+                selection: $selection
+            ) { choice in
+                choice.localizedName
             }
-            .pickerStyle(.menu)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
             .labelsHidden()
-            .tint(.appIdentity)
+            .controlSize(.small)
+            .tint(Color.secondary)
+            .opacity(0.75)
+            .frame(maxWidth: .infinity)
         }
+        .padding(.vertical, spacing)
     }
 }
 

--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsViewModel.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsViewModel.swift
@@ -30,17 +30,18 @@ final class AdvancedAudioOptionsViewModel: ObservableObject {
         options: AdvancedAudioOptions,
         reciterListBuilder: ReciterListBuilder
     ) {
+        let normalizedEnd = max(options.end, options.start)
         self.options = options
         self.reciterListBuilder = reciterListBuilder
         reciter = options.reciter
         fromVerse = options.start
-        toVerse = options.end
+        toVerse = normalizedEnd
         verseRuns = options.verseRuns
         listRuns = options.listRuns
         verseDelay = options.verseDelay
         repetitionDelay = options.repetitionDelay
         playbackRate = AudioPreferences.shared.playbackRate
-        endAt = Self.deduceEndAt(from: options.start, to: options.end)
+        endAt = Self.deduceEndAt(from: options.start, to: normalizedEnd)
 
         AudioPreferences.shared.$playbackRate.assign(to: &$playbackRate)
     }
@@ -59,10 +60,6 @@ final class AdvancedAudioOptionsViewModel: ObservableObject {
 
     @Published var repetitionDelay: RepetitionDelay
     @Published var verseDelay: VerseDelay
-
-    var suras: [Sura] {
-        options.start.quran.suras
-    }
 
     func play() {
         listener?.updateAudioOptions(to: currentOptions())
@@ -85,10 +82,7 @@ final class AdvancedAudioOptionsViewModel: ObservableObject {
     }
 
     func updateToVerseTo(_ to: AyahNumber) {
-        toVerse = to
-        if to < fromVerse {
-            fromVerse = to
-        }
+        toVerse = max(to, fromVerse)
         endAt = .custom
     }
 

--- a/Features/AdvancedAudioOptionsFeature/Sources/AyahRangePicker.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AyahRangePicker.swift
@@ -1,0 +1,192 @@
+//
+//  AyahRangePicker.swift
+//  Quran
+//
+
+import Localization
+import NoorUI
+import QuranKit
+import QuranLocalization
+import SwiftUI
+import UIx
+
+@MainActor
+struct AyahRangePicker: View {
+    let fromVerse: AyahNumber
+    let toVerse: AyahNumber
+    let updateFromVerseTo: ItemAction<AyahNumber>
+    let updateToVerseTo: ItemAction<AyahNumber>
+
+    @State private var expandedBoundary: Boundary? = .from
+
+    var body: some View {
+        Group {
+            BoundaryRow(
+                title: lAndroid("from"),
+                verse: fromVerse,
+                isExpanded: expandedBoundary == .from
+            ) {
+                toggle(.from)
+            }
+
+            if expandedBoundary == .from {
+                AyahWheelPicker(
+                    selection: fromVerse,
+                    minimum: nil,
+                    onSelection: updateFromVerseTo
+                )
+            }
+
+            BoundaryRow(
+                title: lAndroid("to"),
+                verse: toVerse,
+                isExpanded: expandedBoundary == .to
+            ) {
+                toggle(.to)
+            }
+
+            if expandedBoundary == .to {
+                AyahWheelPicker(
+                    selection: toVerse,
+                    minimum: fromVerse,
+                    onSelection: updateToVerseTo
+                )
+            }
+        }
+    }
+
+    private func toggle(_ boundary: Boundary) {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            expandedBoundary = expandedBoundary == boundary ? nil : boundary
+        }
+    }
+}
+
+private extension AyahRangePicker {
+    enum Boundary {
+        case from
+        case to
+    }
+}
+
+@MainActor
+private struct BoundaryRow: View {
+    let title: String
+    let verse: AyahNumber
+    let isExpanded: Bool
+    let action: @MainActor () -> Void
+
+    @ScaledMetric private var spacing: CGFloat = 8
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: spacing) {
+                Text(title)
+                    .foregroundStyle(.primary)
+
+                Spacer(minLength: spacing)
+
+                let reference: MultipartText = "\(ayah: verse)"
+                reference
+                    .view(ofSize: .body, allowsWrapping: false)
+                    .foregroundStyle(isExpanded ? Color.appIdentity : .secondary)
+
+                Image(systemName: "chevron.down")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(isExpanded ? Color.appIdentity : Color(.tertiaryLabel))
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityValue(verse.localizedName)
+    }
+}
+
+@MainActor
+private struct AyahWheelPicker: View {
+    let selection: AyahNumber
+    let minimum: AyahNumber?
+    let onSelection: ItemAction<AyahNumber>
+
+    @ScaledMetric private var pickerHeight: CGFloat = 150
+    @ScaledMetric private var ayahPickerWidth: CGFloat = 120
+
+    private var model: AyahWheelPickerModel {
+        AyahWheelPickerModel(selection: selection, minimum: minimum)
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Picker(lAndroid("sura"), selection: suraBinding) {
+                ForEach(model.suras) { sura in
+                    let reference: MultipartText = "\(sura.localizedSuraNumber) · \(sura: sura)"
+                    reference
+                        .view(ofSize: .body, allowsWrapping: false)
+                        .tag(sura)
+                }
+            }
+            .pickerStyle(.wheel)
+            .labelsHidden()
+            .frame(maxWidth: .infinity)
+            .clipped()
+
+            Divider()
+
+            Picker(l("ayah"), selection: ayahBinding) {
+                ForEach(model.ayahs, id: \.self) { ayah in
+                    Text(ayah.localizedAyahNumber)
+                        .tag(ayah)
+                }
+            }
+            .pickerStyle(.wheel)
+            .labelsHidden()
+            .frame(width: ayahPickerWidth)
+            .clipped()
+            .id(selection.sura)
+        }
+        .frame(height: pickerHeight)
+    }
+
+    private var suraBinding: Binding<Sura> {
+        Binding(
+            get: { selection.sura },
+            set: { onSelection(model.selecting(sura: $0)) }
+        )
+    }
+
+    private var ayahBinding: Binding<AyahNumber> {
+        Binding(
+            get: { selection },
+            set: { onSelection($0) }
+        )
+    }
+}
+
+struct AyahWheelPickerModel {
+    let selection: AyahNumber
+    let minimum: AyahNumber?
+
+    var suras: [Sura] {
+        selection.quran.suras.filter { sura in
+            guard let minimum else { return true }
+            return sura >= minimum.sura
+        }
+    }
+
+    var ayahs: [AyahNumber] {
+        selection.sura.verses.filter { ayah in
+            guard let minimum, minimum.sura == selection.sura else { return true }
+            return ayah >= minimum
+        }
+    }
+
+    func selecting(sura: Sura) -> AyahNumber {
+        let firstAyah = if let minimum, minimum.sura == sura {
+            minimum.ayah
+        } else {
+            sura.firstVerse.ayah
+        }
+        let ayah = min(max(selection.ayah, firstAyah), sura.lastVerse.ayah)
+        return AyahNumber(sura: sura, ayah: ayah)!
+    }
+}

--- a/Features/AdvancedAudioOptionsFeature/Sources/EndAtChoice.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/EndAtChoice.swift
@@ -14,6 +14,8 @@ enum EndAtChoice: Hashable, CaseIterable {
     case quran
     case custom
 
+    static let pickerChoices: [EndAtChoice] = [.custom, .page, .surah, .juz, .quran]
+
     var audioEnd: AudioEnd? {
         switch self {
         case .page: return .page

--- a/Features/AdvancedAudioOptionsFeature/Tests/AdvancedAudioOptionsViewModelTests.swift
+++ b/Features/AdvancedAudioOptionsFeature/Tests/AdvancedAudioOptionsViewModelTests.swift
@@ -86,6 +86,28 @@ final class AdvancedAudioOptionsViewModelTests: XCTestCase {
         XCTAssertEqual(sut.endAt, .custom)
     }
 
+    func test_updateToVerseTo_clampsEndToStart_whenSelectionIsEarlier() {
+        let alFatihah = quran.suras[0]
+        let start = alFatihah.firstVerse.next!
+        let sut = makeSUT(start: start, end: alFatihah.lastVerse)
+
+        sut.updateToVerseTo(alFatihah.firstVerse)
+
+        XCTAssertEqual(sut.fromVerse, start)
+        XCTAssertEqual(sut.toVerse, start)
+        XCTAssertEqual(sut.endAt, .custom)
+    }
+
+    func test_init_clampsEndToStart_whenOptionsEndIsEarlier() {
+        let alFatihah = quran.suras[0]
+        let start = alFatihah.firstVerse.next!
+
+        let sut = makeSUT(start: start, end: alFatihah.firstVerse)
+
+        XCTAssertEqual(sut.fromVerse, start)
+        XCTAssertEqual(sut.toVerse, start)
+    }
+
     func test_updateFromVerseTo_reAppliesEndAt_whenNotCustom() {
         let alFatihah = quran.suras[0]
         let alBaqarah = quran.suras[1]

--- a/Features/AdvancedAudioOptionsFeature/Tests/AyahWheelPickerModelTests.swift
+++ b/Features/AdvancedAudioOptionsFeature/Tests/AyahWheelPickerModelTests.swift
@@ -1,0 +1,59 @@
+//
+//  AyahWheelPickerModelTests.swift
+//
+
+import QuranKit
+import XCTest
+@testable import AdvancedAudioOptionsFeature
+
+final class AyahWheelPickerModelTests: XCTestCase {
+    func test_selectingShorterSura_clampsAyahToNewSuraEnd() {
+        let alBaqarah = quran.suras[1]
+        let alFatihah = quran.suras[0]
+        let sut = AyahWheelPickerModel(selection: alBaqarah.lastVerse, minimum: nil)
+
+        let selection = sut.selecting(sura: alFatihah)
+
+        XCTAssertEqual(selection, alFatihah.lastVerse)
+    }
+
+    func test_selectingLongerSura_retainsAyahNumber() {
+        let alFatihah = quran.suras[0]
+        let alBaqarah = quran.suras[1]
+        let sut = AyahWheelPickerModel(selection: alFatihah.lastVerse, minimum: nil)
+
+        let selection = sut.selecting(sura: alBaqarah)
+
+        XCTAssertEqual(selection, alBaqarah.verses[6])
+    }
+
+    func test_toSuras_excludeSurasBeforeFrom() {
+        let from = quran.suras[1].verses[99]
+        let selection = quran.suras[2].firstVerse
+        let sut = AyahWheelPickerModel(selection: selection, minimum: from)
+
+        XCTAssertEqual(sut.suras.first, from.sura)
+        XCTAssertFalse(sut.suras.contains(quran.suras[0]))
+    }
+
+    func test_toAyahs_excludeAyahsBeforeFrom_inSameSura() {
+        let sura = quran.suras[1]
+        let from = sura.verses[99]
+        let sut = AyahWheelPickerModel(selection: from, minimum: from)
+
+        XCTAssertEqual(sut.ayahs.first, from)
+        XCTAssertFalse(sut.ayahs.contains(sura.verses[98]))
+    }
+
+    func test_selectingFromSura_clampsRetainedAyahToMinimum() {
+        let from = quran.suras[1].verses[99]
+        let laterSura = quran.suras[2]
+        let sut = AyahWheelPickerModel(selection: laterSura.firstVerse, minimum: from)
+
+        let selection = sut.selecting(sura: from.sura)
+
+        XCTAssertEqual(selection, from)
+    }
+
+    private let quran = Quran.hafsMadani1405
+}


### PR DESCRIPTION
## Summary

- replace pushed verse selection with inline surah and ayah wheel pickers
- clamp ayah values when moving between surahs with different lengths
- prevent the end ayah from preceding the start ayah
- switch End at to Custom whenever the end selection changes
- use a compact, secondary-styled segmented End at control

## Validation

- `make format-lint`
- `make test-no-sync`
- `make test-sync`
- `make test-no-sync TARGET=AdvancedAudioOptionsFeature`
- `make test-sync TARGET=AdvancedAudioOptionsFeature`
- verified cross-surah clamping and End at behavior on iPhone 17 Simulator

## Screenshot

<img width="300" height="652" alt="Advanced audio range picker" src="https://github.com/user-attachments/assets/8d5d16c6-4eb7-48ac-b5da-23cd1b8c9b8c" />