### PR TITLE
fix: distinguish page and ayah Quran navigation

### DIFF
--- a/Features/AppStructureFeature/Sources/Common/TabInteractor.swift
+++ b/Features/AppStructureFeature/Sources/Common/TabInteractor.swift
@@ -27,10 +27,16 @@ class TabInteractor: QuranNavigator {
 
     weak var presenter: TabPresenter?
 
+    func navigateTo(page: Page, lastPage: LastPage?) {
+        navigateTo(
+            input: QuranInput(initialPage: page, lastPage: lastPage, navigationAyah: nil)
+        )
+    }
+
     func navigateTo(ayah: AyahNumber, lastPage: LastPage?) {
-        let input = QuranInput(initialAyah: ayah, lastPage: lastPage)
-        let viewController = quranBuilder.build(input: input)
-        presenter?.pushViewController(viewController, animated: true)
+        navigateTo(
+            input: QuranInput(initialPage: ayah.page, lastPage: lastPage, navigationAyah: ayah)
+        )
     }
 
     func start() {
@@ -39,4 +45,9 @@ class TabInteractor: QuranNavigator {
     // MARK: Private
 
     private let quranBuilder: QuranBuilder
+
+    private func navigateTo(input: QuranInput) {
+        let viewController = quranBuilder.build(input: input)
+        presenter?.pushViewController(viewController, animated: true)
+    }
 }

--- a/Features/AppStructureFeature/Sources/Common/TabInteractor.swift
+++ b/Features/AppStructureFeature/Sources/Common/TabInteractor.swift
@@ -27,8 +27,8 @@ class TabInteractor: QuranNavigator {
 
     weak var presenter: TabPresenter?
 
-    func navigateTo(page: Page, lastPage: LastPage?, highlightingSearchAyah: AyahNumber?) {
-        let input = QuranInput(initialPage: page, lastPage: lastPage, highlightingSearchAyah: highlightingSearchAyah)
+    func navigateTo(ayah: AyahNumber, lastPage: LastPage?) {
+        let input = QuranInput(initialAyah: ayah, lastPage: lastPage)
         let viewController = quranBuilder.build(input: input)
         presenter?.pushViewController(viewController, animated: true)
     }

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
@@ -16,11 +16,11 @@ struct AyahBookmarkCollectionsBuilder {
     init(
         ayahBookmarkCollectionService: AyahBookmarkCollectionService,
         quranTextDataService: QuranTextDataService,
-        navigateToPage: @escaping (Page) -> Void
+        navigateToAyah: @escaping (AyahNumber) -> Void
     ) {
         self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
         self.quranTextDataService = quranTextDataService
-        self.navigateToPage = navigateToPage
+        self.navigateToAyah = navigateToAyah
     }
 
     func buildCollection(
@@ -31,7 +31,7 @@ struct AyahBookmarkCollectionsBuilder {
             ayahBookmarkCollectionService: ayahBookmarkCollectionService,
             collection: collection,
             quranTextDataService: quranTextDataService,
-            navigateToPage: navigateToPage,
+            navigateToAyah: navigateToAyah,
             collectionDeleted: collectionDeleted
         )
         return AyahBookmarkCollectionsViewController(viewModel: viewModel)
@@ -39,6 +39,6 @@ struct AyahBookmarkCollectionsBuilder {
 
     private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
     private let quranTextDataService: QuranTextDataService
-    private let navigateToPage: (Page) -> Void
+    private let navigateToAyah: (AyahNumber) -> Void
 }
 #endif

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
@@ -21,14 +21,14 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
         ayahBookmarkCollectionService: AyahBookmarkCollectionService,
         collection: AyahBookmarkCollection,
         quranTextDataService: QuranTextDataService,
-        navigateToPage: @escaping (Page) -> Void,
+        navigateToAyah: @escaping (AyahNumber) -> Void,
         collectionDeleted: @escaping () -> Void
     ) {
         self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
         self.collection = collection
         collectionID = collection.collection.id
         self.quranTextDataService = quranTextDataService
-        self.navigateToPage = navigateToPage
+        self.navigateToAyah = navigateToAyah
         self.collectionDeleted = collectionDeleted
     }
 
@@ -60,7 +60,7 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
 
     func navigateTo(_ bookmark: AyahCollectionBookmark) {
         logger.info("Bookmarks: select collection bookmark at \(bookmark.ayah)")
-        navigateToPage(bookmark.ayah.page)
+        navigateToAyah(bookmark.ayah)
     }
 
     func deleteBookmark(_ bookmark: AyahCollectionBookmark) async {
@@ -128,7 +128,7 @@ final class AyahBookmarkCollectionsViewModel: ObservableObject {
     private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
     private let quranTextDataService: QuranTextDataService
     private let collectionID: String
-    private let navigateToPage: (Page) -> Void
+    private let navigateToAyah: (AyahNumber) -> Void
     private let collectionDeleted: () -> Void
 
     private func loadAyahTexts(for collection: AyahBookmarkCollection?) async throws {

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsBuilder.swift
@@ -30,6 +30,9 @@ struct BookmarkCollectionsBuilder {
             readingBookmarkService: container.readingBookmarkService(),
             collectionsBuilder: collectionsBuilder,
             navigationController: navigationController,
+            navigateToPage: { [weak listener] page in
+                listener?.navigateTo(page: page, lastPage: nil)
+            },
             navigateToAyah: { [weak listener] ayah in
                 listener?.navigateTo(ayah: ayah, lastPage: nil)
             }

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsBuilder.swift
@@ -20,8 +20,8 @@ struct BookmarkCollectionsBuilder {
         let collectionsBuilder = AyahBookmarkCollectionsBuilder(
             ayahBookmarkCollectionService: collectionService,
             quranTextDataService: container.textDataService(),
-            navigateToPage: { [weak listener] page in
-                listener?.navigateTo(page: page, lastPage: nil, highlightingSearchAyah: nil)
+            navigateToAyah: { [weak listener] ayah in
+                listener?.navigateTo(ayah: ayah, lastPage: nil)
             }
         )
         let viewModel = BookmarkCollectionsViewModel(
@@ -30,8 +30,8 @@ struct BookmarkCollectionsBuilder {
             readingBookmarkService: container.readingBookmarkService(),
             collectionsBuilder: collectionsBuilder,
             navigationController: navigationController,
-            navigateToPage: { [weak listener] page, ayah in
-                listener?.navigateTo(page: page, lastPage: nil, highlightingSearchAyah: ayah)
+            navigateToAyah: { [weak listener] ayah in
+                listener?.navigateTo(ayah: ayah, lastPage: nil)
             }
         )
         return BookmarkCollectionsViewController(viewModel: viewModel)

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -24,14 +24,14 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         readingBookmarkService: MobileSyncReadingBookmarkService,
         collectionsBuilder: AyahBookmarkCollectionsBuilder,
         navigationController: UINavigationController,
-        navigateToPage: @escaping (Page, AyahNumber?) -> Void
+        navigateToAyah: @escaping (AyahNumber) -> Void
     ) {
         self.authenticationClient = authenticationClient
         self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
         self.readingBookmarkService = readingBookmarkService
         self.collectionsBuilder = collectionsBuilder
         self.navigationController = navigationController
-        self.navigateToPage = navigateToPage
+        self.navigateToAyah = navigateToAyah
         isSyncBannerDismissed = preferences.isSyncBannerDismissed
     }
 
@@ -185,9 +185,9 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     func navigateTo(_ readingBookmark: ReadingPositionBookmark) {
         switch readingBookmark.location {
         case .ayah(let ayahNumber):
-            navigateToPage(ayahNumber.page, ayahNumber)
+            navigateToAyah(ayahNumber)
         case .page(let page):
-            navigateToPage(page, nil)
+            navigateToAyah(page.firstVerse)
         }
     }
 
@@ -197,7 +197,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
     private let readingBookmarkService: MobileSyncReadingBookmarkService
     private let collectionsBuilder: AyahBookmarkCollectionsBuilder
-    private let navigateToPage: (Page, AyahNumber?) -> Void
+    private let navigateToAyah: (AyahNumber) -> Void
     private let preferences = BookmarkCollectionsPreferences.shared
     private let readingPreferences = ReadingPreferences.shared
     private weak var navigationController: UINavigationController?

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -24,6 +24,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         readingBookmarkService: MobileSyncReadingBookmarkService,
         collectionsBuilder: AyahBookmarkCollectionsBuilder,
         navigationController: UINavigationController,
+        navigateToPage: @escaping (Page) -> Void,
         navigateToAyah: @escaping (AyahNumber) -> Void
     ) {
         self.authenticationClient = authenticationClient
@@ -31,6 +32,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         self.readingBookmarkService = readingBookmarkService
         self.collectionsBuilder = collectionsBuilder
         self.navigationController = navigationController
+        self.navigateToPage = navigateToPage
         self.navigateToAyah = navigateToAyah
         isSyncBannerDismissed = preferences.isSyncBannerDismissed
     }
@@ -187,7 +189,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         case .ayah(let ayahNumber):
             navigateToAyah(ayahNumber)
         case .page(let page):
-            navigateToAyah(page.firstVerse)
+            navigateToPage(page)
         }
     }
 
@@ -197,6 +199,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
     private let readingBookmarkService: MobileSyncReadingBookmarkService
     private let collectionsBuilder: AyahBookmarkCollectionsBuilder
+    private let navigateToPage: (Page) -> Void
     private let navigateToAyah: (AyahNumber) -> Void
     private let preferences = BookmarkCollectionsPreferences.shared
     private let readingPreferences = ReadingPreferences.shared

--- a/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
@@ -37,8 +37,8 @@ public struct BookmarksBuilder {
         let viewModel = BookmarksViewModel(
             analytics: container.analytics,
             service: service,
-            navigateTo: { [weak listener] page in
-                listener?.navigateTo(page: page, lastPage: nil, highlightingSearchAyah: nil)
+            navigateTo: { [weak listener] ayah in
+                listener?.navigateTo(ayah: ayah, lastPage: nil)
             }
         )
         return BookmarksViewController(viewModel: viewModel)

--- a/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksBuilder.swift
@@ -37,8 +37,8 @@ public struct BookmarksBuilder {
         let viewModel = BookmarksViewModel(
             analytics: container.analytics,
             service: service,
-            navigateTo: { [weak listener] ayah in
-                listener?.navigateTo(ayah: ayah, lastPage: nil)
+            navigateTo: { [weak listener] page in
+                listener?.navigateTo(page: page, lastPage: nil)
             }
         )
         return BookmarksViewController(viewModel: viewModel)

--- a/Features/BookmarksFeature/Sources/BookmarksViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksViewModel.swift
@@ -22,7 +22,7 @@ final class BookmarksViewModel: ObservableObject {
     init(
         analytics: AnalyticsLibrary,
         service: PageBookmarkService,
-        navigateTo: @escaping (AyahNumber) -> Void
+        navigateTo: @escaping (Page) -> Void
     ) {
         self.analytics = analytics
         self.service = service
@@ -53,7 +53,7 @@ final class BookmarksViewModel: ObservableObject {
     func navigateTo(_ item: PageBookmark) {
         logger.info("Bookmarks: select bookmark at \(item.page)")
         analytics.openingQuran(from: .bookmarks)
-        navigateTo(item.page.firstVerse)
+        navigateTo(item.page)
     }
 
     func deleteItem(_ pageBookmark: PageBookmark) async {
@@ -77,7 +77,7 @@ final class BookmarksViewModel: ObservableObject {
 
     // MARK: Private
 
-    private let navigateTo: (AyahNumber) -> Void
+    private let navigateTo: (Page) -> Void
     private let analytics: AnalyticsLibrary
     private let service: PageBookmarkService
     private let readingPreferences = ReadingPreferences.shared

--- a/Features/BookmarksFeature/Sources/BookmarksViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksViewModel.swift
@@ -22,7 +22,7 @@ final class BookmarksViewModel: ObservableObject {
     init(
         analytics: AnalyticsLibrary,
         service: PageBookmarkService,
-        navigateTo: @escaping (Page) -> Void
+        navigateTo: @escaping (AyahNumber) -> Void
     ) {
         self.analytics = analytics
         self.service = service
@@ -53,7 +53,7 @@ final class BookmarksViewModel: ObservableObject {
     func navigateTo(_ item: PageBookmark) {
         logger.info("Bookmarks: select bookmark at \(item.page)")
         analytics.openingQuran(from: .bookmarks)
-        navigateTo(item.page)
+        navigateTo(item.page.firstVerse)
     }
 
     func deleteItem(_ pageBookmark: PageBookmark) async {
@@ -77,7 +77,7 @@ final class BookmarksViewModel: ObservableObject {
 
     // MARK: Private
 
-    private let navigateTo: (Page) -> Void
+    private let navigateTo: (AyahNumber) -> Void
     private let analytics: AnalyticsLibrary
     private let service: PageBookmarkService
     private let readingPreferences = ReadingPreferences.shared

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
@@ -197,17 +197,41 @@ final class AyahBookmarkCollectionsViewModelTests: XCTestCase {
         XCTAssertNil(sut.error)
     }
 
+    func test_navigateToBookmark_navigatesToBookmarkedAyah() async throws {
+        let service = makeService()
+        try await service.createCollection(named: "Highlights")
+        let storedCollection = try await firstCollection()
+        let ayah = try XCTUnwrap(AyahNumber(quran: .hafsMadani1405, sura: 2, ayah: 255))
+        try await service.addAyahBookmarkToCollection(
+            collectionId: storedCollection.collection.id,
+            ayah: ayah
+        )
+        let collection = try await firstCollection()
+        let bookmark = try XCTUnwrap(collection.bookmarks.first)
+        var navigatedAyah: AyahNumber?
+        let sut = makeSUT(
+            collection: collection,
+            service: service,
+            navigateToAyah: { navigatedAyah = $0 }
+        )
+
+        sut.navigateTo(bookmark)
+
+        XCTAssertEqual(navigatedAyah, ayah)
+    }
+
     private func makeSUT(
         collection: AyahBookmarkCollection,
         service: AyahBookmarkCollectionService? = nil,
         quranTextDataService: QuranTextDataService? = nil,
+        navigateToAyah: @escaping (AyahNumber) -> Void = { _ in },
         collectionDeleted: @escaping () -> Void = {}
     ) -> AyahBookmarkCollectionsViewModel {
         AyahBookmarkCollectionsViewModel(
             ayahBookmarkCollectionService: service ?? makeService(),
             collection: collection,
             quranTextDataService: quranTextDataService ?? makeQuranTextDataService(),
-            navigateToPage: { _ in },
+            navigateToAyah: navigateToAyah,
             collectionDeleted: collectionDeleted
         )
     }

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -397,43 +397,33 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         task.cancel()
     }
 
-    func test_navigateToPageReadingBookmark_navigatesToPageWithoutAyah() {
+    func test_navigateToPageReadingBookmark_navigatesToFirstAyahOnPage() {
         let page = Quran.hafsMadani1405.pages[269]
         let bookmark = ReadingPositionBookmark(
             id: "reading-bookmark",
             location: .page(page),
             modifiedOn: .distantPast
         )
-        var navigatedPage: Page?
         var navigatedAyah: AyahNumber?
-        let sut = makeSUT(navigateToPage: {
-            navigatedPage = $0
-            navigatedAyah = $1
-        })
+        let sut = makeSUT(navigateToAyah: { navigatedAyah = $0 })
 
         sut.navigateTo(bookmark)
 
-        XCTAssertEqual(navigatedPage, page)
-        XCTAssertNil(navigatedAyah)
+        XCTAssertEqual(navigatedAyah, page.firstVerse)
     }
 
-    func test_navigateToAyahReadingBookmark_navigatesToPageAndAyah() {
+    func test_navigateToAyahReadingBookmark_navigatesToBookmarkedAyah() {
         let ayah = Quran.hafsMadani1405.pages[269].firstVerse
         let bookmark = ReadingPositionBookmark(
             id: "reading-bookmark",
             location: .ayah(ayah),
             modifiedOn: .distantPast
         )
-        var navigatedPage: Page?
         var navigatedAyah: AyahNumber?
-        let sut = makeSUT(navigateToPage: {
-            navigatedPage = $0
-            navigatedAyah = $1
-        })
+        let sut = makeSUT(navigateToAyah: { navigatedAyah = $0 })
 
         sut.navigateTo(bookmark)
 
-        XCTAssertEqual(navigatedPage, ayah.page)
         XCTAssertEqual(navigatedAyah, ayah)
     }
 
@@ -462,7 +452,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         collectionService: AyahBookmarkCollectionService? = nil,
         readingBookmarkService: MobileSyncReadingBookmarkService? = nil,
         navigationController: UINavigationController? = nil,
-        navigateToPage: @escaping (Page, AyahNumber?) -> Void = { _, _ in }
+        navigateToAyah: @escaping (AyahNumber) -> Void = { _ in }
     ) -> BookmarkCollectionsViewModel {
         let collectionService = collectionService ?? makeService()
         let readingBookmarkService = readingBookmarkService ?? makeReadingBookmarkService()
@@ -470,7 +460,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         let collectionsBuilder = AyahBookmarkCollectionsBuilder(
             ayahBookmarkCollectionService: collectionService,
             quranTextDataService: makeQuranTextDataService(),
-            navigateToPage: { _ in }
+            navigateToAyah: { _ in }
         )
         return BookmarkCollectionsViewModel(
             authenticationClient: authenticationClient,
@@ -478,7 +468,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
             readingBookmarkService: readingBookmarkService,
             collectionsBuilder: collectionsBuilder,
             navigationController: navigationController,
-            navigateToPage: navigateToPage
+            navigateToAyah: navigateToAyah
         )
     }
 
@@ -497,7 +487,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
             ayahBookmarkCollectionService: makeService(),
             collection: collection,
             quranTextDataService: makeQuranTextDataService(),
-            navigateToPage: { _ in },
+            navigateToAyah: { _ in },
             collectionDeleted: {}
         )
     }

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -397,19 +397,19 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         task.cancel()
     }
 
-    func test_navigateToPageReadingBookmark_navigatesToFirstAyahOnPage() {
+    func test_navigateToPageReadingBookmark_navigatesToPage() {
         let page = Quran.hafsMadani1405.pages[269]
         let bookmark = ReadingPositionBookmark(
             id: "reading-bookmark",
             location: .page(page),
             modifiedOn: .distantPast
         )
-        var navigatedAyah: AyahNumber?
-        let sut = makeSUT(navigateToAyah: { navigatedAyah = $0 })
+        var navigatedPage: Page?
+        let sut = makeSUT(navigateToPage: { navigatedPage = $0 })
 
         sut.navigateTo(bookmark)
 
-        XCTAssertEqual(navigatedAyah, page.firstVerse)
+        XCTAssertEqual(navigatedPage, page)
     }
 
     func test_navigateToAyahReadingBookmark_navigatesToBookmarkedAyah() {
@@ -452,6 +452,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         collectionService: AyahBookmarkCollectionService? = nil,
         readingBookmarkService: MobileSyncReadingBookmarkService? = nil,
         navigationController: UINavigationController? = nil,
+        navigateToPage: @escaping (Page) -> Void = { _ in },
         navigateToAyah: @escaping (AyahNumber) -> Void = { _ in }
     ) -> BookmarkCollectionsViewModel {
         let collectionService = collectionService ?? makeService()
@@ -468,6 +469,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
             readingBookmarkService: readingBookmarkService,
             collectionsBuilder: collectionsBuilder,
             navigationController: navigationController,
+            navigateToPage: navigateToPage,
             navigateToAyah: navigateToAyah
         )
     }

--- a/Features/BookmarksFeature/Tests/BookmarksViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarksViewModelTests.swift
@@ -24,14 +24,28 @@ final class BookmarksViewModelTests: XCTestCase {
         XCTAssertNil(sut.error)
     }
 
+    func test_navigateToBookmark_navigatesToFirstAyahOnPage() {
+        let page = Quran.hafsMadani1405.pages[269]
+        let bookmark = PageBookmark(page: page, creationDate: .distantPast)
+        var navigatedAyah: AyahNumber?
+        let sut = makeSUT(navigateTo: { navigatedAyah = $0 })
+
+        sut.navigateTo(bookmark)
+
+        XCTAssertEqual(navigatedAyah, page.firstVerse)
+    }
+
     // MARK: Private
 
-    private func makeSUT(persistence: PageBookmarkPersistenceSpy = PageBookmarkPersistenceSpy()) -> BookmarksViewModel {
+    private func makeSUT(
+        persistence: PageBookmarkPersistenceSpy = PageBookmarkPersistenceSpy(),
+        navigateTo: @escaping (AyahNumber) -> Void = { _ in }
+    ) -> BookmarksViewModel {
         let service = PageBookmarkService(persistence: persistence)
         return BookmarksViewModel(
             analytics: AnalyticsSpy(),
             service: service,
-            navigateTo: { _ in }
+            navigateTo: navigateTo
         )
     }
 }

--- a/Features/BookmarksFeature/Tests/BookmarksViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarksViewModelTests.swift
@@ -24,22 +24,22 @@ final class BookmarksViewModelTests: XCTestCase {
         XCTAssertNil(sut.error)
     }
 
-    func test_navigateToBookmark_navigatesToFirstAyahOnPage() {
+    func test_navigateToBookmark_navigatesToPage() {
         let page = Quran.hafsMadani1405.pages[269]
         let bookmark = PageBookmark(page: page, creationDate: .distantPast)
-        var navigatedAyah: AyahNumber?
-        let sut = makeSUT(navigateTo: { navigatedAyah = $0 })
+        var navigatedPage: Page?
+        let sut = makeSUT(navigateTo: { navigatedPage = $0 })
 
         sut.navigateTo(bookmark)
 
-        XCTAssertEqual(navigatedAyah, page.firstVerse)
+        XCTAssertEqual(navigatedPage, page)
     }
 
     // MARK: Private
 
     private func makeSUT(
         persistence: PageBookmarkPersistenceSpy = PageBookmarkPersistenceSpy(),
-        navigateTo: @escaping (AyahNumber) -> Void = { _ in }
+        navigateTo: @escaping (Page) -> Void = { _ in }
     ) -> BookmarksViewModel {
         let service = PageBookmarkService(persistence: persistence)
         return BookmarksViewModel(

--- a/Features/FeaturesSupport/Sources/QuranNavigator.swift
+++ b/Features/FeaturesSupport/Sources/QuranNavigator.swift
@@ -10,5 +10,5 @@ import QuranKit
 
 @MainActor
 public protocol QuranNavigator: AnyObject {
-    func navigateTo(page: Page, lastPage: LastPage?, highlightingSearchAyah: AyahNumber?)
+    func navigateTo(ayah: AyahNumber, lastPage: LastPage?)
 }

--- a/Features/FeaturesSupport/Sources/QuranNavigator.swift
+++ b/Features/FeaturesSupport/Sources/QuranNavigator.swift
@@ -10,5 +10,6 @@ import QuranKit
 
 @MainActor
 public protocol QuranNavigator: AnyObject {
+    func navigateTo(page: Page, lastPage: LastPage?)
     func navigateTo(ayah: AyahNumber, lastPage: LastPage?)
 }

--- a/Features/HomeFeature/Sources/HomeBuilder.swift
+++ b/Features/HomeFeature/Sources/HomeBuilder.swift
@@ -33,16 +33,22 @@ public struct HomeBuilder {
             lastPageService: container.lastPageService(),
             textRetriever: textRetriever,
             readingBookmarkService: container.readingBookmarkService(),
-            navigateToQuran: { [weak listener] ayah, lastPage in
-                listener?.navigateTo(ayah: ayah, lastPage: lastPage)
+            navigateToPage: { [weak listener] page, lastPage in
+                listener?.navigateTo(page: page, lastPage: lastPage)
+            },
+            navigateToAyah: { [weak listener] ayah in
+                listener?.navigateTo(ayah: ayah, lastPage: nil)
             }
         )
         #else
         let viewModel = HomeViewModel(
             lastPageService: container.lastPageService(),
             textRetriever: textRetriever,
-            navigateToQuran: { [weak listener] ayah, lastPage in
-                listener?.navigateTo(ayah: ayah, lastPage: lastPage)
+            navigateToPage: { [weak listener] page, lastPage in
+                listener?.navigateTo(page: page, lastPage: lastPage)
+            },
+            navigateToAyah: { [weak listener] ayah in
+                listener?.navigateTo(ayah: ayah, lastPage: nil)
             }
         )
         #endif

--- a/Features/HomeFeature/Sources/HomeBuilder.swift
+++ b/Features/HomeFeature/Sources/HomeBuilder.swift
@@ -33,28 +33,16 @@ public struct HomeBuilder {
             lastPageService: container.lastPageService(),
             textRetriever: textRetriever,
             readingBookmarkService: container.readingBookmarkService(),
-            navigateToPage: { [weak listener] page, lastPage, ayah in
-                listener?.navigateTo(page: page, lastPage: lastPage, highlightingSearchAyah: ayah)
-            },
-            navigateToSura: { [weak listener] sura in
-                listener?.navigateTo(page: sura.page, lastPage: nil, highlightingSearchAyah: nil)
-            },
-            navigateToQuarter: { [weak listener] quarter in
-                listener?.navigateTo(page: quarter.page, lastPage: nil, highlightingSearchAyah: nil)
+            navigateToQuran: { [weak listener] ayah, lastPage in
+                listener?.navigateTo(ayah: ayah, lastPage: lastPage)
             }
         )
         #else
         let viewModel = HomeViewModel(
             lastPageService: container.lastPageService(),
             textRetriever: textRetriever,
-            navigateToPage: { [weak listener] page, lastPage, ayah in
-                listener?.navigateTo(page: page, lastPage: lastPage, highlightingSearchAyah: ayah)
-            },
-            navigateToSura: { [weak listener] sura in
-                listener?.navigateTo(page: sura.page, lastPage: nil, highlightingSearchAyah: nil)
-            },
-            navigateToQuarter: { [weak listener] quarter in
-                listener?.navigateTo(page: quarter.page, lastPage: nil, highlightingSearchAyah: nil)
+            navigateToQuran: { [weak listener] ayah, lastPage in
+                listener?.navigateTo(ayah: ayah, lastPage: lastPage)
             }
         )
         #endif

--- a/Features/HomeFeature/Sources/HomeViewModel.swift
+++ b/Features/HomeFeature/Sources/HomeViewModel.swift
@@ -36,12 +36,14 @@ final class HomeViewModel: ObservableObject {
         lastPageService: any LastPageService,
         textRetriever: QuranTextDataService,
         readingBookmarkService: MobileSyncReadingBookmarkService,
-        navigateToQuran: @escaping (AyahNumber, LastPage?) -> Void
+        navigateToPage: @escaping (Page, LastPage?) -> Void,
+        navigateToAyah: @escaping (AyahNumber) -> Void
     ) {
         self.lastPageService = lastPageService
         self.textRetriever = textRetriever
         self.readingBookmarkService = readingBookmarkService
-        self.navigateToQuran = navigateToQuran
+        self.navigateToPage = navigateToPage
+        self.navigateToAyah = navigateToAyah
 
         HomePreferences.shared.$surahSortOrder
             .assign(to: &$surahSortOrder)
@@ -50,11 +52,13 @@ final class HomeViewModel: ObservableObject {
     init(
         lastPageService: any LastPageService,
         textRetriever: QuranTextDataService,
-        navigateToQuran: @escaping (AyahNumber, LastPage?) -> Void
+        navigateToPage: @escaping (Page, LastPage?) -> Void,
+        navigateToAyah: @escaping (AyahNumber) -> Void
     ) {
         self.lastPageService = lastPageService
         self.textRetriever = textRetriever
-        self.navigateToQuran = navigateToQuran
+        self.navigateToPage = navigateToPage
+        self.navigateToAyah = navigateToAyah
 
         HomePreferences.shared.$surahSortOrder
             .assign(to: &$surahSortOrder)
@@ -105,26 +109,26 @@ final class HomeViewModel: ObservableObject {
     }
 
     func navigateTo(_ lastPage: LastPage) {
-        navigateToQuran(lastPage.page.firstVerse, lastPage)
+        navigateToPage(lastPage.page, lastPage)
     }
 
     #if QURAN_SYNC
     func navigateTo(_ readingBookmark: ReadingPositionBookmark) {
         switch readingBookmark.location {
         case .ayah(let ayahNumber):
-            navigateToQuran(ayahNumber, nil)
+            navigateToAyah(ayahNumber)
         case .page(let page):
-            navigateToQuran(page.firstVerse, nil)
+            navigateToPage(page, nil)
         }
     }
     #endif
 
     func navigateTo(_ sura: Sura) {
-        navigateToQuran(sura.firstVerse, nil)
+        navigateToAyah(sura.firstVerse)
     }
 
     func navigateTo(_ item: QuarterItem) {
-        navigateToQuran(item.quarter.firstVerse, nil)
+        navigateToAyah(item.quarter.firstVerse)
     }
 
     func toggleSurahSortOrder() {
@@ -138,7 +142,8 @@ final class HomeViewModel: ObservableObject {
     #if QURAN_SYNC
     private let readingBookmarkService: MobileSyncReadingBookmarkService
     #endif
-    private let navigateToQuran: (AyahNumber, LastPage?) -> Void
+    private let navigateToPage: (Page, LastPage?) -> Void
+    private let navigateToAyah: (AyahNumber) -> Void
     private let readingPreferences = ReadingPreferences.shared
 
     private func loadLastPages() async {

--- a/Features/HomeFeature/Sources/HomeViewModel.swift
+++ b/Features/HomeFeature/Sources/HomeViewModel.swift
@@ -36,16 +36,12 @@ final class HomeViewModel: ObservableObject {
         lastPageService: any LastPageService,
         textRetriever: QuranTextDataService,
         readingBookmarkService: MobileSyncReadingBookmarkService,
-        navigateToPage: @escaping (Page, LastPage?, AyahNumber?) -> Void,
-        navigateToSura: @escaping (Sura) -> Void,
-        navigateToQuarter: @escaping (Quarter) -> Void
+        navigateToQuran: @escaping (AyahNumber, LastPage?) -> Void
     ) {
         self.lastPageService = lastPageService
         self.textRetriever = textRetriever
         self.readingBookmarkService = readingBookmarkService
-        self.navigateToPage = navigateToPage
-        self.navigateToSura = navigateToSura
-        self.navigateToQuarter = navigateToQuarter
+        self.navigateToQuran = navigateToQuran
 
         HomePreferences.shared.$surahSortOrder
             .assign(to: &$surahSortOrder)
@@ -54,15 +50,11 @@ final class HomeViewModel: ObservableObject {
     init(
         lastPageService: any LastPageService,
         textRetriever: QuranTextDataService,
-        navigateToPage: @escaping (Page, LastPage?, AyahNumber?) -> Void,
-        navigateToSura: @escaping (Sura) -> Void,
-        navigateToQuarter: @escaping (Quarter) -> Void
+        navigateToQuran: @escaping (AyahNumber, LastPage?) -> Void
     ) {
         self.lastPageService = lastPageService
         self.textRetriever = textRetriever
-        self.navigateToPage = navigateToPage
-        self.navigateToSura = navigateToSura
-        self.navigateToQuarter = navigateToQuarter
+        self.navigateToQuran = navigateToQuran
 
         HomePreferences.shared.$surahSortOrder
             .assign(to: &$surahSortOrder)
@@ -113,26 +105,26 @@ final class HomeViewModel: ObservableObject {
     }
 
     func navigateTo(_ lastPage: LastPage) {
-        navigateToPage(lastPage.page, lastPage, nil)
+        navigateToQuran(lastPage.page.firstVerse, lastPage)
     }
 
     #if QURAN_SYNC
     func navigateTo(_ readingBookmark: ReadingPositionBookmark) {
         switch readingBookmark.location {
         case .ayah(let ayahNumber):
-            navigateToPage(ayahNumber.page, nil, ayahNumber)
+            navigateToQuran(ayahNumber, nil)
         case .page(let page):
-            navigateToPage(page, nil, nil)
+            navigateToQuran(page.firstVerse, nil)
         }
     }
     #endif
 
     func navigateTo(_ sura: Sura) {
-        navigateToSura(sura)
+        navigateToQuran(sura.firstVerse, nil)
     }
 
     func navigateTo(_ item: QuarterItem) {
-        navigateToQuarter(item.quarter)
+        navigateToQuran(item.quarter.firstVerse, nil)
     }
 
     func toggleSurahSortOrder() {
@@ -146,9 +138,7 @@ final class HomeViewModel: ObservableObject {
     #if QURAN_SYNC
     private let readingBookmarkService: MobileSyncReadingBookmarkService
     #endif
-    private let navigateToPage: (Page, LastPage?, AyahNumber?) -> Void
-    private let navigateToSura: (Sura) -> Void
-    private let navigateToQuarter: (Quarter) -> Void
+    private let navigateToQuran: (AyahNumber, LastPage?) -> Void
     private let readingPreferences = ReadingPreferences.shared
 
     private func loadLastPages() async {

--- a/Features/NotesFeature/Sources/NotesBuilder.swift
+++ b/Features/NotesFeature/Sources/NotesBuilder.swift
@@ -42,7 +42,7 @@ public struct NotesBuilder {
             textService: textService,
             textRetriever: textRetriever,
             navigateTo: { [weak listener] verse in
-                listener?.navigateTo(page: verse.page, lastPage: nil, highlightingSearchAyah: nil)
+                listener?.navigateTo(ayah: verse, lastPage: nil)
             },
             editNote: editNote
         )
@@ -53,7 +53,7 @@ public struct NotesBuilder {
             textRetriever: textRetriever,
             textService: textService,
             navigateTo: { [weak listener] verse in
-                listener?.navigateTo(page: verse.page, lastPage: nil, highlightingSearchAyah: nil)
+                listener?.navigateTo(ayah: verse, lastPage: nil)
             },
             editNote: editNote
         )

--- a/Features/NotesFeature/Tests/NotesViewModelTests.swift
+++ b/Features/NotesFeature/Tests/NotesViewModelTests.swift
@@ -120,6 +120,37 @@ final class NotesViewModelTests: XCTestCase {
         XCTAssertTrue(text.hasSuffix("Al-Fātihah, Ayah 1"))
     }
 
+    func test_navigateToNote_navigatesToStartAyah() throws {
+        let startAyah = try XCTUnwrap(AyahNumber(quran: .hafsMadani1405, sura: 2, ayah: 255))
+        let endAyah = try XCTUnwrap(startAyah.next)
+        let note = QuranAnnotations.Note(
+            id: "note",
+            text: "Ayat al-Kursi",
+            startAyah: startAyah,
+            endAyah: endAyah,
+            modifiedDate: .distantPast
+        )
+        let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-quran-database")
+        var navigatedAyah: AyahNumber?
+        let sut = NotesViewModel(
+            noteService: noteService,
+            textService: QuranTextDataService(
+                databasesURL: unavailableDatabase,
+                quranFileURL: unavailableDatabase
+            ),
+            textRetriever: ShareableVerseTextRetriever(
+                databasesURL: unavailableDatabase,
+                quranFileURL: unavailableDatabase
+            ),
+            navigateTo: { navigatedAyah = $0 },
+            editNote: { _ in }
+        )
+
+        sut.navigateTo(NoteItem(note: note, quranText: nil))
+
+        XCTAssertEqual(navigatedAyah, startAyah)
+    }
+
     private func storedNotes() async throws -> [QuranAnnotations.Note] {
         var iterator = noteService.notesSequence(quran: .hafsMadani1405).makeAsyncIterator()
         return try await iterator.next() ?? []

--- a/Features/QuranContentFeature/Sources/ContentViewModel.swift
+++ b/Features/QuranContentFeature/Sources/ContentViewModel.swift
@@ -58,7 +58,7 @@ public final class ContentViewModel: ObservableObject {
         self.deps = deps
         self.input = input
 
-        visiblePages = [input.initialAyah.page]
+        visiblePages = [input.initialPage]
 
         highlights = deps.highlightsService.highlights
         twoPagesEnabled = deps.quranContentStatePreferences.twoPagesEnabled
@@ -196,8 +196,8 @@ public final class ContentViewModel: ObservableObject {
     }
 
     private func configureInitialPage() {
-        deps.lastPageUpdater.configure(initialPage: input.initialAyah.page, lastPage: input.lastPage)
-        highlights.navigationVerse = input.initialAyah
+        deps.lastPageUpdater.configure(initialPage: input.initialPage, lastPage: input.lastPage)
+        highlights.navigationVerse = input.navigationAyah
     }
 
     private func visiblePagesUpdated() {

--- a/Features/QuranContentFeature/Sources/ContentViewModel.swift
+++ b/Features/QuranContentFeature/Sources/ContentViewModel.swift
@@ -58,7 +58,7 @@ public final class ContentViewModel: ObservableObject {
         self.deps = deps
         self.input = input
 
-        visiblePages = [input.initialPage]
+        visiblePages = [input.initialAyah.page]
 
         highlights = deps.highlightsService.highlights
         twoPagesEnabled = deps.quranContentStatePreferences.twoPagesEnabled
@@ -196,13 +196,13 @@ public final class ContentViewModel: ObservableObject {
     }
 
     private func configureInitialPage() {
-        deps.lastPageUpdater.configure(initialPage: input.initialPage, lastPage: input.lastPage)
-        highlights.searchVerses = [input.highlightingSearchAyah].compactMap { $0 }
+        deps.lastPageUpdater.configure(initialPage: input.initialAyah.page, lastPage: input.lastPage)
+        highlights.navigationVerse = input.initialAyah
     }
 
     private func visiblePagesUpdated() {
-        // remove search highlight when page changes
-        highlights.searchVerses = []
+        // Remove the navigation highlight when the reader changes pages.
+        highlights.navigationVerse = nil
 
         let pages = visiblePages
         let isTranslationView = deps.quranContentStatePreferences.quranMode == .translation

--- a/Features/QuranContentFeature/Sources/QuranInput.swift
+++ b/Features/QuranContentFeature/Sources/QuranInput.swift
@@ -12,15 +12,13 @@ import QuranKit
 public struct QuranInput {
     // MARK: Lifecycle
 
-    public init(initialPage: Page, lastPage: LastPage?, highlightingSearchAyah: AyahNumber?) {
-        self.initialPage = initialPage
+    public init(initialAyah: AyahNumber, lastPage: LastPage?) {
+        self.initialAyah = initialAyah
         self.lastPage = lastPage
-        self.highlightingSearchAyah = highlightingSearchAyah
     }
 
     // MARK: Public
 
-    public let initialPage: Page
+    public let initialAyah: AyahNumber
     public let lastPage: LastPage?
-    public let highlightingSearchAyah: AyahNumber?
 }

--- a/Features/QuranContentFeature/Sources/QuranInput.swift
+++ b/Features/QuranContentFeature/Sources/QuranInput.swift
@@ -12,13 +12,15 @@ import QuranKit
 public struct QuranInput {
     // MARK: Lifecycle
 
-    public init(initialAyah: AyahNumber, lastPage: LastPage?) {
-        self.initialAyah = initialAyah
+    public init(initialPage: Page, lastPage: LastPage?, navigationAyah: AyahNumber?) {
+        self.initialPage = initialPage
         self.lastPage = lastPage
+        self.navigationAyah = navigationAyah
     }
 
     // MARK: Public
 
-    public let initialAyah: AyahNumber
+    public let initialPage: Page
     public let lastPage: LastPage?
+    public let navigationAyah: AyahNumber?
 }

--- a/Features/SearchFeature/Sources/SearchBuilder.swift
+++ b/Features/SearchFeature/Sources/SearchBuilder.swift
@@ -31,7 +31,7 @@ public struct SearchBuilder {
                 quranFileURL: container.quranUthmaniV2Database
             ),
             navigateTo: { [weak listener] verse in
-                listener?.navigateTo(page: verse.page, lastPage: nil, highlightingSearchAyah: verse)
+                listener?.navigateTo(ayah: verse, lastPage: nil)
             }
         )
         let viewController = SearchViewController(viewModel: viewModel)

--- a/Model/QuranAnnotations/Sources/QuranHighlights.swift
+++ b/Model/QuranAnnotations/Sources/QuranHighlights.swift
@@ -16,7 +16,7 @@ public struct QuranHighlights: Equatable {
 
     public var readingVerses: [AyahNumber] = []
     public var shareVerses: [AyahNumber] = []
-    public var searchVerses: [AyahNumber] = []
+    public var navigationVerse: AyahNumber?
     #if QURAN_SYNC
     public var highlightVerses: [AyahNumber: HighlightColor] = [:]
     #else
@@ -28,11 +28,10 @@ public struct QuranHighlights: Equatable {
 
 extension QuranHighlights {
     public func needsScrolling(comparingTo oldValue: Self) -> Bool {
-        // Check readingHighlights & searchHighlights
         if oldValue.readingVerses != readingVerses {
             return true
         }
-        if oldValue.searchVerses != searchVerses {
+        if oldValue.navigationVerse != navigationVerse {
             return true
         }
         return false
@@ -42,7 +41,7 @@ extension QuranHighlights {
         if let firstReadingVerse = readingVerses.first {
             return firstReadingVerse
         }
-        return searchVerses.first
+        return navigationVerse
     }
 
     public func verseToScrollTo(comparingTo oldValue: Self) -> AyahNumber? {

--- a/UI/NoorUI/Sources/Theme/QuranHighlights+Theme.swift
+++ b/UI/NoorUI/Sources/Theme/QuranHighlights+Theme.swift
@@ -31,11 +31,11 @@ extension QuranHighlights {
 
     static let readingColor = UIColor.appIdentity.withAlphaComponent(opacity)
     static let shareColor = UIColor.systemBlue.withAlphaComponent(opacity)
-    static let searchColor = UIColor.systemGray.withAlphaComponent(opacity)
+    static let navigationColor = UIColor.systemGray.withAlphaComponent(opacity)
 
     // TODO: Use Color
     public func versesByHighlights() -> [AyahNumber: UIColor] {
-        // Sort order: share, reading, search, .note
+        // Sort order: share, reading, navigation, .note
         var versesByHighlights: [AyahNumber: UIColor] = [:]
 
         #if QURAN_SYNC
@@ -54,7 +54,9 @@ extension QuranHighlights {
             }
         }
 
-        add(verses: searchVerses, color: Self.searchColor)
+        if let navigationVerse {
+            versesByHighlights[navigationVerse] = Self.navigationColor
+        }
         add(verses: readingVerses, color: Self.readingColor)
         add(verses: shareVerses, color: Self.shareColor)
         return versesByHighlights


### PR DESCRIPTION
## Summary

- replace the search-specific `highlightingSearchAyah` name with `navigationVerse`
- distinguish page navigation from exact ayah navigation in `QuranNavigator`
- apply a transient reader highlight only for exact ayah destinations
- clear the navigation highlight after the reader changes pages
- add regression coverage for page bookmarks, reading bookmarks, collection entries, and notes

## Navigation behavior

| Feature | NO SYNC | SYNC |
| --- | --- | --- |
| Home → last read | Page | Page |
| Home → sura | Ayah | Ayah |
| Home → juz / quarter | Ayah | Ayah |
| Home → reading bookmark (`.page`) | N/A | Page |
| Home → reading bookmark (`.ayah`) | N/A | Ayah |
| Bookmarks → legacy page bookmark | Page | N/A |
| Bookmarks → reading bookmark (`.page`) | N/A | Page |
| Bookmarks → reading bookmark (`.ayah`) | N/A | Ayah |
| Bookmarks → Old Page Bookmarks collection | N/A | Ayah |
| Bookmarks → Favorites collection | N/A | Ayah |
| Bookmarks → custom collection | N/A | Ayah |
| Bookmarks → colored highlight collection | N/A | Ayah |
| Notes | Ayah | Ayah |
| Search | Ayah | Ayah |

`Ayah` opens the containing page and transiently highlights the destination ayah. `Page` opens the page without a transient navigation highlight.

## Why

The previous input name coupled navigation highlighting to search, while several non-search features also navigate to an exact ayah. At the same time, page-based destinations should preserve page semantics instead of manufacturing an ayah target.

The new API makes the route intent explicit: feature call sites choose either `navigateTo(page:lastPage:)` or `navigateTo(ayah:lastPage:)`, and the reader receives an optional `navigationAyah` only for the latter.

## Validation

- `make format-lint`
- `make test-no-sync`
- `make test-sync PACKAGE_DESTINATION='id=<fresh iPhone 17 simulator>'`
- `make build-example-no-sync`
- `make build-example-sync`
