### PR TITLE
fix: correct app icon announcement copy

### DIFF
--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -282,7 +282,7 @@
 
 // New app icon announcement
 "new.icon_announcement.title" = "A new icon";
-"new.icon_announcement.body" = "In our next update, the Quran app icon on your Home Screen will change. This new icon is now the shared mark of a family of tools built around Allah's word. More to details soon.";
+"new.icon_announcement.body" = "In our next update, the Quran app icon on your Home Screen will change. This new icon is now the shared mark of a family of tools built around Allah's word. More details soon.";
 "new.icon_announcement.now" = "NOW";
 "new.icon_announcement.coming_soon" = "COMING SOON";
 "new.icon_announcement.same_app.title" = "Same app, new icon";


### PR DESCRIPTION
## Summary

- remove the extra “to” from the English app icon announcement
- keep the Arabic copy unchanged because it already correctly says “more details soon”

## Why

The English announcement ended with the grammatical typo “More to details soon.” Users will now see “More details soon.”

## Impact

Copy-only change to the English app icon announcement; no behavior or Arabic text changes.

## Validation

- `plutil -lint` on the English and Arabic localization files
- `make format-lint`
- no-sync and sync package builds succeeded
- `make test-sync TARGET=QuranLocalizationTests` passed (3 tests)
- initially failing no-sync targets passed on isolated reruns; the full all-target plans still expose unrelated shared ZIP/SQLite test-resource collisions