### PR TITLE
build: add local MobileSync debug workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,12 @@ The Makefile exposes explicit targets for each sync mode:
 
 - no sync: `make build-no-sync`, `make test-no-sync`, `make build-example-no-sync`, `make run-example-no-sync`
 - sync enabled: `make build-sync`, `make test-sync`, `make build-example-sync`, `make run-example-sync`
+- local sync: `make build-mobile-sync-spm`, `make build-sync-local-debug`, `make test-sync-local-debug`, `make build-example-sync-local-debug`, `make run-example-sync-local-debug`
 - SwiftFormat: `make format-lint`
 
 Package build targets honor `TARGET` as a scheme override, such as `make build-no-sync TARGET=NoorUI`. Package test targets always use the `QuranEngine-Package` scheme. Omit `TARGET` to run its full test plan, or set a production or test target to filter the run, such as `make test-sync TARGET=AyahMenuFeature` or `make test-sync TARGET=AyahMenuFeatureTests`. Keep every package test target in `QuranEngine-Package.xctestplan`. Ambient `QURAN_SYNC` may be set or unset through `launchctl`, so always use an explicit sync-mode target.
+
+Local sync targets expect `quran-ios`, `mobile-sync`, and `mobile-sync-spm` under one workspace. The Makefile finds that workspace through `git rev-parse --git-common-dir`, so the defaults work from both the primary checkout and Git worktrees. Do not derive sibling repositories from `../` relative to a worktree. `MOBILE_SYNC_DIR` locates the Gradle repository, `MOBILE_SYNC_SPM_PATH` selects the local Swift package, and `MOBILE_SYNC_XCFRAMEWORK_PATH` selects its local binary; path presence is the local/remote switch. The Makefile must supply and validate these paths. Keep the XCFramework path relative to the `mobile-sync-spm` package root because SwiftPM binary target paths must be relative.
 
 Keeping these commands green locally should keep the CI workflow green as well.
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,19 @@ EXAMPLE_BUNDLE_IDENTIFIER ?= com.quran.QuranEngineApp
 EXAMPLE_NO_SYNC_SIMULATOR ?= iPhone 17,26.1
 EXAMPLE_SYNC_SIMULATOR ?= iPhone 17 Pro,26.1
 DERIVED_DATA_DIR ?= .build/DerivedData
+GIT_COMMON_DIR := $(shell git rev-parse --path-format=absolute --git-common-dir)
+QURAN_WORKSPACE_DIR := $(abspath $(GIT_COMMON_DIR)/../..)
+MOBILE_SYNC_DIR ?= $(QURAN_WORKSPACE_DIR)/mobile-sync
+MOBILE_SYNC_SPM_PATH ?= $(QURAN_WORKSPACE_DIR)/mobile-sync-spm
+MOBILE_SYNC_CONFIGURATION ?= debug
+MOBILE_SYNC_XCFRAMEWORK_PATH ?= ../mobile-sync/umbrella/build/XCFrameworks/$(MOBILE_SYNC_CONFIGURATION)/Shared.xcframework
+MOBILE_SYNC_XCFRAMEWORK_OUTPUT ?= $(MOBILE_SYNC_DIR)/umbrella/build/XCFrameworks/$(MOBILE_SYNC_CONFIGURATION)/Shared.xcframework
+MOBILE_SYNC_SPM_SCHEME ?= MobileSync
+MOBILE_SYNC_SPM_SDK ?= iphonesimulator
+MOBILE_SYNC_SPM_DESTINATION ?= generic/platform=iOS Simulator
+MOBILE_SYNC_SPM_DERIVED_DATA ?= .build/DerivedData/local-$(MOBILE_SYNC_CONFIGURATION)
+MOBILE_SYNC_HTTP_LOG_LEVEL ?= ALL
+QURAN_OAUTH_CLIENT_ID ?=
 
 SWIFT_FORMAT_REPO=https://github.com/nicklockwood/SwiftFormat
 SWIFT_FORMAT_VERSION=0.62.1
@@ -25,10 +38,14 @@ TEST_TARGET=$(if $(TARGET),$(if $(filter %Tests,$(TARGET)),$(TARGET),$(TARGET)Te
 TEST_FILTER=$(if $(TEST_TARGET),-only-testing:$(TEST_TARGET))
 WITHOUT_QURAN_SYNC=set -o pipefail; env QURAN_SYNC=
 WITH_QURAN_SYNC=set -o pipefail; env QURAN_SYNC=QURAN_SYNC
+WITH_LOCAL_MOBILE_SYNC=set -o pipefail; env MOBILE_SYNC_XCFRAMEWORK_PATH="$(MOBILE_SYNC_XCFRAMEWORK_PATH)"
+WITH_LOCAL_QURAN_SYNC=set -o pipefail; env QURAN_SYNC=QURAN_SYNC MOBILE_SYNC_SPM_PATH="$(MOBILE_SYNC_SPM_PATH)" MOBILE_SYNC_XCFRAMEWORK_PATH="$(MOBILE_SYNC_XCFRAMEWORK_PATH)"
 WITHOUT_QURAN_SYNC_DERIVED_DATA=$(DERIVED_DATA_DIR)/no-sync
 WITH_QURAN_SYNC_DERIVED_DATA=$(DERIVED_DATA_DIR)/sync
+WITH_LOCAL_QURAN_SYNC_DERIVED_DATA=$(DERIVED_DATA_DIR)/sync-local-$(MOBILE_SYNC_CONFIGURATION)
 WITH_QURAN_SYNC_APP_SWIFT_FLAGS='OTHER_SWIFT_FLAGS=$$(inherited) -D QURAN_SYNC'
 WHATS_NEW_LAUNCH_ARGUMENTS=-whats-new.seen-version 0
+LOCAL_SYNC_SIMULATOR_ENV=env SIMCTL_CHILD_MOBILE_SYNC_HTTP_LOG_LEVEL="$(MOBILE_SYNC_HTTP_LOG_LEVEL)" $(if $(QURAN_OAUTH_CLIENT_ID),SIMCTL_CHILD_QURAN_OAUTH_CLIENT_ID="$(QURAN_OAUTH_CLIENT_ID)")
 comma := ,
 simulator-os = $(lastword $(subst $(comma), ,$(1)))
 simulator-name = $(subst $(comma)$(call simulator-os,$(1)),,$(1))
@@ -49,13 +66,15 @@ define run-example-app
 	if [ -n "$(strip $(3))" ]; then \
 		xcrun simctl terminate "$$simulator" "$(EXAMPLE_BUNDLE_IDENTIFIER)" >/dev/null 2>&1 || true; \
 	fi; \
-	xcrun simctl launch "$$simulator" "$(EXAMPLE_BUNDLE_IDENTIFIER)" $(3)
+	$(4) xcrun simctl launch "$$simulator" "$(EXAMPLE_BUNDLE_IDENTIFIER)" $(3)
 endef
 
 .PHONY: test-no-sync test-sync
 .PHONY: build-no-sync build-sync
 .PHONY: build-example-no-sync build-example-sync
 .PHONY: run-example-no-sync run-example-sync run-example-no-sync-whats-new run-example-sync-whats-new
+.PHONY: build-mobile-sync-spm build-sync-local-debug test-sync-local-debug
+.PHONY: build-example-sync-local-debug run-example-sync-local-debug
 .PHONY: clone-swiftformat build-swiftformat force-build-swiftformat clean-swiftformat format-lint format-autocorrect lint-no-kotlin-interop
 .PHONY: install-swiftlint build-for-analyzer swiftlint-analyzer
 
@@ -71,22 +90,44 @@ build-no-sync:
 build-sync:
 	$(WITH_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_QURAN_SYNC_DERIVED_DATA)" build -scheme "$(BUILD_SCHEME)" -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
 
+build-mobile-sync-spm:
+	@test -d "$(MOBILE_SYNC_DIR)" || { echo "mobile-sync not found at $(MOBILE_SYNC_DIR)" >&2; exit 1; }
+	@test -n "$(MOBILE_SYNC_SPM_PATH)" || { echo "MOBILE_SYNC_SPM_PATH is required" >&2; exit 1; }
+	@test -d "$(MOBILE_SYNC_SPM_PATH)" || { echo "mobile-sync-spm not found at $(MOBILE_SYNC_SPM_PATH)" >&2; exit 1; }
+	@test -n "$(MOBILE_SYNC_XCFRAMEWORK_PATH)" || { echo "MOBILE_SYNC_XCFRAMEWORK_PATH is required" >&2; exit 1; }
+	cd "$(MOBILE_SYNC_DIR)" && ./gradlew :umbrella:assembleSharedDebugXCFramework
+	@test -d "$(MOBILE_SYNC_XCFRAMEWORK_OUTPUT)" || { echo "XCFramework not found at $(MOBILE_SYNC_XCFRAMEWORK_OUTPUT)" >&2; exit 1; }
+	cd "$(MOBILE_SYNC_SPM_PATH)" && ( $(WITH_LOCAL_MOBILE_SYNC) xcrun xcodebuild -derivedDataPath "$(MOBILE_SYNC_SPM_DERIVED_DATA)" build -scheme "$(MOBILE_SYNC_SPM_SCHEME)" -sdk "$(MOBILE_SYNC_SPM_SDK)" -destination "$(MOBILE_SYNC_SPM_DESTINATION)" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO 2>&1 | xcbeautify --renderer github-actions )
+
+build-sync-local-debug: build-mobile-sync-spm
+	$(WITH_LOCAL_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_LOCAL_QURAN_SYNC_DERIVED_DATA)" build -scheme "$(BUILD_SCHEME)" -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
+
+test-sync-local-debug: build-mobile-sync-spm
+	$(WITH_LOCAL_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_LOCAL_QURAN_SYNC_DERIVED_DATA)" build test -scheme "$(PACKAGE_SCHEME)" $(TEST_FILTER) -sdk "$(PACKAGE_SDK)" -destination "$(PACKAGE_DESTINATION)" 2>&1 | xcbeautify --renderer github-actions
+
 build-example-no-sync:
 	$(WITHOUT_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITHOUT_QURAN_SYNC_DERIVED_DATA)" build -project $(EXAMPLE_PROJECT) -scheme $(EXAMPLE_SCHEME) -sdk "$(EXAMPLE_SDK)" -destination "$(EXAMPLE_DESTINATION)" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO 2>&1 | xcbeautify --renderer github-actions
 
 build-example-sync:
 	$(WITH_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_QURAN_SYNC_DERIVED_DATA)" build -project $(EXAMPLE_PROJECT) -scheme $(EXAMPLE_SCHEME) -sdk "$(EXAMPLE_SDK)" -destination "$(EXAMPLE_DESTINATION)" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO $(WITH_QURAN_SYNC_APP_SWIFT_FLAGS) 2>&1 | xcbeautify --renderer github-actions
 
+build-example-sync-local-debug: build-mobile-sync-spm
+	$(WITH_LOCAL_QURAN_SYNC) xcrun xcodebuild -derivedDataPath "$(WITH_LOCAL_QURAN_SYNC_DERIVED_DATA)" build -project $(EXAMPLE_PROJECT) -scheme $(EXAMPLE_SCHEME) -sdk "$(EXAMPLE_SDK)" -destination "$(EXAMPLE_DESTINATION)" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO $(WITH_QURAN_SYNC_APP_SWIFT_FLAGS) 2>&1 | xcbeautify --renderer github-actions
+
 run-example-no-sync: EXAMPLE_DESTINATION = $(call simulator-destination,$(EXAMPLE_NO_SYNC_SIMULATOR))
 run-example-sync: EXAMPLE_DESTINATION = $(call simulator-destination,$(EXAMPLE_SYNC_SIMULATOR))
 run-example-no-sync-whats-new: EXAMPLE_DESTINATION = $(call simulator-destination,$(EXAMPLE_NO_SYNC_SIMULATOR))
 run-example-sync-whats-new: EXAMPLE_DESTINATION = $(call simulator-destination,$(EXAMPLE_SYNC_SIMULATOR))
+run-example-sync-local-debug: EXAMPLE_DESTINATION = $(call simulator-destination,$(EXAMPLE_SYNC_SIMULATOR))
 
 run-example-no-sync: build-example-no-sync
 	$(call run-example-app,$(EXAMPLE_NO_SYNC_SIMULATOR),$(WITHOUT_QURAN_SYNC_DERIVED_DATA))
 
 run-example-sync: build-example-sync
 	$(call run-example-app,$(EXAMPLE_SYNC_SIMULATOR),$(WITH_QURAN_SYNC_DERIVED_DATA))
+
+run-example-sync-local-debug: build-example-sync-local-debug
+	$(call run-example-app,$(EXAMPLE_SYNC_SIMULATOR),$(WITH_LOCAL_QURAN_SYNC_DERIVED_DATA),,$(LOCAL_SYNC_SIMULATOR_ENV))
 
 run-example-no-sync-whats-new: build-example-no-sync
 	$(call run-example-app,$(EXAMPLE_NO_SYNC_SIMULATOR),$(WITHOUT_QURAN_SYNC_DERIVED_DATA),$(WHATS_NEW_LAUNCH_ARGUMENTS))

--- a/Package.swift
+++ b/Package.swift
@@ -26,6 +26,7 @@ let mobileSyncPackageDependency: Package.Dependency = {
     }
     return .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.16")
 }()
+
 let mobileSyncPackageDependencies: [Package.Dependency] =
     quranSyncEnabled ? [mobileSyncPackageDependency] : []
 let mobileSyncTargetDependencies: [Target.Dependency] = quranSyncEnabled ? [

--- a/Package.swift
+++ b/Package.swift
@@ -18,9 +18,16 @@ let quranSyncEnabled = quranSyncValue != nil && quranSyncValue != "0" && quranSy
 let quranSyncSettings: [SwiftSetting] = quranSyncEnabled ? [
     .define("QURAN_SYNC"),
 ] : []
-let mobileSyncPackageDependencies: [Package.Dependency] = quranSyncEnabled ? [
-    .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.16"),
-] : []
+let localMobileSyncPackagePath = ProcessInfo.processInfo.environment["MOBILE_SYNC_SPM_PATH"]?
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+let mobileSyncPackageDependency: Package.Dependency = {
+    if let localMobileSyncPackagePath, !localMobileSyncPackagePath.isEmpty {
+        return .package(path: localMobileSyncPackagePath)
+    }
+    return .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.16")
+}()
+let mobileSyncPackageDependencies: [Package.Dependency] =
+    quranSyncEnabled ? [mobileSyncPackageDependency] : []
 let mobileSyncTargetDependencies: [Target.Dependency] = quranSyncEnabled ? [
     .product(name: "MobileSync", package: "mobile-sync-spm"),
 ] : []

--- a/README.md
+++ b/README.md
@@ -46,6 +46,43 @@ make test-sync TARGET=AyahMenuFeatureTests
 
 For test commands, `TARGET` accepts either the production target or its `Tests` target. Both focused examples above select `AyahMenuFeatureTests`. New test targets must also be added to `QuranEngine-Package.xctestplan`.
 
+### Local MobileSync Development
+
+For local sync development, keep the three repositories under the same workspace:
+
+```text
+Quran/
+├── mobile-sync/
+├── mobile-sync-spm/
+└── quran-ios/
+```
+
+The Makefile derives the workspace from Git's common directory. This works from both the primary `quran-ios` checkout and Git worktrees, whose immediate parent does not contain the sibling repositories.
+
+```sh
+# Build the KMP debug XCFramework, then build mobile-sync-spm against it
+make build-mobile-sync-spm
+
+# Build or test QuranEngine against both local dependencies
+make build-sync-local-debug
+make test-sync-local-debug
+
+# Build or launch the example app against both local dependencies
+make build-example-sync-local-debug
+make run-example-sync-local-debug QURAN_OAUTH_CLIENT_ID=<client-id>
+```
+
+`MOBILE_SYNC_SPM_PATH` selects the local `mobile-sync-spm` package, while `MOBILE_SYNC_XCFRAMEWORK_PATH` selects the local KMP binary. The Makefile provides and validates defaults for the sibling-repository layout. Override the paths when using another layout:
+
+```sh
+make build-sync-local-debug \
+  MOBILE_SYNC_DIR=/path/to/mobile-sync \
+  MOBILE_SYNC_SPM_PATH=/path/to/mobile-sync-spm \
+  MOBILE_SYNC_XCFRAMEWORK_PATH=../relative/path/to/Shared.xcframework
+```
+
+`MOBILE_SYNC_XCFRAMEWORK_PATH` is relative to the `mobile-sync-spm` package root, as required by Swift Package Manager binary targets. Local example launches default to full HTTP request and response logging; set `MOBILE_SYNC_HTTP_LOG_LEVEL=INFO` or `NONE` to reduce it. Authentication and cookie headers are redacted.
+
 ## Repository Structure and Architecture
 
 The library consists of 6 top-level directories:


### PR DESCRIPTION
## Summary

- Add Make targets that build the local KMP debug XCFramework, build `mobile-sync-spm` against it, and then build/test/run QuranEngine with both local dependencies.
- Resolve sibling repositories from Git's common directory so defaults work in normal checkouts and Git worktrees.
- Require and validate the local package and XCFramework paths through explicit Make variables.
- Pass OAuth client and HTTP logging configuration to the Simulator launch environment.
- Document the local workflow in `README.md` and `AGENTS.md`.

## Why

Debugging KMP sync behavior from the iOS example app previously required manual package edits and path setup, and `../mobile-sync` fails from generated worktree directories. This provides one reproducible command for local API debugging.

## Companion PRs

- quran/mobile-sync-spm#16 — environment-selected local XCFramework.
- quran/mobile-sync#223 — safe configurable iOS HTTP logging.

## Validation

- `make build-mobile-sync-spm`
- `make run-example-sync-local-debug QURAN_OAUTH_CLIENT_ID=<client-id>`
- Confirmed the example app builds and launches on iPhone 17 Pro / iOS 26.1 using the local debug XCFramework and local Swift package.