### PR TITLE
fix: make advanced audio options cancellable

### DIFF
--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsViewModel.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsViewModel.swift
@@ -42,8 +42,6 @@ final class AdvancedAudioOptionsViewModel: ObservableObject {
         repetitionDelay = options.repetitionDelay
         playbackRate = AudioPreferences.shared.playbackRate
         endAt = Self.deduceEndAt(from: options.start, to: normalizedEnd)
-
-        AudioPreferences.shared.$playbackRate.assign(to: &$playbackRate)
     }
 
     // MARK: Internal
@@ -62,6 +60,7 @@ final class AdvancedAudioOptionsViewModel: ObservableObject {
     @Published var verseDelay: VerseDelay
 
     func play() {
+        AudioPreferences.shared.playbackRate = playbackRate
         listener?.updateAudioOptions(to: currentOptions())
         dismiss()
     }
@@ -94,7 +93,7 @@ final class AdvancedAudioOptionsViewModel: ObservableObject {
     // MARK: - Updating Playback Rate
 
     func updatePlaybackRate(to rate: Float) {
-        AudioPreferences.shared.playbackRate = rate
+        playbackRate = rate
     }
 
     // MARK: Private

--- a/Features/AdvancedAudioOptionsFeature/Sources/AyahRangePicker.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AyahRangePicker.swift
@@ -17,7 +17,7 @@ struct AyahRangePicker: View {
     let updateFromVerseTo: ItemAction<AyahNumber>
     let updateToVerseTo: ItemAction<AyahNumber>
 
-    @State private var expandedBoundary: Boundary? = .from
+    @State private var expandedBoundary: Boundary?
 
     var body: some View {
         Group {

--- a/Features/AdvancedAudioOptionsFeature/Tests/AdvancedAudioOptionsViewModelTests.swift
+++ b/Features/AdvancedAudioOptionsFeature/Tests/AdvancedAudioOptionsViewModelTests.swift
@@ -5,6 +5,7 @@
 import Foundation
 import QueuePlayer
 import QuranAudio
+import QuranAudioKit
 import QuranKit
 import ReciterListFeature
 import XCTest
@@ -194,6 +195,32 @@ final class AdvancedAudioOptionsViewModelTests: XCTestCase {
         sut.play()
 
         XCTAssertEqual(listener.updatedOptions?.verseDelay, .threeQuarters)
+    }
+
+    // MARK: - Playback rate
+
+    func test_dismiss_doesNotPersistSelectedPlaybackRate() {
+        let originalRate = AudioPreferences.shared.playbackRate
+        defer { AudioPreferences.shared.playbackRate = originalRate }
+        AudioPreferences.shared.playbackRate = 1
+        let sut = makeSUT(start: quran.firstVerse, end: quran.firstVerse)
+
+        sut.updatePlaybackRate(to: 1.25)
+        sut.dismiss()
+
+        XCTAssertEqual(AudioPreferences.shared.playbackRate, 1)
+    }
+
+    func test_play_persistsSelectedPlaybackRate() {
+        let originalRate = AudioPreferences.shared.playbackRate
+        defer { AudioPreferences.shared.playbackRate = originalRate }
+        AudioPreferences.shared.playbackRate = 1
+        let sut = makeSUT(start: quran.firstVerse, end: quran.firstVerse)
+
+        sut.updatePlaybackRate(to: 1.25)
+        sut.play()
+
+        XCTAssertEqual(AudioPreferences.shared.playbackRate, 1.25)
     }
 
     func test_verseDelaySorted_matchesExpectedOrder() {


### PR DESCRIPTION
## Summary

- open Advanced Audio Options with both ayah-range wheels collapsed
- keep playback-speed changes local until Play commits them
- preserve the saved playback speed when Cancel dismisses the sheet

## Root cause

The From boundary was initialized as expanded, and playback speed was bound directly to `AudioPreferences`, so selecting a rate persisted it before the user committed the form.

## Validation

- `make format-lint`
- `make test-no-sync TARGET=AdvancedAudioOptionsFeature` — 29 tests passed
- `make test-sync TARGET=AdvancedAudioOptionsFeature` — 29 tests passed
- iPhone 17 simulator: verified collapsed range rows and Cancel restoring the previously saved speed

## Screenshot

<img width="300" alt="Advanced Audio Options opening with range wheels collapsed" src="https://github.com/user-attachments/assets/3291c7fc-9842-491d-bef6-8592e62cdae1" />