### PR TITLE
feat: refresh settings account card

### DIFF
--- a/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -46,7 +46,7 @@
 "setting.share_app" = "مشاركة التطبيق...";
 "setting.app_version" = "نسخة التطبيق";
 "setting.quran_account.sign_in" = "تسجيل الدخول إلى Quran.com";
-"setting.quran_account.sign_in.subtitle" = "مزامنة الملاحظات والعلامات والمجموعات";
+"setting.quran_account.sign_in.subtitle" = "مزامنة الملاحظات والعلامات المرجعية والمجموعات";
 "setting.quran_account.signed_in" = "تم تسجيل الدخول";
 "setting.quran_account.profile" = "إدارة الحساب";
 "setting.quran_account.sign_out" = "تسجيل الخروج";

--- a/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -45,8 +45,10 @@
 "setting.donate" = "تبرع";
 "setting.share_app" = "مشاركة التطبيق...";
 "setting.app_version" = "نسخة التطبيق";
-"setting.quran_account.sign_in" = "تسجيل الدخول";
-"setting.quran_account.profile" = "ملف Quran.com";
+"setting.quran_account.sign_in" = "تسجيل الدخول إلى Quran.com";
+"setting.quran_account.sign_in.subtitle" = "مزامنة الملاحظات والعلامات والمجموعات";
+"setting.quran_account.signed_in" = "تم تسجيل الدخول";
+"setting.quran_account.profile" = "إدارة الحساب";
 "setting.quran_account.sign_out" = "تسجيل الخروج";
 "setting.quran_account.sync_devices" = "مزامنة العلامات عبر جميع الأجهزة";
 "setting.quran_account.custom_collections" = "إبقاء مجموعاتك المخصصة متزامنة";

--- a/Core/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -518,9 +518,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "Eigene Sammlungen synchron halten";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "Quran.com-Profil";
+"setting.quran_account.profile" = "Konto verwalten";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "Anmelden";
+"setting.quran_account.sign_in" = "Bei Quran.com anmelden";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "Notizen, Lesezeichen und Sammlungen synchronisieren";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "Angemeldet";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "Abmelden";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -52,8 +52,10 @@
 "setting.donate" = "Donate";
 "setting.share_app" = "Share the app...";
 "setting.app_version" = "App Version";
-"setting.quran_account.sign_in" = "Sign in";
-"setting.quran_account.profile" = "Quran.com Profile";
+"setting.quran_account.sign_in" = "Sign in to Quran.com";
+"setting.quran_account.sign_in.subtitle" = "Sync notes, bookmarks and collections";
+"setting.quran_account.signed_in" = "Signed in";
+"setting.quran_account.profile" = "Manage account";
 "setting.quran_account.sign_out" = "Sign out";
 "setting.quran_account.sync_devices" = "Sync your bookmarks across all devices";
 "setting.quran_account.custom_collections" = "Keep your custom collections in sync";

--- a/Core/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -518,9 +518,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "Mantén sincronizadas tus colecciones personalizadas";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "Perfil de Quran.com";
+"setting.quran_account.profile" = "Gestionar cuenta";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "Iniciar sesión";
+"setting.quran_account.sign_in" = "Iniciar sesión en Quran.com";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "Sincroniza notas, marcadores y colecciones";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "Sesión iniciada";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "Cerrar sesión";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -520,9 +520,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "مجموعه‌های سفارشی را همگام نگه دارید";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "نمایهٔ Quran.com";
+"setting.quran_account.profile" = "مدیریت حساب";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "ورود";
+"setting.quran_account.sign_in" = "ورود به Quran.com";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "همگام‌سازی یادداشت‌ها، نشانک‌ها و مجموعه‌ها";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "وارد شده‌اید";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "خروج";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -518,9 +518,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "Synchroniser vos collections personnalisées";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "Profil Quran.com";
+"setting.quran_account.profile" = "Gérer le compte";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "Se connecter";
+"setting.quran_account.sign_in" = "Se connecter à Quran.com";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "Synchronisez vos notes, signets et collections";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "Connecté";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "Se déconnecter";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/kk.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/kk.lproj/Localizable.strings
@@ -502,9 +502,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "Арнаулы жинақтарды синхрондап сақтау";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "Quran.com профилі";
+"setting.quran_account.profile" = "Есептік жазбаны басқару";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "Кіру";
+"setting.quran_account.sign_in" = "Quran.com сайтына кіру";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "Жазбаларды, бетбелгілерді және жинақтарды синхрондау";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "Кірдіңіз";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "Шығу";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -501,9 +501,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "Pastikan koleksi tersuai anda disegerakkan";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "Profil Quran.com";
+"setting.quran_account.profile" = "Urus akaun";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "Log masuk";
+"setting.quran_account.sign_in" = "Log masuk ke Quran.com";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "Segerakkan nota, penanda halaman dan koleksi";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "Telah log masuk";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "Log keluar";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -430,9 +430,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "Je aangepaste verzamelingen synchroniseren";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "Quran.com-profiel";
+"setting.quran_account.profile" = "Account beheren";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "Inloggen";
+"setting.quran_account.sign_in" = "Inloggen bij Quran.com";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "Notities, bladwijzers en verzamelingen synchroniseren";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "Ingelogd";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "Uitloggen";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/pt.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/pt.lproj/Localizable.strings
@@ -519,9 +519,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "Mantenha suas coleções personalizadas sincronizadas";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "Perfil do Quran.com";
+"setting.quran_account.profile" = "Gerenciar conta";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "Entrar";
+"setting.quran_account.sign_in" = "Entrar no Quran.com";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "Sincronize notas, marcadores e coleções";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "Conectado";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "Sair";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -518,9 +518,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "Синхронизировать пользовательские коллекции";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "Профиль Quran.com";
+"setting.quran_account.profile" = "Управление аккаунтом";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "Войти";
+"setting.quran_account.sign_in" = "Войти в Quran.com";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "Синхронизируйте заметки, закладки и коллекции";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "Выполнен вход";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "Выйти";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -460,9 +460,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "Özel koleksiyonlarınızı eşitlenmiş tutun";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "Quran.com profili";
+"setting.quran_account.profile" = "Hesabı yönet";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "Giriş yap";
+"setting.quran_account.sign_in" = "Quran.com'da oturum aç";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "Notları, yer imlerini ve koleksiyonları eşitleyin";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "Oturum açıldı";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "Çıkış yap";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ug.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ug.lproj/Localizable.strings
@@ -521,9 +521,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "ئىختىيارىي توپلاملىرىڭىزنى ماسقەدەم ساقلاڭ";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "Quran.com ئارخىپى";
+"setting.quran_account.profile" = "ھېساباتنى باشقۇرۇش";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "كىرىش";
+"setting.quran_account.sign_in" = "Quran.com غا كىرىش";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "خاتىرە، خەتكۈچ ۋە توپلاملارنى ماسقەدەملەڭ";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "كىردىڭىز";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "چىقىش";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/uz.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/uz.lproj/Localizable.strings
@@ -520,9 +520,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "Maxsus to‘plamlaringizni sinxron saqlang";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "Quran.com profili";
+"setting.quran_account.profile" = "Hisobni boshqarish";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "Kirish";
+"setting.quran_account.sign_in" = "Quran.comʼga kirish";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "Eslatmalar, xatcho‘plar va to‘plamlarni sinxronlang";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "Kirilgan";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "Chiqish";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -427,9 +427,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "Giữ bộ sưu tập tùy chỉnh được đồng bộ";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "Hồ sơ Quran.com";
+"setting.quran_account.profile" = "Quản lý tài khoản";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "Đăng nhập";
+"setting.quran_account.sign_in" = "Đăng nhập Quran.com";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "Đồng bộ ghi chú, dấu trang và bộ sưu tập";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "Đã đăng nhập";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "Đăng xuất";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/zh.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/zh.lproj/Localizable.strings
@@ -519,9 +519,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.custom_collections" = "同步你的自定义收藏集";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.profile" = "Quran.com 个人资料";
+"setting.quran_account.profile" = "管理账户";
 // Metadata: Translated by ChatGPT; human review required.
-"setting.quran_account.sign_in" = "登录";
+"setting.quran_account.sign_in" = "登录 Quran.com";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.sign_in.subtitle" = "同步笔记、书签和收藏集";
+// Metadata: Translated by ChatGPT; human review required.
+"setting.quran_account.signed_in" = "已登录";
 // Metadata: Translated by ChatGPT; human review required.
 "setting.quran_account.sign_out" = "退出登录";
 // Metadata: Translated by ChatGPT; human review required.

--- a/Features/SettingsFeature/Sources/QuranComAccountCard.swift
+++ b/Features/SettingsFeature/Sources/QuranComAccountCard.swift
@@ -162,7 +162,7 @@ struct QuranComAccountCard: View {
     List {
         QuranComAccountCard(
             isAuthenticated: true,
-            email: "mohamede1945@gmail.com",
+            email: "user@example.com",
             manageAccountAction: {},
             signInAction: {},
             signOutAction: {}

--- a/Features/SettingsFeature/Sources/QuranComAccountCard.swift
+++ b/Features/SettingsFeature/Sources/QuranComAccountCard.swift
@@ -1,0 +1,175 @@
+#if QURAN_SYNC
+import Foundation
+import Localization
+import NoorUI
+import SwiftUI
+import UIx
+
+@MainActor
+struct QuranComAccountCard: View {
+    @ScaledMetric private var avatarSize = 48.0
+    @ScaledMetric private var cardCornerRadius = 20.0
+    @ScaledMetric private var cardPadding = 16.0
+    @ScaledMetric private var headerSpacing = 12.0
+    @ScaledMetric private var iconCornerRadius = 14.0
+    @ScaledMetric private var rowVerticalPadding = 14.0
+    @ScaledMetric private var signInVerticalPadding = 12.0
+
+    let isAuthenticated: Bool
+    let email: String?
+    let manageAccountAction: AsyncAction
+    let signInAction: AsyncAction
+    let signOutAction: AsyncAction
+
+    var body: some View {
+        Group {
+            if isAuthenticated {
+                authenticatedContent
+            } else {
+                unauthenticatedContent
+            }
+        }
+        .padding(cardPadding)
+        .background(Color.secondarySystemGroupedBackground)
+        .clipShape(RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous))
+    }
+
+    private var unauthenticatedContent: some View {
+        VStack(spacing: cardPadding) {
+            HStack(alignment: .top, spacing: headerSpacing) {
+                Image(systemName: "arrow.up")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: avatarSize, height: avatarSize)
+                    .background(
+                        Color.accentColor.opacity(0.1),
+                        in: RoundedRectangle(cornerRadius: iconCornerRadius, style: .continuous)
+                    )
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(l("setting.quran_account.sign_in"))
+                        .font(.headline)
+                        .foregroundStyle(Color.label)
+
+                    Text(l("setting.quran_account.sign_in.subtitle"))
+                        .font(.subheadline)
+                        .foregroundStyle(Color.secondaryLabel)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            AsyncButton(action: signInAction) {
+                Text(l("setting.quran_account.sign_in"))
+                    .font(.headline)
+                    .foregroundStyle(Color.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, signInVerticalPadding)
+                    .background(Color.accentColor, in: Capsule())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var authenticatedContent: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: headerSpacing) {
+                Text(accountInitial)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(Color.accentColor)
+                    .frame(width: avatarSize, height: avatarSize)
+                    .background(Color.accentColor.opacity(0.1), in: Circle())
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(l("setting.quran_account.signed_in"))
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(Color.accentColor)
+                        .textCase(.uppercase)
+
+                    Text(email ?? l("setting.quran_account.profile"))
+                        .font(.subheadline)
+                        .foregroundStyle(Color.label)
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(.bottom, cardPadding)
+
+            Divider()
+
+            AsyncButton(action: manageAccountAction) {
+                HStack {
+                    Text(l("setting.quran_account.profile"))
+                        .foregroundStyle(Color.label)
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(Color.tertiaryLabel)
+                        .accessibilityHidden(true)
+                }
+                .frame(maxWidth: .infinity)
+                .contentShape(Rectangle())
+                .padding(.vertical, rowVerticalPadding)
+            }
+            .buttonStyle(.plain)
+
+            Divider()
+
+            AsyncButton(action: signOutAction) {
+                Text(l("setting.quran_account.sign_out"))
+                    .foregroundStyle(Color.red)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .padding(.top, rowVerticalPadding)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var accountInitial: String {
+        guard let firstCharacter = email?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .first
+        else {
+            return "Q"
+        }
+        return String(firstCharacter).uppercased()
+    }
+}
+
+#Preview("Signed out") {
+    List {
+        QuranComAccountCard(
+            isAuthenticated: false,
+            email: nil,
+            manageAccountAction: {},
+            signInAction: {},
+            signOutAction: {}
+        )
+        .listRowInsets(.zero)
+        .listRowBackground(Color.clear)
+    }
+    .listStyle(.insetGrouped)
+}
+
+#Preview("Signed in") {
+    List {
+        QuranComAccountCard(
+            isAuthenticated: true,
+            email: "mohamede1945@gmail.com",
+            manageAccountAction: {},
+            signInAction: {},
+            signOutAction: {}
+        )
+        .listRowInsets(.zero)
+        .listRowBackground(Color.clear)
+    }
+    .listStyle(.insetGrouped)
+}
+#endif

--- a/Features/SettingsFeature/Sources/SettingsRootView.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootView.swift
@@ -88,11 +88,15 @@ private struct SettingsRootViewUI: View {
         NoorList {
             #if QURAN_SYNC
             NoorBasicSection {
-                if isAuthenticated {
-                    authenticatedQuranComSection
-                } else {
-                    unauthenticatedQuranComSection
-                }
+                QuranComAccountCard(
+                    isAuthenticated: isAuthenticated,
+                    email: loggedInUserEmail,
+                    manageAccountAction: { await openQuranComProfile() },
+                    signInAction: { await loginAction() },
+                    signOutAction: { await logoutAction() }
+                )
+                .listRowInsets(.zero)
+                .listRowBackground(Color.clear)
             }
             #endif
 
@@ -195,62 +199,6 @@ private struct SettingsRootViewUI: View {
         #endif
         .errorAlert(error: $error)
     }
-
-    // MARK: Private
-
-    #if QURAN_SYNC
-    private var unauthenticatedQuranComSection: some View {
-        Group {
-            NoorListItem(
-                image: .init(.profile, color: .secondaryLabel),
-                title: styledText(l("setting.quran_account.sign_in"), fontWeight: .semibold),
-                accessory: .disclosureIndicator,
-                action: loginAction
-            )
-
-            NoorListItem(
-                image: .init(.checkmark, color: .accentColor),
-                title: .text(l("setting.quran_account.sync_devices"))
-            )
-
-            NoorListItem(
-                image: .init(.checkmark, color: .accentColor),
-                title: .text(l("setting.quran_account.custom_collections"))
-            )
-
-            NoorListItem(
-                image: .init(.checkmark, color: .accentColor),
-                title: .text(l("setting.quran_account.attach_notes"))
-            )
-        }
-    }
-
-    private var authenticatedQuranComSection: some View {
-        Group {
-            NoorListItem(
-                image: .init(.profile, color: .secondaryLabel),
-                title: .text(loggedInUserEmail ?? l("setting.quran_account.profile")),
-                accessory: .image(.settings, color: .secondaryLabel),
-                action: openQuranComProfile
-            )
-
-            NoorListItem(
-                image: .init(.signOut, color: .secondaryLabel),
-                title: styledText(l("setting.quran_account.sign_out"), foregroundColor: .red),
-                action: logoutAction
-            )
-        }
-    }
-
-    private func styledText(
-        _ text: String,
-        foregroundColor: Color? = nil,
-        fontWeight: Font.Weight? = nil
-    ) -> MultipartText {
-        let range = text.startIndex ..< text.endIndex
-        return "\(text, highlighting: [HighlightingRange(range, foregroundColor: foregroundColor, fontWeight: fontWeight)])"
-    }
-    #endif
 }
 
 struct SettingsRootView_Previews: PreviewProvider {


### PR DESCRIPTION
## Summary

- replace the settings Quran.com account rows with dedicated signed-out and signed-in cards
- add the requested sign-in title and subtitle
- show account initial, signed-in status, regular-weight email, manage-account action, and destructive sign-out action
- preserve the existing authentication, profile navigation, and logout behavior
- update all supported localization catalogs

## Impact

Sync builds now present a clearer Quran.com account state in Settings while non-sync behavior remains unchanged.

## Screenshots

| Signed out | Signed in |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/5c39ccbb-5d22-48f5-8ca8-bd54f8e7664d" alt="Signed-out Quran.com account card in Settings" width="300"> | <img src="https://github.com/user-attachments/assets/760ca513-46a7-4151-afc6-efe1421abfda" alt="Signed-in Quran.com account card in Settings" width="300"> |

## Validation

- `make format-lint`
- `make test-sync TARGET=SettingsFeature`
- `make test-no-sync TARGET=SettingsFeature`
- `make test-sync TARGET=LocalizationTests`
- `make test-no-sync TARGET=LocalizationTests`
- `make run-example-sync`
- Simulator semantic and visual QA for the signed-out card