### PR TITLE
test: stabilize asynchronous CI tests

### DIFF
--- a/Core/Utilities/Tests/AsyncPublisherTests.swift
+++ b/Core/Utilities/Tests/AsyncPublisherTests.swift
@@ -35,8 +35,9 @@ class AsyncPublisherTests: XCTestCase {
         let prefix = 2
         let asyncPublisher = subject.values(bufferingPolicy: .unbounded)
 
-        Task {
-            for await number in asyncPublisher {
+        Task { [iterator = asyncPublisher.makeAsyncIterator()] in
+            var iterator = iterator
+            while let number = await iterator.next() {
                 await values.append(number)
                 if await values.results.count == prefix {
                     break
@@ -44,9 +45,6 @@ class AsyncPublisherTests: XCTestCase {
             }
             await channel.send(())
         }
-
-        // Wait until loop starts.
-        await Task.megaYield()
 
         for number in numbers {
             subject.send(number)
@@ -60,26 +58,25 @@ class AsyncPublisherTests: XCTestCase {
 
     func test_passThroughSubject_taskCancellation() async {
         let asyncPublisher = subject.values(bufferingPolicy: .unbounded)
+        let received = AsyncChannel<Int>()
 
-        let task = Task {
-            for await number in asyncPublisher {
+        let task = Task { [iterator = asyncPublisher.makeAsyncIterator()] in
+            var iterator = iterator
+            while let number = await iterator.next() {
                 await values.append(number)
+                await received.send(number)
             }
             await values.append(1945)
+            await channel.send(())
         }
-
-        // Wait until loop starts.
-        await Task.megaYield()
 
         for number in numbers {
             subject.send(number)
-            await Task.megaYield()
+            await AsyncAssertEqual(await received.next(), number)
         }
 
-        // Cancel the task.
         task.cancel()
-        // Wait for cancellation to happen.
-        await Task.megaYield()
+        await channel.next()
 
         await AsyncAssertEqual(await values.results, numbers + [1945])
     }

--- a/Core/Utilities/Tests/AsyncThrowingPublisherTests.swift
+++ b/Core/Utilities/Tests/AsyncThrowingPublisherTests.swift
@@ -44,9 +44,10 @@ class AsyncThrowingPublisherTests: XCTestCase {
     func test_passThroughSubject_failure() async {
         let asyncPublisher = subject.values()
 
-        Task {
+        Task { [iterator = asyncPublisher.makeAsyncIterator()] in
+            var iterator = iterator
             do {
-                for try await number in asyncPublisher {
+                while let number = try await iterator.next() {
                     await values.append(number)
                 }
             } catch {
@@ -54,9 +55,6 @@ class AsyncThrowingPublisherTests: XCTestCase {
             }
             await channel.send(())
         }
-
-        // Wait until loop starts.
-        await Task.megaYield()
 
         // Send failure
         subject.send(completion: .failure(.invalid))
@@ -71,18 +69,20 @@ class AsyncThrowingPublisherTests: XCTestCase {
         let prefix = 2
         let asyncPublisher = subject.values(bufferingPolicy: .unbounded)
 
-        Task {
-            for try await number in asyncPublisher {
-                await values.append(number)
-                if await values.results.count == prefix {
-                    break
+        Task { [iterator = asyncPublisher.makeAsyncIterator()] in
+            var iterator = iterator
+            do {
+                while let number = try await iterator.next() {
+                    await values.append(number)
+                    if await values.results.count == prefix {
+                        break
+                    }
                 }
+            } catch {
+                XCTFail("Unexpected error: \(error)")
             }
             await channel.send(())
         }
-
-        // Wait until loop starts.
-        await Task.megaYield()
 
         for number in numbers {
             subject.send(number)
@@ -96,26 +96,29 @@ class AsyncThrowingPublisherTests: XCTestCase {
 
     func test_passThroughSubject_taskCancellation() async {
         let asyncPublisher = subject.values(bufferingPolicy: .unbounded)
+        let received = AsyncChannel<Int>()
 
-        let task = Task {
-            for try await number in asyncPublisher {
-                await values.append(number)
+        let task = Task { [iterator = asyncPublisher.makeAsyncIterator()] in
+            var iterator = iterator
+            do {
+                while let number = try await iterator.next() {
+                    await values.append(number)
+                    await received.send(number)
+                }
+            } catch {
+                XCTFail("Unexpected error: \(error)")
             }
             await values.append(1945)
+            await channel.send(())
         }
-
-        // Wait until loop starts.
-        await Task.megaYield()
 
         for number in numbers {
             subject.send(number)
-            await Task.megaYield()
+            await AsyncAssertEqual(await received.next(), number)
         }
 
-        // Cancel the task.
         task.cancel()
-        // Wait for cancellation to happen.
-        await Task.megaYield()
+        await channel.next()
 
         await AsyncAssertEqual(await values.results, numbers + [1945])
     }

--- a/Data/SQLitePersistence/Tests/DatabaseConnectionTests.swift
+++ b/Data/SQLitePersistence/Tests/DatabaseConnectionTests.swift
@@ -43,51 +43,55 @@ class DatabaseConnectionTests: XCTestCase {
     }
 
     func test_readPublisher() async throws {
-        // Since we can't guarantee a defined sequence of intermediate states, the test
-        // here attempts to perform a series of changes in a way that would eventually
-        // deliver a specifc set of values.
-        // Adding some latency is key, as it allows SQLite to commit changes to the desk.
         let connection = DatabaseConnection(url: testURL, readonly: false)
         try await connection.createNamesTable()
         let publisher = try connection.namesPublisher()
+        var cancellable: AnyCancellable?
+        let values = AsyncThrowingStream<[String], Error> { continuation in
+            cancellable = publisher.sink(
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        continuation.finish()
+                    case .failure(let error):
+                        continuation.finish(throwing: error)
+                    }
+                },
+                receiveValue: { continuation.yield($0) }
+            )
+        }
+        defer { cancellable?.cancel() }
+        var iterator = values.makeAsyncIterator()
 
-        var assertExpectation: XCTestExpectation?
-        var expectedNames: [String]?
-        let cancellable = publisher.sink(
-            receiveCompletion: { _ in },
-            receiveValue: { names in
-                guard let expected = expectedNames else { return }
+        try await assertNextNames([], from: &iterator)
 
-                if Set(expected) == Set(names) {
-                    assertExpectation?.fulfill()
-                    assertExpectation = nil
-                    expectedNames = nil
-                }
-            }
-        )
-
-        expectedNames = ["Alice"]
-        let expectation1 = expectation(description: "Expected to deliver the first batch of inserted names")
-        assertExpectation = expectation1
         try await connection.insert(name: "Alice")
-        await fulfillment(of: [expectation1], timeout: 2)
+        try await assertNextNames(["Alice"], from: &iterator)
 
-        // Add more
-        expectedNames = ["Alice", "Bob", "Derek"]
-        let expectation2 = expectation(description: "Expected to deliver the second batch of names")
-        assertExpectation = expectation2
         try await connection.insert(name: "Bob")
         try await connection.insert(name: "Derek")
-        await fulfillment(of: [expectation2], timeout: 2)
+        try await assertNextNames(["Alice", "Bob", "Derek"], from: &iterator)
 
-        // Remove one
-        expectedNames = ["Alice", "Derek"]
-        let expectation3 = expectation(description: "Expected to deliver the third batch of names")
-        assertExpectation = expectation3
         try await connection.remove(name: "Bob")
-        await fulfillment(of: [expectation3], timeout: 2)
+        try await assertNextNames(["Alice", "Derek"], from: &iterator)
+    }
 
-        cancellable.cancel()
+    private func assertNextNames(
+        _ expectedNames: [String],
+        from iterator: inout AsyncThrowingStream<[String], Error>.Iterator,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        while let names = try await iterator.next() {
+            if Set(expectedNames) == Set(names) {
+                return
+            }
+        }
+        XCTFail(
+            "Publisher completed before delivering \(expectedNames)",
+            file: file,
+            line: line
+        )
     }
 
     func test_sharing() async throws {

--- a/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
+++ b/Domain/AnnotationsService/Tests/LastPageUpdaterTests.swift
@@ -14,7 +14,7 @@ final class LastPageUpdaterTests: XCTestCase {
 
         sut.configure(initialPage: quran.pages[0], lastPage: nil)
 
-        await waitUntil { service.addPages == [self.quran.pages[0]] }
+        await service.waitForNextAdd()
         XCTAssertEqual(service.addPages, [quran.pages[0]])
         XCTAssertEqual(service.updateCallCount, 0)
     }
@@ -27,7 +27,7 @@ final class LastPageUpdaterTests: XCTestCase {
 
         sut.configure(initialPage: quran.pages[1], lastPage: lastPage)
 
-        await waitUntil { service.updateCalls.first?.page == self.quran.pages[0] }
+        await service.waitForNextUpdate()
         XCTAssertEqual(service.updateCalls.first?.page, quran.pages[0])
         XCTAssertEqual(service.updateCalls.first?.toPage, quran.pages[1])
         XCTAssertEqual(service.addCallCount, 0)
@@ -38,16 +38,18 @@ final class LastPageUpdaterTests: XCTestCase {
         let sut = LastPageUpdater(service: service)
 
         sut.configure(initialPage: quran.pages[0], lastPage: nil)
-        await waitUntil { service.addPages == [self.quran.pages[0]] }
+        await service.waitForNextAdd()
         sut.updateTo(pages: [quran.pages[1]])
 
         service.completeNextAdd()
-        await waitUntil { service.updateCalls.count == 1 }
+        await service.waitForNextAddCompletion()
+        await service.waitForNextUpdate()
         let updateCalls = service.updateCalls
         XCTAssertEqual(updateCalls.first?.page, quran.pages[0])
         XCTAssertEqual(updateCalls.first?.toPage, quran.pages[1])
         service.completeNextUpdate()
-        await waitUntil { sut.lastPage?.page == self.quran.pages[1] }
+        await service.waitForNextUpdateCompletion()
+        XCTAssertEqual(sut.lastPage?.page, quran.pages[1])
         assertIdentity(sut.lastPage, syncID: "created-last-page", noSyncPage: quran.pages[1])
     }
 
@@ -57,19 +59,21 @@ final class LastPageUpdaterTests: XCTestCase {
         let lastPage = makeLastPage(page: quran.pages[0])
 
         sut.configure(initialPage: quran.pages[1], lastPage: lastPage)
-        await waitUntil { service.updateCalls.count == 1 }
+        await service.waitForNextUpdate()
         sut.updateTo(pages: [quran.pages[2]])
         sut.updateTo(pages: [quran.pages[3]])
         let callsWhileFirstUpdateIsPending = service.updateCalls
         XCTAssertEqual(callsWhileFirstUpdateIsPending.count, 1)
 
         service.completeNextUpdate()
-        await waitUntil { service.updateCalls.count == 2 }
+        await service.waitForNextUpdateCompletion()
+        await service.waitForNextUpdate()
         let updateCalls = service.updateCalls
         XCTAssertEqual(updateCalls[1].page, quran.pages[1])
         XCTAssertEqual(updateCalls[1].toPage, quran.pages[3])
         service.completeNextUpdate()
-        await waitUntil { sut.lastPage?.page == self.quran.pages[3] }
+        await service.waitForNextUpdateCompletion()
+        XCTAssertEqual(sut.lastPage?.page, quran.pages[3])
         assertIdentity(sut.lastPage, syncID: "last-page", noSyncPage: quran.pages[3])
     }
 
@@ -79,15 +83,13 @@ final class LastPageUpdaterTests: XCTestCase {
         let lastPage = makeLastPage(page: quran.pages[0])
 
         sut.configure(initialPage: quran.pages[1], lastPage: lastPage)
-        await waitUntil { service.updateCalls.count == 1 }
+        await service.waitForNextUpdate()
         sut.updateTo(pages: [quran.pages[2]])
         sut.updateTo(pages: [quran.pages[1]])
 
         service.completeNextUpdate()
-        await waitUntil { sut.lastPage?.page == self.quran.pages[1] }
-        for _ in 0 ..< 10 {
-            await Task.yield()
-        }
+        await service.waitForNextUpdateCompletion()
+        XCTAssertEqual(sut.lastPage?.page, quran.pages[1])
         let updateCalls = service.updateCalls
         XCTAssertEqual(updateCalls.count, 1)
     }
@@ -100,7 +102,7 @@ final class LastPageUpdaterTests: XCTestCase {
         sut.configure(initialPage: quran.pages[0], lastPage: lastPage)
         sut.updateTo(pages: [quran.pages[0]])
 
-        await waitUntil { service.updateCalls.count == 1 }
+        await service.waitForNextUpdate()
         let updateCalls = service.updateCalls
         XCTAssertEqual(updateCalls.first?.page, quran.pages[0])
         XCTAssertEqual(updateCalls.first?.toPage, quran.pages[0])
@@ -112,17 +114,19 @@ final class LastPageUpdaterTests: XCTestCase {
         let lastPage = makeLastPage(page: quran.pages[0])
 
         sut.configure(initialPage: quran.pages[1], lastPage: lastPage)
-        await waitUntil { service.updateCalls.count == 1 }
+        await service.waitForNextUpdate()
         sut.updateTo(pages: [quran.pages[0]])
 
         service.completeNextUpdate()
-        await waitUntil { service.updateCalls.count == 2 }
+        await service.waitForNextUpdateCompletion()
+        await service.waitForNextUpdate()
         let updateCalls = service.updateCalls
         XCTAssertEqual(updateCalls[1].page, quran.pages[1])
         XCTAssertEqual(updateCalls[1].toPage, quran.pages[0])
 
         service.completeNextUpdate()
-        await waitUntil { sut.lastPage?.page == self.quran.pages[0] }
+        await service.waitForNextUpdateCompletion()
+        XCTAssertEqual(sut.lastPage?.page, quran.pages[0])
     }
 
     func test_reconfigure_discardsInFlightResultBeforeStartingNewWrite() async {
@@ -130,20 +134,22 @@ final class LastPageUpdaterTests: XCTestCase {
         let sut = LastPageUpdater(service: service)
 
         sut.configure(initialPage: quran.pages[1], lastPage: makeLastPage(page: quran.pages[0], id: "old-session"))
-        await waitUntil { service.updateCalls.count == 1 }
+        await service.waitForNextUpdate()
         sut.configure(initialPage: quran.pages[11], lastPage: makeLastPage(page: quran.pages[10], id: "new-session"))
         let callsWhileFirstUpdateIsPending = service.updateCalls
         XCTAssertEqual(callsWhileFirstUpdateIsPending.count, 1)
 
         service.completeNextUpdate()
-        await waitUntil { service.updateCalls.count == 2 }
+        await service.waitForNextUpdateCompletion()
+        await service.waitForNextUpdate()
         let updateCalls = service.updateCalls
         XCTAssertEqual(updateCalls[1].page, quran.pages[10])
         XCTAssertEqual(updateCalls[1].toPage, quran.pages[11])
         XCTAssertEqual(sut.lastPage?.page, quran.pages[10])
         assertIdentity(sut.lastPage, syncID: "new-session", noSyncPage: quran.pages[10])
         service.completeNextUpdate()
-        await waitUntil { sut.lastPage?.page == self.quran.pages[11] }
+        await service.waitForNextUpdateCompletion()
+        XCTAssertEqual(sut.lastPage?.page, quran.pages[11])
         assertIdentity(sut.lastPage, syncID: "new-session", noSyncPage: quran.pages[11])
     }
 
@@ -155,32 +161,18 @@ final class LastPageUpdaterTests: XCTestCase {
             let sut = LastPageUpdater(service: service)
             weakSUT = sut
             sut.configure(initialPage: quran.pages[0], lastPage: nil)
-            await waitUntil { service.addPages.count == 1 }
+            await service.waitForNextAdd()
         }
 
-        await waitUntil { weakSUT == nil }
-        await waitUntil { service.cancellationCount == 1 }
+        await service.waitForNextCancellation()
+        XCTAssertNil(weakSUT)
+        XCTAssertEqual(service.cancellationCount, 1)
     }
 
     private let quran = Quran(raw: Madani1405QuranReadingInfoRawData())
 
     private func makeLastPage(page: Page, id: String = "last-page") -> LastPage {
         makeTestLastPage(page: page, syncID: id)
-    }
-
-    private func waitUntil(
-        timeoutIterations: Int = 100,
-        condition: @escaping @MainActor () async -> Bool,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) async {
-        for _ in 0 ..< timeoutIterations {
-            if await condition() {
-                return
-            }
-            await Task.yield()
-        }
-        XCTFail("Condition was not met in time", file: file, line: line)
     }
 }
 
@@ -195,15 +187,41 @@ private final class ControllableLastPageService: LastPageService {
     private(set) var updateCalls: [UpdateCall] = []
     private(set) var cancellationCount = 0
 
+    func waitForNextAdd() async {
+        await addStarted.wait()
+    }
+
+    func waitForNextAddCompletion() async {
+        await addCompleted.wait()
+    }
+
+    func waitForNextUpdate() async {
+        await updateStarted.wait()
+    }
+
+    func waitForNextUpdateCompletion() async {
+        await updateCompleted.wait()
+    }
+
+    func waitForNextCancellation() async {
+        await cancelled.wait()
+    }
+
     func lastPages(quran _: Quran) -> AnyAsyncSequence<[LastPage]> {
         .init(Just<[LastPage]>([]).values)
     }
 
     func add(page: Page) async throws -> LastPage {
         addPages.append(page)
+        defer {
+            Task { @MainActor [addCompleted] in
+                addCompleted.signal()
+            }
+        }
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 pendingAdds.append((page, continuation))
+                addStarted.signal()
             }
         } onCancel: {
             Task { @MainActor in
@@ -214,9 +232,15 @@ private final class ControllableLastPageService: LastPageService {
 
     func update(lastPage: LastPage, toPage: Page) async throws -> LastPage {
         updateCalls.append(UpdateCall(page: lastPage.page, toPage: toPage))
+        defer {
+            Task { @MainActor [updateCompleted] in
+                updateCompleted.signal()
+            }
+        }
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 pendingUpdates.append((lastPage, toPage, continuation))
+                updateStarted.signal()
             }
         } onCancel: {
             Task { @MainActor in
@@ -247,9 +271,15 @@ private final class ControllableLastPageService: LastPageService {
 
     private var pendingAdds: [PendingAdd] = []
     private var pendingUpdates: [PendingUpdate] = []
+    private let addStarted = TestSignal()
+    private let addCompleted = TestSignal()
+    private let updateStarted = TestSignal()
+    private let updateCompleted = TestSignal()
+    private let cancelled = TestSignal()
 
     private func cancelPendingOperation() {
         cancellationCount += 1
+        cancelled.signal()
         if !pendingAdds.isEmpty {
             pendingAdds.removeFirst().continuation.resume(throwing: CancellationError())
         } else if !pendingUpdates.isEmpty {
@@ -270,6 +300,14 @@ private final class LastPageServiceSpy: LastPageService {
     private(set) var addPages: [Page] = []
     private(set) var updateCalls: [UpdateCall] = []
 
+    func waitForNextAdd() async {
+        await addStarted.wait()
+    }
+
+    func waitForNextUpdate() async {
+        await updateStarted.wait()
+    }
+
     func lastPages(quran _: Quran) -> AnyAsyncSequence<[LastPage]> {
         .init(Just<[LastPage]>([]).values)
     }
@@ -277,14 +315,43 @@ private final class LastPageServiceSpy: LastPageService {
     func add(page: Page) async throws -> LastPage {
         addCallCount += 1
         addPages.append(page)
+        addStarted.signal()
         return makeTestLastPage(page: page, syncID: "created-last-page")
     }
 
     func update(lastPage: LastPage, toPage: Page) async throws -> LastPage {
         updateCallCount += 1
         updateCalls.append(UpdateCall(page: lastPage.page, toPage: toPage))
+        updateStarted.signal()
         return updatedLastPage(lastPage, page: toPage)
     }
+
+    private let addStarted = TestSignal()
+    private let updateStarted = TestSignal()
+}
+
+@MainActor
+private final class TestSignal {
+    func signal() {
+        guard !waiters.isEmpty else {
+            bufferedSignals += 1
+            return
+        }
+        waiters.removeFirst().resume()
+    }
+
+    func wait() async {
+        guard bufferedSignals == 0 else {
+            bufferedSignals -= 1
+            return
+        }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    private var bufferedSignals = 0
+    private var waiters: [CheckedContinuation<Void, Never>] = []
 }
 
 private func makeTestLastPage(page: Page, syncID: String) -> LastPage {

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -210,12 +210,25 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         try await service.createCollection(named: oldPageBookmarksCollectionName)
         let sut = makeSUT(collectionService: service)
         let viewController = BookmarkCollectionsViewController(viewModel: sut)
+        var cancellable: AnyCancellable?
+        let collections = AsyncStream<[AyahBookmarkCollection]> { continuation in
+            cancellable = sut.$collections.sink { continuation.yield($0) }
+        }
+        var iterator = collections.makeAsyncIterator()
 
         let task = Task { await sut.start() }
-        await waitUntil { viewController.navigationItem.leftBarButtonItem != nil }
+        defer {
+            task.cancel()
+            cancellable?.cancel()
+        }
+
+        while let collections = await iterator.next() {
+            if !BookmarkCollectionsViewModel.deletableCollections(from: collections).isEmpty {
+                break
+            }
+        }
 
         XCTAssertNotNil(viewController.navigationItem.leftBarButtonItem)
-        task.cancel()
     }
 
     func test_start_setsAuthenticatedState_whenRestoreSucceeds() async {


### PR DESCRIPTION
## What changed

- Subscribe publisher iterators before sending values and synchronize cancellation with explicit acknowledgements.
- Consume SQLite publisher updates through a buffered async stream instead of mutable expectations and fixed timeouts.
- Replace bounded `Task.yield()` polling in `LastPageUpdaterTests` with buffered test signals.
- Observe bookmark collection state directly before asserting the edit button.

## Why

Several asynchronous tests depended on scheduler timing, fixed yield counts, or short expectation timeouts. Under CI load, work could run before subscriptions were ready or after the polling budget expired, producing intermittent failures despite correct production behavior.

These tests now synchronize on the actual state transitions they assert, removing timing sensitivity without changing production code.

## Impact

Test-only changes. CI should no longer intermittently fail in the publisher cancellation, SQLite observation, last-page update, or bookmark collection suites.

## Validation

- `make test-sync`
- `make test-no-sync`
- `make build-example-sync`
- `make build-example-no-sync`
- `make format-lint`