### PR TITLE
feat: categorize Mushaf selector options

### DIFF
--- a/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -201,6 +201,11 @@
 "reading.selector.selectMushaf.short" = "اختر";
 "reading.selector.selectMushaf.long" = "اختر هذا المصحف";
 "reading.selector.title" = "اختر المصحف";
+"reading.selector.group.uthmani" = "العثماني";
+"reading.selector.group.tajweed" = "التجويد";
+"reading.selector.group.naskh" = "النسخ";
+"reading.selector.badge.experimental" = "تجريبي";
+"reading.selector.badge.large-screen-optimized" = "مهيأ للشاشات الأكبر";
 "reading.selector.selection-description" = "اضغط على المصحف للمزيد من المعلومات.";
 "reading.selector.property.hafs" = "مصحف حفص عن عاصم";
 "reading.selector.property.pages.604" = "٦٠٤ صفحة";

--- a/Core/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -225,6 +225,11 @@
 "reading.selector.selectMushaf.long" = "Als aktuellen Mushaf festlegen";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.title" = "Mushaf auswählen";
+"reading.selector.group.uthmani" = "Uthmani";
+"reading.selector.group.tajweed" = "Tajweed";
+"reading.selector.group.naskh" = "Naskh";
+"reading.selector.badge.experimental" = "Experimentell";
+"reading.selector.badge.large-screen-optimized" = "Für größere Bildschirme optimiert";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.selection-description" = "Tippen Sie auf einen Mushaf für mehr Informationen.";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -222,6 +222,11 @@
 "reading.selector.selectMushaf.short" = "Select";
 "reading.selector.selectMushaf.long" = "Set as current Mushaf";
 "reading.selector.title" = "Choose Mushaf";
+"reading.selector.group.uthmani" = "Uthmani";
+"reading.selector.group.tajweed" = "Tajweed";
+"reading.selector.group.naskh" = "Naskh";
+"reading.selector.badge.experimental" = "Experimental";
+"reading.selector.badge.large-screen-optimized" = "Large-screen optimized";
 "reading.selector.selection-description" = "Tap on a Mushaf for more information.";
 "reading.selector.property.hafs" = "Hafs Mushaf";
 "reading.selector.property.pages.604" = "604 pages";

--- a/Core/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -225,6 +225,11 @@
 "reading.selector.selectMushaf.long" = "Establecer como Mushaf actual";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.title" = "Elegir Mushaf";
+"reading.selector.group.uthmani" = "Uthmani";
+"reading.selector.group.tajweed" = "Tajweed";
+"reading.selector.group.naskh" = "Naskh";
+"reading.selector.badge.experimental" = "Experimental";
+"reading.selector.badge.large-screen-optimized" = "Optimizado para pantallas más grandes";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.selection-description" = "Toca un Mushaf para obtener más información.";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -227,6 +227,11 @@
 "reading.selector.selectMushaf.long" = "تنظیم به عنوان مشاف فعلی";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.title" = "انتخاب مشاف";
+"reading.selector.group.uthmani" = "عثمانی";
+"reading.selector.group.tajweed" = "تجوید";
+"reading.selector.group.naskh" = "نسخ";
+"reading.selector.badge.experimental" = "آزمایشی";
+"reading.selector.badge.large-screen-optimized" = "بهینه‌شده برای صفحه‌نمایش‌های بزرگ‌تر";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.selection-description" = "برای اطلاعات بیشتر روی مشاف ضربه بزنید.";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -225,6 +225,11 @@
 "reading.selector.selectMushaf.long" = "Définir comme Mushaf actuel";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.title" = "Choisir le Mushaf";
+"reading.selector.group.uthmani" = "Uthmani";
+"reading.selector.group.tajweed" = "Tajwid";
+"reading.selector.group.naskh" = "Naskh";
+"reading.selector.badge.experimental" = "Expérimental";
+"reading.selector.badge.large-screen-optimized" = "Optimisé pour les écrans plus grands";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.selection-description" = "Touchez un Mushaf pour plus d'informations.";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/kk.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/kk.lproj/Localizable.strings
@@ -209,6 +209,11 @@
 "reading.selector.selectMushaf.long" = "Ағымдағы Мусхаф ретінде орнату";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.title" = "Мусхафты таңдау";
+"reading.selector.group.uthmani" = "Османи";
+"reading.selector.group.tajweed" = "Тәжуид";
+"reading.selector.group.naskh" = "Насх";
+"reading.selector.badge.experimental" = "Эксперименттік";
+"reading.selector.badge.large-screen-optimized" = "Үлкен экрандарға бейімделген";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.selection-description" = "Көбірек ақпарат алу үшін Мусхафқа түртіңіз.";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -208,6 +208,11 @@
 "reading.selector.selectMushaf.long" = "Tetapkan sebagai Mushaf semasa";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.title" = "Pilih Mushaf";
+"reading.selector.group.uthmani" = "Uthmani";
+"reading.selector.group.tajweed" = "Tajwid";
+"reading.selector.group.naskh" = "Naskh";
+"reading.selector.badge.experimental" = "Eksperimen";
+"reading.selector.badge.large-screen-optimized" = "Dioptimumkan untuk skrin yang lebih besar";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.selection-description" = "Ketik pada Mushaf untuk maklumat lanjut.";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -153,6 +153,11 @@
 "reading.selector.selectMushaf.short" = "Selecteer";
 "reading.selector.selectMushaf.long" = "Stel in als huidige Mushaf";
 "reading.selector.title" = "Kies Musaf";
+"reading.selector.group.uthmani" = "Uthmani";
+"reading.selector.group.tajweed" = "Tajweed";
+"reading.selector.group.naskh" = "Naskh";
+"reading.selector.badge.experimental" = "Experimenteel";
+"reading.selector.badge.large-screen-optimized" = "Geoptimaliseerd voor grotere schermen";
 "reading.selector.selection-description" = "Tik op een Mushaf voor meer informatie.";
 "reading.selector.property.hafs" = "Hafs Mushaf";
 "reading.selector.property.pages.604" = "604 pagina's";

--- a/Core/Localization/Sources/Resources/pt.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/pt.lproj/Localizable.strings
@@ -226,6 +226,11 @@
 "reading.selector.selectMushaf.long" = "Definir como Mushaf atual";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.title" = "Escolher Mushaf";
+"reading.selector.group.uthmani" = "Uthmani";
+"reading.selector.group.tajweed" = "Tajwid";
+"reading.selector.group.naskh" = "Naskh";
+"reading.selector.badge.experimental" = "Experimental";
+"reading.selector.badge.large-screen-optimized" = "Otimizado para telas maiores";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.selection-description" = "Toque em um Mushaf para mais informações.";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -225,6 +225,11 @@
 "reading.selector.selectMushaf.long" = "Установить как текущий Мусхаф";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.title" = "Выбрать Мусхаф";
+"reading.selector.group.uthmani" = "Усмани";
+"reading.selector.group.tajweed" = "Таджвид";
+"reading.selector.group.naskh" = "Насх";
+"reading.selector.badge.experimental" = "Экспериментальный";
+"reading.selector.badge.large-screen-optimized" = "Оптимизирован для больших экранов";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.selection-description" = "Нажмите на Мусхаф для получения дополнительной информации.";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -169,6 +169,11 @@
 "reading.selector.selectMushaf.long" = "Mevcut Mushaf olarak ayarla";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.title" = "Mushaf Seç";
+"reading.selector.group.uthmani" = "Osmanî";
+"reading.selector.group.tajweed" = "Tecvid";
+"reading.selector.group.naskh" = "Nesih";
+"reading.selector.badge.experimental" = "Deneysel";
+"reading.selector.badge.large-screen-optimized" = "Daha büyük ekranlar için optimize edildi";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.selection-description" = "Daha fazla bilgi için bir Mushaf'a dokunun.";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ug.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ug.lproj/Localizable.strings
@@ -228,6 +228,11 @@
 "reading.selector.selectMushaf.long" = "نۆۋەتتىكى مۇشاف قىلىپ بەلگىلەش";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.title" = "مۇشاف تاللاش";
+"reading.selector.group.uthmani" = "ئوسمانى";
+"reading.selector.group.tajweed" = "تەجۋىد";
+"reading.selector.group.naskh" = "نەسخ";
+"reading.selector.badge.experimental" = "تەجرىبە";
+"reading.selector.badge.large-screen-optimized" = "چوڭ ئېكرانلارغا ماسلاشتۇرۇلغان";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.selection-description" = "تېخىمۇ كۆپ ئۇچۇرلار ئۈچۈن مۇشافنى تەكشۈرۈڭ.";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/uz.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/uz.lproj/Localizable.strings
@@ -227,6 +227,11 @@
 "reading.selector.selectMushaf.long" = "Joriy Mushaf sifatida belgilash";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.title" = "Mushaf tanlash";
+"reading.selector.group.uthmani" = "Usmoniy";
+"reading.selector.group.tajweed" = "Tajvid";
+"reading.selector.group.naskh" = "Nasx";
+"reading.selector.badge.experimental" = "Tajribaviy";
+"reading.selector.badge.large-screen-optimized" = "Kattaroq ekranlar uchun moslashtirilgan";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.selection-description" = "Ko'proq ma'lumot olish uchun Mushafni bosing.";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -153,6 +153,11 @@
 "reading.selector.selectMushaf.short" = "Chọn";
 "reading.selector.selectMushaf.long" = "Đặt làm Mushaf hiện tại";
 "reading.selector.title" = "Chọn Mushaf";
+"reading.selector.group.uthmani" = "Uthmani";
+"reading.selector.group.tajweed" = "Tajweed";
+"reading.selector.group.naskh" = "Naskh";
+"reading.selector.badge.experimental" = "Thử nghiệm";
+"reading.selector.badge.large-screen-optimized" = "Tối ưu cho màn hình lớn hơn";
 "reading.selector.selection-description" = "Chạm vào Mushaf để biết thêm thông tin.";
 "reading.selector.property.hafs" = "Hafs Mushaf";
 "reading.selector.property.pages.604" = "604 trang";

--- a/Core/Localization/Sources/Resources/zh.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/zh.lproj/Localizable.strings
@@ -226,6 +226,11 @@
 "reading.selector.selectMushaf.long" = "设为当前Mushaf";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.title" = "选择Mushaf";
+"reading.selector.group.uthmani" = "奥斯曼体";
+"reading.selector.group.tajweed" = "泰吉威德";
+"reading.selector.group.naskh" = "纳斯赫体";
+"reading.selector.badge.experimental" = "实验性";
+"reading.selector.badge.large-screen-optimized" = "针对更大屏幕优化";
 // Metadata: Translated by ChatGPT; human review required.
 "reading.selector.selection-description" = "点击Mushaf获取更多信息。";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Features/ReadingSelectorFeature/Sources/ReadingSelectorViewModel.swift
+++ b/Features/ReadingSelectorFeature/Sources/ReadingSelectorViewModel.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Localization
 import QuranKit
 import ReadingService
 
@@ -24,8 +25,30 @@ class ReadingSelectorViewModel: ObservableObject {
     @Published var progress: Double?
     @Published var error: Error?
 
-    var readings: [ReadingInfo<Reading>] {
-        Reading.allReadings.map { ReadingInfo($0) }
+    var readingGroups: [ReadingGroup<Reading>] {
+        [
+            ReadingGroup(
+                id: "uthmani",
+                title: l("reading.selector.group.uthmani"),
+                readings: [
+                    .hafs_1405,
+                    .hafs_1441,
+                    .hafs_1440,
+                    .hafs_1439,
+                    .hafs_1421,
+                ].map(ReadingInfo.init)
+            ),
+            ReadingGroup(
+                id: "tajweed",
+                title: l("reading.selector.group.tajweed"),
+                readings: [Reading.tajweed].map(ReadingInfo.init)
+            ),
+            ReadingGroup(
+                id: "naskh",
+                title: l("reading.selector.group.naskh"),
+                readings: [Reading.naskh].map(ReadingInfo.init)
+            ),
+        ]
     }
 
     func start() async {
@@ -72,11 +95,27 @@ class ReadingSelectorViewModel: ObservableObject {
 
 private extension ReadingInfo where Value == Reading {
     init(_ reading: Reading) {
+        let badge: ReadingBadge? = switch reading {
+        case .hafs_1441, .hafs_1439:
+            ReadingBadge(
+                title: l("reading.selector.badge.large-screen-optimized"),
+                style: .informational
+            )
+        case .naskh:
+            ReadingBadge(
+                title: l("reading.selector.badge.experimental"),
+                style: .experimental
+            )
+        default:
+            nil
+        }
+
         self.init(
             value: reading,
             title: reading.title,
             description: reading.description,
-            properties: reading.properties
+            properties: reading.properties,
+            badge: badge
         )
     }
 }

--- a/Features/ReadingSelectorFeature/Sources/View/ReadingInfo.swift
+++ b/Features/ReadingSelectorFeature/Sources/View/ReadingInfo.swift
@@ -8,6 +8,16 @@
 import Localization
 import QuranKit
 
+struct ReadingBadge: Hashable {
+    enum Style: Hashable {
+        case informational
+        case experimental
+    }
+
+    let title: String
+    let style: Style
+}
+
 struct ReadingInfo<Value: Hashable>: Hashable, Identifiable {
     // MARK: Internal
 
@@ -15,8 +25,15 @@ struct ReadingInfo<Value: Hashable>: Hashable, Identifiable {
     let title: String
     let description: String
     let properties: [Reading.Property]
+    let badge: ReadingBadge?
 
     var id: Value { value }
+}
+
+struct ReadingGroup<Value: Hashable>: Identifiable {
+    let id: String
+    let title: String
+    let readings: [ReadingInfo<Value>]
 }
 
 // Test data
@@ -37,8 +54,19 @@ enum ReadingInfoTestData {
                     .init(type: .supports, property: "Property 1"),
                     .init(type: .supports, property: "Property 2"),
                     .init(type: .lacks, property: "Property 3"),
-                ]
+                ],
+                badge: $0 == .e
+                    ? ReadingBadge(title: "Experimental", style: .experimental)
+                    : nil
             )
         }
+    }
+
+    static var groups: [ReadingGroup<Reading>] {
+        [
+            ReadingGroup(id: "a", title: "Uthmani", readings: Array(readings.prefix(3))),
+            ReadingGroup(id: "b", title: "Tajweed", readings: [readings[3]]),
+            ReadingGroup(id: "c", title: "Naskh", readings: [readings[4]]),
+        ]
     }
 }

--- a/Features/ReadingSelectorFeature/Sources/View/ReadingItem.swift
+++ b/Features/ReadingSelectorFeature/Sources/View/ReadingItem.swift
@@ -19,6 +19,7 @@ struct ReadingItem<Value: Hashable, ImageView: View>: View {
     let action: () -> Void
 
     @ScaledMetric var cornerRadius = Dimensions.cornerRadius
+    @ScaledMetric private var badgeDotSize = 6
 
     var body: some View {
         Button(action: action) {
@@ -28,6 +29,9 @@ struct ReadingItem<Value: Hashable, ImageView: View>: View {
                         VStack(alignment: .leading) {
                             if let progress {
                                 ProgressView(value: progress, total: 1)
+                            }
+                            if let badge = reading.badge {
+                                badgeView(badge)
                             }
                             titleView
                             descriptionView
@@ -59,6 +63,40 @@ struct ReadingItem<Value: Hashable, ImageView: View>: View {
     private var descriptionView: some View {
         Text(reading.description)
             .font(.footnote)
+    }
+
+    private func badgeView(_ badge: ReadingBadge) -> some View {
+        HStack(spacing: 6) {
+            Circle()
+                .frame(width: badgeDotSize, height: badgeDotSize)
+
+            Text(badge.title)
+                .font(.caption2.bold())
+                .textCase(.uppercase)
+        }
+        .foregroundColor(badgeForegroundColor(badge.style))
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(badgeBackgroundColor(badge.style)))
+        .padding(.bottom, 4)
+    }
+
+    private func badgeForegroundColor(_ style: ReadingBadge.Style) -> Color {
+        switch style {
+        case .informational:
+            return .appIdentity
+        case .experimental:
+            return .red
+        }
+    }
+
+    private func badgeBackgroundColor(_ style: ReadingBadge.Style) -> Color {
+        switch style {
+        case .informational:
+            return Color.appIdentity.opacity(0.1)
+        case .experimental:
+            return Color.red.opacity(0.1)
+        }
     }
 
     private var backgroundRectangle: some InsettableShape {

--- a/Features/ReadingSelectorFeature/Sources/View/ReadingSelector.swift
+++ b/Features/ReadingSelectorFeature/Sources/View/ReadingSelector.swift
@@ -5,6 +5,7 @@
 //  Created by Mohamed Afifi on 2023-02-12.
 //
 
+import Localization
 import NoorUI
 import QuranKit
 import SwiftUI
@@ -20,7 +21,7 @@ struct ReadingSelector: View {
             error: $viewModel.error,
             progress: viewModel.progress,
             selectedValue: viewModel.selectedReading,
-            readings: viewModel.readings,
+            groups: viewModel.readingGroups,
             imageView: imageView,
             selectItem: { viewModel.showReading($0) },
             start: { await viewModel.start() },
@@ -52,26 +53,43 @@ private struct ReadingSelectorUI<Value: Hashable, ImageView: View>: View {
 
     let progress: Double?
     let selectedValue: Value?
-    let readings: [ReadingInfo<Value>]
+    let groups: [ReadingGroup<Value>]
     let imageView: (ReadingInfo<Value>) -> ImageView
     let selectItem: (Value) -> Void
     let start: AsyncAction
     let retry: AsyncAction
 
     var body: some View {
-        ScrollView {
-            VStack {
-                ForEach(readings) { reading in
-                    let selected = selectedValue == reading.value
-                    ReadingItem(
-                        reading: reading,
-                        imageView: imageView(reading),
-                        selected: selected,
-                        progress: selected ? progress : nil
-                    ) {
-                        readingInfoDetails = reading
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack {
+                    Color.clear
+                        .frame(height: 0)
+                        .id(ReadingSelectorScrollPosition.top)
+
+                    SegmentedChoicesPicker(
+                        title: l("reading.selector.title"),
+                        items: groups.map(\.id),
+                        selection: $selectedGroupID,
+                        label: groupTitle
+                    )
+                    .padding()
+
+                    ForEach(selectedReadings) { reading in
+                        let selected = selectedValue == reading.value
+                        ReadingItem(
+                            reading: reading,
+                            imageView: imageView(reading),
+                            selected: selected,
+                            progress: selected ? progress : nil
+                        ) {
+                            readingInfoDetails = reading
+                        }
                     }
                 }
+            }
+            .onChange(of: selectedGroupID) { _ in
+                proxy.scrollTo(ReadingSelectorScrollPosition.top, anchor: .top)
             }
         }
         .sheet(item: $readingInfoDetails) { reading in
@@ -90,12 +108,58 @@ private struct ReadingSelectorUI<Value: Hashable, ImageView: View>: View {
                 .edgesIgnoringSafeArea(.all)
         )
         .task { await start() }
+        .onChange(of: selectedValue) { selectedValue in
+            guard
+                let selectedValue,
+                let group = groups.first(where: { group in
+                    group.readings.contains(where: { $0.value == selectedValue })
+                })
+            else { return }
+            selectedGroupID = group.id
+        }
         .errorAlert(error: $error, retry: retry)
     }
 
     // MARK: Private
 
     @State private var readingInfoDetails: ReadingInfo<Value>?
+    @State private var selectedGroupID: String
+
+    private var selectedReadings: [ReadingInfo<Value>] {
+        groups.first(where: { $0.id == selectedGroupID })?.readings ?? []
+    }
+
+    init(
+        error: Binding<Error?>,
+        progress: Double?,
+        selectedValue: Value?,
+        groups: [ReadingGroup<Value>],
+        imageView: @escaping (ReadingInfo<Value>) -> ImageView,
+        selectItem: @escaping (Value) -> Void,
+        start: @escaping AsyncAction,
+        retry: @escaping AsyncAction
+    ) {
+        _error = error
+        self.progress = progress
+        self.selectedValue = selectedValue
+        self.groups = groups
+        self.imageView = imageView
+        self.selectItem = selectItem
+        self.start = start
+        self.retry = retry
+        let selectedGroup = groups.first { group in
+            group.readings.contains(where: { $0.value == selectedValue })
+        }
+        _selectedGroupID = State(initialValue: selectedGroup?.id ?? groups.first?.id ?? "")
+    }
+
+    private func groupTitle(_ id: String) -> String {
+        groups.first(where: { $0.id == id })?.title ?? ""
+    }
+}
+
+private enum ReadingSelectorScrollPosition {
+    case top
 }
 
 struct ReadingSelector_Previews: PreviewProvider {
@@ -111,7 +175,7 @@ struct ReadingSelector_Previews: PreviewProvider {
                     error: $error,
                     progress: 0.3,
                     selectedValue: selectedValue,
-                    readings: ReadingInfoTestData.readings,
+                    groups: ReadingInfoTestData.groups,
                     imageView: imageView,
                     selectItem: { selectedValue = $0 },
                     start: { },


### PR DESCRIPTION
## Summary

- split the Mushaf selector into localized Uthmani, Tajweed, and Naskh segments
- preserve the requested Uthmani order: 1405, 1441, 1440, 1439, 1421
- add localized large-screen optimized badges to 1441 and 1439
- add a localized experimental badge to Naskh
- style badges with semantic accent/red dots and light tinted backgrounds
- reset the list scroll position when switching segments

## User impact

Mushaf choices are easier to scan by script type, and variants with special display characteristics are called out directly on their cards.

## Validation

- `make format-lint`
- `make build-no-sync TARGET=ReadingSelectorFeature`
- `make test-no-sync TARGET=LocalizationTests`
- `make test-sync TARGET=LocalizationTests`
- built and visually verified in the iPhone 17 Simulator

## Screenshots

<p>
  <img src="https://github.com/user-attachments/assets/458c65e1-5890-41db-ac0c-a613149dd5b2" alt="Large-screen optimized Mushaf badge" width="300">
  <img src="https://github.com/user-attachments/assets/59f7f9a6-b9a5-4a8d-961e-246ede444bb6" alt="Experimental Naskh badge" width="300">
</p>
