### PR TITLE
refactor(sync): move bookmark collections to domain

### DIFF
--- a/Domain/AnnotationsService/Sources/AyahBookmarkCollectionService.swift
+++ b/Domain/AnnotationsService/Sources/AyahBookmarkCollectionService.swift
@@ -15,6 +15,11 @@ import Utilities
 import VLogging
 
 public struct AyahBookmarkCollection {
+    public init(collection: Collection_, bookmarks: [AyahCollectionBookmark]) {
+        self.collection = collection
+        self.bookmarks = bookmarks
+    }
+
     public let collection: Collection_
     public let bookmarks: [AyahCollectionBookmark]
 }
@@ -60,14 +65,14 @@ public enum AyahBookmarkCollectionKind: Equatable {
         }
     }
 
-    var highlightColor: HighlightColor? {
+    public var highlightColor: HighlightColor? {
         guard case .colored(let color) = self else {
             return nil
         }
         return color
     }
 
-    var isOldPageBookmarks: Bool {
+    public var isOldPageBookmarks: Bool {
         self == .oldPageBookmarks
     }
 

--- a/Domain/AnnotationsService/Sources/AyahBookmarkCollectionsModels+Identifiable.swift
+++ b/Domain/AnnotationsService/Sources/AyahBookmarkCollectionsModels+Identifiable.swift
@@ -1,6 +1,4 @@
 #if QURAN_SYNC
-import MobileSync
-
 extension AyahBookmarkCollection: Identifiable {
     public var id: String { collection.id }
 }

--- a/Domain/AnnotationsService/Tests/AyahBookmarkCollectionServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/AyahBookmarkCollectionServiceTests.swift
@@ -5,7 +5,7 @@ import QuranAnnotations
 import QuranKit
 import Utilities
 import XCTest
-@testable import BookmarksFeature
+@testable import AnnotationsService
 
 final class AyahBookmarkCollectionServiceTests: XCTestCase {
     private let database = MobileSyncTestDatabase.shared

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollection+Presentation.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollection+Presentation.swift
@@ -1,4 +1,5 @@
 #if QURAN_SYNC
+import AnnotationsService
 import Localization
 import NoorUI
 import QuranAnnotations

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsBuilder.swift
@@ -5,6 +5,7 @@
 //  Created by Ahmed Nabil on 2026-05-05.
 //
 
+import AnnotationsService
 import NoorUI
 import QuranAnnotations
 import QuranKit

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsView.swift
@@ -5,6 +5,7 @@
 //  Created by Ahmed Nabil on 2026-05-05.
 //
 
+import AnnotationsService
 import Localization
 import NoorUI
 import QuranAnnotations

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Ahmed Nabil on 2026-05-05.
 //
 
+import AnnotationsService
 import Combine
 import Localization
 import NoorUI

--- a/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahBookmarkCollectionsViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by Ahmed Nabil on 2026-05-05.
 //
 
+import AnnotationsService
 import Combine
 import QuranAnnotations
 import QuranKit

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsBuilder.swift
@@ -3,6 +3,7 @@
 //  BookmarkAyahsBuilder.swift
 //
 
+import AnnotationsService
 import AppDependencies
 import NoorUI
 import QuranKit

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsView.swift
@@ -3,6 +3,7 @@
 //  BookmarkAyahsView.swift
 //
 
+import AnnotationsService
 import Localization
 import NoorUI
 import SwiftUI

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsBuilder.swift
@@ -3,6 +3,7 @@
 //  BookmarkCollectionsBuilder.swift
 //
 
+import AnnotationsService
 import AppDependencies
 import FeaturesSupport
 import QuranKit

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
@@ -3,6 +3,7 @@
 //  BookmarkCollectionsView.swift
 //
 
+import AnnotationsService
 import FeaturesSupport
 import Localization
 import NoorUI

--- a/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahBookmarkCollectionsViewModelTests.swift
@@ -6,6 +6,7 @@ import QuranKit
 import QuranResources
 import QuranTextKit
 import XCTest
+@testable import AnnotationsService
 @testable import BookmarksFeature
 
 @MainActor

--- a/Features/BookmarksFeature/Tests/BookmarkAyahsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkAyahsViewModelTests.swift
@@ -5,6 +5,7 @@ import NoorUI
 import QuranAnnotations
 import QuranKit
 import XCTest
+@testable import AnnotationsService
 @testable import BookmarksFeature
 
 @MainActor

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -1,5 +1,4 @@
 #if QURAN_SYNC
-import AnnotationsService
 import AuthenticationClient
 import AuthenticationClientFake
 import Combine
@@ -13,6 +12,7 @@ import QuranTextKit
 import ReadingService
 import UIKit
 import XCTest
+@testable import AnnotationsService
 @testable import BookmarksFeature
 
 @MainActor

--- a/Features/QuranViewFeature/Tests/QuranSyncedHighlightsObserverTests.swift
+++ b/Features/QuranViewFeature/Tests/QuranSyncedHighlightsObserverTests.swift
@@ -1,11 +1,11 @@
 #if QURAN_SYNC
-import AnnotationsService
 import Combine
 import MobileSync
 import MobileSyncTestSupport
 import QuranAnnotations
 import QuranKit
 import XCTest
+@testable import AnnotationsService
 @testable import BookmarksFeature
 @testable import QuranViewFeature
 

--- a/Package.swift
+++ b/Package.swift
@@ -523,11 +523,13 @@ private func domainTargets() -> [[Target]] {
 
         target(type, name: "AnnotationsService", dependencies: [
             "QuranAnnotations",
+            "QuranKit",
             "LastPagePersistence",
             "NotePersistence",
             "PageBookmarkPersistence",
             "Preferences",
             "QuranTextKit",
+            "ReadingService",
             "Localization",
             "Analytics",
             "Utilities",


### PR DESCRIPTION
## What changed

- move `AyahBookmarkCollectionService`, its collection models, and tests from `BookmarksFeature` to `AnnotationsService`
- move the related `Identifiable` conformances with their models
- update imports, package dependencies, and access control required by the new module boundary

## Why

Collection persistence and MobileSync mapping belong in the domain data-service layer, not in the bookmarks UI feature.

This PR intentionally preserves the existing collection and highlight behavior. The dedicated highlight-service change is stacked separately.

## User impact

None. This is an ownership-only refactor.

## Validation

- `make format-lint`
- `make build-sync`
- `make build-no-sync`
- `make test-sync TARGET=AnnotationsServiceTests` (38 tests)
- `make test-sync TARGET=BookmarksFeatureTests` (44 tests)
