### PR TITLE
Replace WhatsNewKit with native What’s New UI

### DIFF
--- a/Features/WhatsNewFeature/Sources/AppIconAnnouncementView.swift
+++ b/Features/WhatsNewFeature/Sources/AppIconAnnouncementView.swift
@@ -23,8 +23,6 @@ struct AppIconAnnouncementView: View {
     @ScaledMetric(relativeTo: .body) private var comparisonSpacing = 12.0
     @ScaledMetric(relativeTo: .body) private var contentSpacing = 28.0
     @ScaledMetric(relativeTo: .body) private var detailRowVerticalPadding = 12.0
-    @ScaledMetric(relativeTo: .headline) private var headerBottomPadding = 4.0
-    @ScaledMetric(relativeTo: .headline) private var headerTopPadding = 20.0
     @ScaledMetric(relativeTo: .title) private var iconCornerRadius = 22.0
     @ScaledMetric(relativeTo: .caption) private var iconLabelSpacing = 10.0
     @ScaledMetric(relativeTo: .title) private var iconLength = 100.0
@@ -39,8 +37,6 @@ struct AppIconAnnouncementView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            whatsNewTitle
-
             ScrollView(showsIndicators: false) {
                 VStack(spacing: contentSpacing) {
                     introduction
@@ -56,15 +52,6 @@ struct AppIconAnnouncementView: View {
         }
         .background(Color(.systemGroupedBackground).ignoresSafeArea())
         .tint(.newAppIconTint)
-    }
-
-    private var whatsNewTitle: some View {
-        Text(l("new.title"))
-            .font(.headline)
-            .multilineTextAlignment(.center)
-            .foregroundStyle(.secondary)
-            .padding(.top, headerTopPadding)
-            .padding(.bottom, headerBottomPadding)
     }
 
     private var introduction: some View {

--- a/Features/WhatsNewFeature/Sources/AppWhatsNew.swift
+++ b/Features/WhatsNewFeature/Sources/AppWhatsNew.swift
@@ -7,8 +7,6 @@
 //
 
 import Localization
-import UIKit
-import WhatsNewKit
 
 struct AppWhatsNew: Decodable {
     let versions: [WhatsNewVersion]
@@ -26,14 +24,17 @@ struct WhatsNewItem: Decodable {
     let subtitle: String
     let image: String
 
-    var whatsNewItem: WhatsNew.Item {
-        let image: UIImage?
-        image = UIImage.symbol(self.image, withConfiguration: UIImage.SymbolConfiguration(weight: .light))
-        return .init(
-            title: l(title),
-            subtitle: subtitleText,
-            image: image ?? UIColor.clear.image()
-        )
+    var localizedTitle: String {
+        l(title)
+    }
+
+    var localizedDetails: [String] {
+        subtitleText
+            .components(separatedBy: .newlines)
+            .map { detail in
+                detail.hasPrefix("* ") ? String(detail.dropFirst(2)) : detail
+            }
+            .filter { !$0.isEmpty }
     }
 
     // MARK: Private

--- a/Features/WhatsNewFeature/Sources/AppWhatsNewController.swift
+++ b/Features/WhatsNewFeature/Sources/AppWhatsNewController.swift
@@ -12,7 +12,6 @@ import NoorUI
 import SwiftUI
 import UIKit
 import VLogging
-import WhatsNewKit
 
 @MainActor
 public class AppWhatsNewController {
@@ -51,56 +50,45 @@ public class AppWhatsNewController {
         let view = AppIconAnnouncementView { [weak self, weak navigationController] in
             guard let self, let navigationController else { return }
 
-            guard let whatsNewViewController = makeWhatsNewViewController(versions: versions) else {
-                navigationController.dismiss(animated: true)
-                return
-            }
+            let whatsNewViewController = makeWhatsNewViewController(
+                versions: versions,
+                navigationController: navigationController
+            )
 
             analytics.presentWhatsNew(versions: versions.map(\.version))
             navigationController.pushViewController(whatsNewViewController, animated: true)
         }
         let announcementViewController = UIHostingController(rootView: view)
+        announcementViewController.navigationItem.title = l("new.title")
+        announcementViewController.navigationItem.largeTitleDisplayMode = .never
 
         navigationController.setViewControllers([announcementViewController], animated: false)
-        navigationController.setNavigationBarHidden(true, animated: false)
         navigationController.modalPresentationStyle = .pageSheet
         navigationController.sheetPresentationController?.detents = [.large()]
 
         parent.present(navigationController, animated: true)
     }
 
-    private func makeWhatsNewViewController(versions: [WhatsNewVersion]) -> WhatsNewViewController? {
-        let whatsNewItems = versions.flatMap(\.items).map(\.whatsNewItem)
+    private func makeWhatsNewViewController(
+        versions: [WhatsNewVersion],
+        navigationController: UINavigationController
+    ) -> UIViewController {
+        let latestVersion = versions
+            .map(\.version)
+            .max { lhs, rhs in
+                lhs.compare(rhs, options: .numeric) == .orderedAscending
+            }
 
-        let whatsNew = WhatsNew(
-            title: l("new.title"),
-            items: whatsNewItems
+        let view = AppWhatsNewView(
+            items: versions.flatMap(\.items),
+            onContinue: { [weak navigationController] in
+                navigationController?.dismiss(animated: true)
+                logger.info("WhatsNew continue button tapped")
+            }
         )
-
-        // custom whats new configuration
-        var configuration = WhatsNewViewController.Configuration()
-
-        configuration.completionButton.title = l("new.action")
-        configuration.completionButton.action = .custom { vc in
-            (vc.navigationController ?? vc).dismiss(animated: true)
-            logger.info("WhatsNew continue button tapped")
-        }
-        configuration.titleView.titleMode = .scrolls
-
-        configuration.tintColor = .appIdentity
-        configuration.backgroundColor = .systemBackground
-        configuration.titleView.titleColor = .label
-        configuration.itemsView.titleColor = .label
-        configuration.itemsView.subtitleColor = .secondaryLabel
-        configuration.itemsView.titleFont = .preferredFont(forTextStyle: .headline)
-        configuration.itemsView.subtitleFont = .preferredFont(forTextStyle: .callout)
-        configuration.itemsView.imageSize = .fixed(height: 30)
-
-        return WhatsNewViewController(
-            whatsNew: whatsNew,
-            configuration: configuration,
-            versionStore: store
-        )
+        let viewController = AppWhatsNewViewController(rootView: view)
+        store.lastSeenVersion = latestVersion
+        return viewController
     }
 
     private nonisolated func whatsNewItems(after lastSeen: String?, whatsNew: AppWhatsNew) -> [WhatsNewVersion] {

--- a/Features/WhatsNewFeature/Sources/AppWhatsNewVersionStore.swift
+++ b/Features/WhatsNewFeature/Sources/AppWhatsNewVersionStore.swift
@@ -7,24 +7,10 @@
 //
 
 import Preferences
-import WhatsNewKit
 
-/// The InMemoryWhatsNewVersionStore
-final class AppWhatsNewVersionStore: WhatsNewVersionStore {
-    // MARK: Public
-
-    func has(version: WhatsNew.Version) -> Bool {
-        false
-    }
-
-    // MARK: Internal
-
+final class AppWhatsNewVersionStore {
     @Preference(whatsNewVersion)
     var lastSeenVersion: String?
-
-    func set(version: WhatsNew.Version) {
-        lastSeenVersion = version.description
-    }
 
     // MARK: Private
 

--- a/Features/WhatsNewFeature/Sources/AppWhatsNewView.swift
+++ b/Features/WhatsNewFeature/Sources/AppWhatsNewView.swift
@@ -1,0 +1,166 @@
+//
+//  AppWhatsNewView.swift
+//  Quran
+//
+
+import Localization
+import SwiftUI
+import UIKit
+
+@MainActor
+struct AppWhatsNewView: View {
+    @ScaledMetric(relativeTo: .body) private var actionBottomPadding = 20.0
+    @ScaledMetric(relativeTo: .body) private var actionCornerRadius = 14.0
+    @ScaledMetric(relativeTo: .body) private var actionHorizontalPadding = 23.5
+    @ScaledMetric(relativeTo: .body) private var actionTopPadding = 5.0
+    @ScaledMetric(relativeTo: .body) private var actionVerticalPadding = 14.0
+    @ScaledMetric(relativeTo: .body) private var cardCornerRadius = 22.0
+    @ScaledMetric(relativeTo: .body) private var cardSpacing = 18.0
+    @ScaledMetric(relativeTo: .body) private var detailSpacing = 12.0
+    @ScaledMetric(relativeTo: .body) private var headerSpacing = 14.0
+    @ScaledMetric(relativeTo: .body) private var iconCornerRadius = 14.0
+    @ScaledMetric(relativeTo: .body) private var iconLength = 48.0
+
+    let items: [WhatsNewItem]
+    let onContinue: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: cardSpacing) {
+                ForEach(items.indices, id: \.self) { index in
+                    AppWhatsNewCard(
+                        item: items[index],
+                        cardCornerRadius: cardCornerRadius,
+                        detailSpacing: detailSpacing,
+                        headerSpacing: headerSpacing,
+                        iconCornerRadius: iconCornerRadius,
+                        iconLength: iconLength
+                    )
+                }
+            }
+            .frame(maxWidth: 560)
+            .padding()
+            .frame(maxWidth: .infinity)
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            action
+        }
+        .background(Color(.systemGroupedBackground).ignoresSafeArea())
+    }
+
+    private var action: some View {
+        Button(action: onContinue) {
+            Text(l("new.action"))
+                .font(.headline)
+                .foregroundStyle(Color(.systemBackground))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, actionVerticalPadding)
+                .background(Color.accentColor)
+                .clipShape(RoundedRectangle(cornerRadius: actionCornerRadius, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .padding(.top, actionTopPadding)
+        .padding(.horizontal, actionHorizontalPadding)
+        .padding(.bottom, actionBottomPadding)
+        .background(Color(.systemGroupedBackground))
+    }
+}
+
+@MainActor
+private struct AppWhatsNewCard: View {
+    let item: WhatsNewItem
+    let cardCornerRadius: CGFloat
+    let detailSpacing: CGFloat
+    let headerSpacing: CGFloat
+    let iconCornerRadius: CGFloat
+    let iconLength: CGFloat
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: headerSpacing) {
+            HStack(spacing: headerSpacing) {
+                Image(systemName: item.image)
+                    .font(.title3.weight(.medium))
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: iconLength, height: iconLength)
+                    .background(Color.accentColor.opacity(0.12))
+                    .clipShape(RoundedRectangle(cornerRadius: iconCornerRadius, style: .continuous))
+                    .accessibilityHidden(true)
+
+                Text(item.localizedTitle)
+                    .font(.title3.bold())
+                    .foregroundStyle(.primary)
+            }
+
+            VStack(alignment: .leading, spacing: detailSpacing) {
+                ForEach(item.localizedDetails.indices, id: \.self) { index in
+                    detail(item.localizedDetails[index])
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous))
+        .accessibilityElement(children: .combine)
+    }
+
+    private func detail(_ text: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: detailSpacing) {
+            Text("•")
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            Text(text)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+@MainActor
+final class AppWhatsNewViewController: UIHostingController<AppWhatsNewView> {
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        configureNavigationTitle()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        configureNavigationTitle()
+    }
+
+    private func configureNavigationTitle() {
+        navigationItem.titleView = navigationTitleLabel
+        navigationItem.largeTitleDisplayMode = .never
+    }
+
+    private lazy var navigationTitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = l("new.title")
+        label.font = .preferredFont(forTextStyle: .headline)
+        label.adjustsFontForContentSizeCategory = true
+        label.textColor = .label
+        label.textAlignment = .center
+        label.accessibilityTraits = .header
+        return label
+    }()
+}
+
+#Preview {
+    AppWhatsNewView(
+        items: [
+            WhatsNewItem(
+                title: "new.audio_upgrades",
+                subtitle: "new.audio_upgrades.details",
+                image: "speedometer"
+            ),
+            WhatsNewItem(
+                title: "new.personalization",
+                subtitle: "new.personalization.details",
+                image: "paintpalette.fill"
+            ),
+        ],
+        onContinue: {}
+    )
+}

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ WITH_QURAN_SYNC=set -o pipefail; env QURAN_SYNC=QURAN_SYNC
 WITHOUT_QURAN_SYNC_DERIVED_DATA=$(DERIVED_DATA_DIR)/no-sync
 WITH_QURAN_SYNC_DERIVED_DATA=$(DERIVED_DATA_DIR)/sync
 WITH_QURAN_SYNC_APP_SWIFT_FLAGS='OTHER_SWIFT_FLAGS=$$(inherited) -D QURAN_SYNC'
+WHATS_NEW_LAUNCH_ARGUMENTS=-whats-new.seen-version 0
 comma := ,
 simulator-os = $(lastword $(subst $(comma), ,$(1)))
 simulator-name = $(subst $(comma)$(call simulator-os,$(1)),,$(1))
@@ -45,13 +46,16 @@ define run-example-app
 	open -a Simulator --args -CurrentDeviceUDID "$$simulator"; \
 	xcrun simctl bootstatus "$$simulator" -b; \
 	xcrun simctl install "$$simulator" "$(2)/Build/Products/Debug-iphonesimulator/$(EXAMPLE_SCHEME).app"; \
-	xcrun simctl launch "$$simulator" "$(EXAMPLE_BUNDLE_IDENTIFIER)"
+	if [ -n "$(strip $(3))" ]; then \
+		xcrun simctl terminate "$$simulator" "$(EXAMPLE_BUNDLE_IDENTIFIER)" >/dev/null 2>&1 || true; \
+	fi; \
+	xcrun simctl launch "$$simulator" "$(EXAMPLE_BUNDLE_IDENTIFIER)" $(3)
 endef
 
 .PHONY: test-no-sync test-sync
 .PHONY: build-no-sync build-sync
 .PHONY: build-example-no-sync build-example-sync
-.PHONY: run-example-no-sync run-example-sync
+.PHONY: run-example-no-sync run-example-sync run-example-no-sync-whats-new run-example-sync-whats-new
 .PHONY: clone-swiftformat build-swiftformat force-build-swiftformat clean-swiftformat format-lint format-autocorrect lint-no-kotlin-interop
 .PHONY: install-swiftlint build-for-analyzer swiftlint-analyzer
 
@@ -75,12 +79,20 @@ build-example-sync:
 
 run-example-no-sync: EXAMPLE_DESTINATION = $(call simulator-destination,$(EXAMPLE_NO_SYNC_SIMULATOR))
 run-example-sync: EXAMPLE_DESTINATION = $(call simulator-destination,$(EXAMPLE_SYNC_SIMULATOR))
+run-example-no-sync-whats-new: EXAMPLE_DESTINATION = $(call simulator-destination,$(EXAMPLE_NO_SYNC_SIMULATOR))
+run-example-sync-whats-new: EXAMPLE_DESTINATION = $(call simulator-destination,$(EXAMPLE_SYNC_SIMULATOR))
 
 run-example-no-sync: build-example-no-sync
 	$(call run-example-app,$(EXAMPLE_NO_SYNC_SIMULATOR),$(WITHOUT_QURAN_SYNC_DERIVED_DATA))
 
 run-example-sync: build-example-sync
 	$(call run-example-app,$(EXAMPLE_SYNC_SIMULATOR),$(WITH_QURAN_SYNC_DERIVED_DATA))
+
+run-example-no-sync-whats-new: build-example-no-sync
+	$(call run-example-app,$(EXAMPLE_NO_SYNC_SIMULATOR),$(WITHOUT_QURAN_SYNC_DERIVED_DATA),$(WHATS_NEW_LAUNCH_ARGUMENTS))
+
+run-example-sync-whats-new: build-example-sync
+	$(call run-example-app,$(EXAMPLE_SYNC_SIMULATOR),$(WITH_QURAN_SYNC_DERIVED_DATA),$(WHATS_NEW_LAUNCH_ARGUMENTS))
 
 clone-swiftformat:
 	@mkdir -p $(BUILD_TOOLS_DIR)

--- a/Package.resolved
+++ b/Package.resolved
@@ -109,15 +109,6 @@
       }
     },
     {
-      "identity" : "whatsnewkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SvenTiigi/WhatsNewKit.git",
-      "state" : {
-        "revision" : "92a9d6f5f6754aba0df972514fd7686f1de03bcc",
-        "version" : "1.3.7"
-      }
-    },
-    {
       "identity" : "xctest-dynamic-overlay",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",

--- a/Package.swift
+++ b/Package.swift
@@ -63,7 +63,6 @@ let package = Package(
 
         // UI
         .package(url: "https://github.com/GenericDataSource/GenericDataSource", from: "3.1.3"),
-        .package(url: "https://github.com/SvenTiigi/WhatsNewKit", from: "1.3.7"),
         .package(url: "https://github.com/mohamede1945/Popover", branch: "master"),
 
         // Testing
@@ -582,7 +581,6 @@ private func featuresTargets() -> [[Target]] {
         ]),
 
         target(type, name: "WhatsNewFeature", hasTests: false, dependencies: [
-            "WhatsNewKit",
             "NoorUI",
             "Analytics",
         ], resources: [


### PR DESCRIPTION
## Summary

- replace WhatsNewKit with an app-owned SwiftUI release-notes experience
- keep the icon announcement’s branded tint while using the app accent color for release-note cards and actions
- persist and compare seen versions directly through app preferences
- add sync and no-sync Make targets that force-show What’s New without clearing simulator data

## Why

The existing integration used WhatsNewKit for presentation, but its version check always returned false, so the framework’s suppression behavior was bypassed. Owning the UI and version lifecycle removes the dependency and makes the behavior explicit and testable.

## Screenshots

| Icon announcement | Release notes |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/23d6da22-86d6-4606-9fa7-92970c5dd6e4" width="300"> | <img src="https://github.com/user-attachments/assets/c00d5049-aed7-4234-95ba-15c4208e1de8" width="300"> |

## Validation

- `make format-lint`
- `make build-no-sync TARGET=WhatsNewFeature`
- `make build-sync TARGET=WhatsNewFeature`
- `make test-no-sync`
- `make test-sync`
- `make run-example-no-sync-whats-new`
- simulator QA on iOS 26.4