### PR TITLE
fix: use wheel for repeat count selection

### DIFF
--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
@@ -220,13 +220,38 @@ private struct RunsPicker: View {
 
     @Binding var runs: Runs
 
-    @ViewBuilder
+    @State private var isExpanded = false
+
+    @ScaledMetric private var pickerHeight: CGFloat = 150
+    @ScaledMetric private var spacing: CGFloat = 8
+
     var body: some View {
-        if #available(iOS 16.0, *) {
-            picker
-                .pickerStyle(.navigationLink)
-        } else {
-            picker
+        Group {
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: spacing) {
+                    Text(l("audio.repeat-count"))
+                        .foregroundStyle(.primary)
+
+                    Spacer(minLength: spacing)
+
+                    Text(runs.localizedDescription)
+                        .foregroundStyle(isExpanded ? Color.appIdentity : .secondary)
+
+                    Image(systemName: "chevron.down")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(isExpanded ? Color.appIdentity : Color(.tertiaryLabel))
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if isExpanded {
+                picker
+            }
         }
     }
 
@@ -246,6 +271,11 @@ private struct RunsPicker: View {
                     .tag(option)
             }
         }
+        .pickerStyle(.wheel)
+        .labelsHidden()
+        .frame(maxWidth: .infinity)
+        .frame(height: pickerHeight)
+        .clipped()
     }
 }
 

--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
@@ -222,21 +222,12 @@ private struct RunsMenuPicker: View {
     @Binding var runs: Runs
 
     var body: some View {
-        Menu {
-            Button {
-                runs = .indefinite
-            } label: {
-                Label(Runs.indefinite.localizedDescription.capitalized, systemImage: "infinity")
-            }
-
-            Divider()
-
+        Picker(selection: $runs) {
+            Label(Runs.indefinite.localizedDescription.capitalized, systemImage: "infinity")
+                .tag(Runs.indefinite)
             ForEach(1 ... 100, id: \.self) { count in
-                Button {
-                    runs = .finite(count)
-                } label: {
-                    Text(Runs.finite(count).localizedDescription)
-                }
+                Text(Runs.finite(count).localizedDescription)
+                    .tag(Runs.finite(count))
             }
         } label: {
             HStack {
@@ -251,6 +242,7 @@ private struct RunsMenuPicker: View {
             }
             .contentShape(Rectangle())
         }
+        .pickerStyle(.menu)
     }
 }
 

--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
@@ -234,10 +234,10 @@ private struct RunsPicker: View {
 
     private var picker: some View {
         Picker(l("audio.repeat-count"), selection: $runs) {
-            Label(
-                Runs.indefinite.localizedDescription.capitalized,
-                systemImage: "infinity"
-            )
+            HStack {
+                Text(Runs.indefinite.localizedDescription.capitalized)
+                Image(systemName: "infinity")
+            }
             .tag(Runs.indefinite)
 
             ForEach(1 ... 100, id: \.self) { count in

--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
@@ -238,7 +238,7 @@ private struct RunsPicker: View {
 
                     Spacer(minLength: spacing)
 
-                    Text(runs.localizedDescription)
+                    selectedRunsLabel
                         .foregroundStyle(isExpanded ? Color.appIdentity : .secondary)
 
                     Image(systemName: "chevron.down")
@@ -256,6 +256,19 @@ private struct RunsPicker: View {
     }
 
     // MARK: Private
+
+    @ViewBuilder
+    private var selectedRunsLabel: some View {
+        switch runs {
+        case .finite:
+            Text(runs.localizedDescription)
+        case .indefinite:
+            HStack {
+                Text(runs.localizedDescription.capitalized)
+                Image(systemName: "infinity")
+            }
+        }
+    }
 
     private var picker: some View {
         Picker(l("audio.repeat-count"), selection: $runs) {

--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
@@ -222,12 +222,16 @@ private struct RunsMenuPicker: View {
     @Binding var runs: Runs
 
     var body: some View {
-        Picker(selection: $runs) {
-            Label(Runs.indefinite.localizedDescription.capitalized, systemImage: "infinity")
-                .tag(Runs.indefinite)
-            ForEach(1 ... 100, id: \.self) { count in
-                Text(Runs.finite(count).localizedDescription)
-                    .tag(Runs.finite(count))
+        Menu {
+            Picker(selection: $runs) {
+                Label(Runs.indefinite.localizedDescription.capitalized, systemImage: "infinity")
+                    .tag(Runs.indefinite)
+                ForEach(1 ... 100, id: \.self) { count in
+                    Text(Runs.finite(count).localizedDescription)
+                        .tag(Runs.finite(count))
+                }
+            } label: {
+                EmptyView()
             }
         } label: {
             HStack {
@@ -242,7 +246,6 @@ private struct RunsMenuPicker: View {
             }
             .contentShape(Rectangle())
         }
-        .pickerStyle(.menu)
     }
 }
 

--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
@@ -167,7 +167,7 @@ private struct PlayEachVerseSection: View {
 
     var body: some View {
         Section(header: Text(lAndroid("play_each_verse").replacingOccurrences(of: ":", with: ""))) {
-            RunsMenuPicker(runs: $verseRuns)
+            RunsPicker(runs: $verseRuns)
 
             VStack(alignment: .leading, spacing: 10) {
                 Text(l("audio.verse-delay"))
@@ -194,7 +194,7 @@ private struct PlaySetChoicesSection: View {
 
     var body: some View {
         Section(header: Text(lAndroid("play_verses_range").replacingOccurrences(of: ":", with: ""))) {
-            RunsMenuPicker(runs: $listRuns)
+            RunsPicker(runs: $listRuns)
 
             VStack(alignment: .leading, spacing: 10) {
                 Text(l("audio.repetition-delay"))
@@ -215,36 +215,36 @@ private struct PlaySetChoicesSection: View {
     }
 }
 
-/// Keeps repeat counts compact in the form while still exposing every supported count.
-private struct RunsMenuPicker: View {
+private struct RunsPicker: View {
     // MARK: Internal
 
     @Binding var runs: Runs
 
+    @ViewBuilder
     var body: some View {
-        Menu {
-            Picker(selection: $runs) {
-                Label(Runs.indefinite.localizedDescription.capitalized, systemImage: "infinity")
-                    .tag(Runs.indefinite)
-                ForEach(1 ... 100, id: \.self) { count in
-                    Text(Runs.finite(count).localizedDescription)
-                        .tag(Runs.finite(count))
-                }
-            } label: {
-                EmptyView()
+        if #available(iOS 16.0, *) {
+            picker
+                .pickerStyle(.navigationLink)
+        } else {
+            picker
+        }
+    }
+
+    // MARK: Private
+
+    private var picker: some View {
+        Picker(l("audio.repeat-count"), selection: $runs) {
+            Label(
+                Runs.indefinite.localizedDescription.capitalized,
+                systemImage: "infinity"
+            )
+            .tag(Runs.indefinite)
+
+            ForEach(1 ... 100, id: \.self) { count in
+                let option = Runs.finite(count)
+                Text(option.localizedDescription.capitalized)
+                    .tag(option)
             }
-        } label: {
-            HStack {
-                Text(l("audio.repeat-count"))
-                    .foregroundStyle(Color(.label))
-                Spacer()
-                Text(runs.localizedDescription)
-                    .foregroundStyle(.secondary)
-                Image(systemName: "chevron.up.chevron.down")
-                    .font(.footnote.weight(.semibold))
-                    .foregroundStyle(.tertiary)
-            }
-            .contentShape(Rectangle())
         }
     }
 }


### PR DESCRIPTION
## Summary

- replace the long repeat-count selection list with an inline wheel picker
- keep the form row compact until the wheel is expanded
- offer `Loop ∞` followed by precise choices from `1×` through `100×`
- show `Loop ∞` in the collapsed row when loop playback is selected

## Root cause

The original menu did not expose the active selection, while the navigation-style replacement required scanning a list of up to 100 rows. The inline wheel preserves exact selection without leaving Advanced Audio Options.

## User impact

Repeat counts are faster to browse, remain precise, and use the same expandable wheel interaction already established by the ayah range controls.

## Screenshot

<img width="300" alt="Expanded repeat count wheel with Loop selected" src="https://github.com/user-attachments/assets/581190f1-e7ba-4cfe-ab0a-94fcc74991f8" />

## Validation

- `make format-lint`
- `make test-no-sync TARGET=AdvancedAudioOptionsFeature` — 27 tests passed
- `make build-sync TARGET=AdvancedAudioOptionsFeature`
- built and visually verified `QuranEngineApp` on iPhone 17 simulator, including the selected `Loop ∞` state