### PR TITLE
feat: add reusable UI tags

### DIFF
--- a/Features/ReadingSelectorFeature/Sources/ReadingSelectorViewModel.swift
+++ b/Features/ReadingSelectorFeature/Sources/ReadingSelectorViewModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Localization
+import NoorUI
 import QuranKit
 import ReadingService
 
@@ -95,19 +96,19 @@ class ReadingSelectorViewModel: ObservableObject {
 
 private extension ReadingInfo where Value == Reading {
     init(_ reading: Reading) {
-        let badge: ReadingBadge? = switch reading {
+        let tags: [NoorTag] = switch reading {
         case .hafs_1441, .hafs_1439:
-            ReadingBadge(
+            [NoorTag(
                 title: l("reading.selector.badge.large-screen-optimized"),
-                style: .informational
-            )
+                tone: .accent
+            )]
         case .naskh:
-            ReadingBadge(
+            [NoorTag(
                 title: l("reading.selector.badge.experimental"),
-                style: .experimental
-            )
+                tone: .red
+            )]
         default:
-            nil
+            []
         }
 
         self.init(
@@ -115,7 +116,7 @@ private extension ReadingInfo where Value == Reading {
             title: reading.title,
             description: reading.description,
             properties: reading.properties,
-            badge: badge
+            tags: tags
         )
     }
 }

--- a/Features/ReadingSelectorFeature/Sources/View/ReadingInfo.swift
+++ b/Features/ReadingSelectorFeature/Sources/View/ReadingInfo.swift
@@ -6,17 +6,8 @@
 //
 
 import Localization
+import NoorUI
 import QuranKit
-
-struct ReadingBadge: Hashable {
-    enum Style: Hashable {
-        case informational
-        case experimental
-    }
-
-    let title: String
-    let style: Style
-}
 
 struct ReadingInfo<Value: Hashable>: Hashable, Identifiable {
     // MARK: Internal
@@ -25,7 +16,7 @@ struct ReadingInfo<Value: Hashable>: Hashable, Identifiable {
     let title: String
     let description: String
     let properties: [Reading.Property]
-    let badge: ReadingBadge?
+    let tags: [NoorTag]
 
     var id: Value { value }
 }
@@ -55,9 +46,9 @@ enum ReadingInfoTestData {
                     .init(type: .supports, property: "Property 2"),
                     .init(type: .lacks, property: "Property 3"),
                 ],
-                badge: $0 == .e
-                    ? ReadingBadge(title: "Experimental", style: .experimental)
-                    : nil
+                tags: $0 == .e
+                    ? [NoorTag(title: "Experimental", tone: .red)]
+                    : []
             )
         }
     }

--- a/Features/ReadingSelectorFeature/Sources/View/ReadingItem.swift
+++ b/Features/ReadingSelectorFeature/Sources/View/ReadingItem.swift
@@ -19,7 +19,6 @@ struct ReadingItem<Value: Hashable, ImageView: View>: View {
     let action: () -> Void
 
     @ScaledMetric var cornerRadius = Dimensions.cornerRadius
-    @ScaledMetric private var badgeDotSize = 6
 
     var body: some View {
         Button(action: action) {
@@ -30,8 +29,8 @@ struct ReadingItem<Value: Hashable, ImageView: View>: View {
                             if let progress {
                                 ProgressView(value: progress, total: 1)
                             }
-                            if let badge = reading.badge {
-                                badgeView(badge)
+                            if !reading.tags.isEmpty {
+                                tagsView
                             }
                             titleView
                             descriptionView
@@ -65,38 +64,13 @@ struct ReadingItem<Value: Hashable, ImageView: View>: View {
             .font(.footnote)
     }
 
-    private func badgeView(_ badge: ReadingBadge) -> some View {
-        HStack(spacing: 6) {
-            Circle()
-                .frame(width: badgeDotSize, height: badgeDotSize)
-
-            Text(badge.title)
-                .font(.caption2.bold())
-                .textCase(.uppercase)
+    private var tagsView: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(reading.tags, id: \.self) { tag in
+                NoorTagView(tag)
+            }
         }
-        .foregroundColor(badgeForegroundColor(badge.style))
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(Capsule().fill(badgeBackgroundColor(badge.style)))
         .padding(.bottom, 4)
-    }
-
-    private func badgeForegroundColor(_ style: ReadingBadge.Style) -> Color {
-        switch style {
-        case .informational:
-            return .appIdentity
-        case .experimental:
-            return .red
-        }
-    }
-
-    private func badgeBackgroundColor(_ style: ReadingBadge.Style) -> Color {
-        switch style {
-        case .informational:
-            return Color.appIdentity.opacity(0.1)
-        case .experimental:
-            return Color.red.opacity(0.1)
-        }
     }
 
     private var backgroundRectangle: some InsettableShape {

--- a/Features/WhatsNewFeature/Sources/AppWhatsNew.swift
+++ b/Features/WhatsNewFeature/Sources/AppWhatsNew.swift
@@ -7,6 +7,7 @@
 //
 
 import Localization
+import NoorUI
 
 struct AppWhatsNew: Decodable {
     let versions: [WhatsNewVersion]
@@ -23,6 +24,7 @@ struct WhatsNewItem: Decodable {
     let title: String
     let subtitle: String
     let image: String
+    let tags: [WhatsNewTag]?
 
     var localizedTitle: String {
         l(title)
@@ -35,6 +37,10 @@ struct WhatsNewItem: Decodable {
                 detail.hasPrefix("* ") ? String(detail.dropFirst(2)) : detail
             }
             .filter { !$0.isEmpty }
+    }
+
+    var localizedTags: [NoorTag] {
+        tags?.map(\.localizedTag) ?? []
     }
 
     // MARK: Private
@@ -51,5 +57,14 @@ struct WhatsNewItem: Decodable {
         let components = text.replacingOccurrences(of: "%%", with: "")
             .components(separatedBy: ":")
         return l(components[1], table: Table(rawValue: components[0])!)
+    }
+}
+
+struct WhatsNewTag: Decodable {
+    let title: String
+    let tone: NoorTag.Tone
+
+    var localizedTag: NoorTag {
+        NoorTag(title: l(title), tone: tone)
     }
 }

--- a/Features/WhatsNewFeature/Sources/AppWhatsNewView.swift
+++ b/Features/WhatsNewFeature/Sources/AppWhatsNewView.swift
@@ -4,6 +4,7 @@
 //
 
 import Localization
+import NoorUI
 import SwiftUI
 import UIKit
 
@@ -91,6 +92,14 @@ private struct AppWhatsNewCard: View {
                     .foregroundStyle(.primary)
             }
 
+            if !item.localizedTags.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(item.localizedTags, id: \.self) { tag in
+                        NoorTagView(tag)
+                    }
+                }
+            }
+
             VStack(alignment: .leading, spacing: detailSpacing) {
                 ForEach(item.localizedDetails.indices, id: \.self) { index in
                     detail(item.localizedDetails[index])
@@ -153,12 +162,14 @@ final class AppWhatsNewViewController: UIHostingController<AppWhatsNewView> {
             WhatsNewItem(
                 title: "new.audio_upgrades",
                 subtitle: "new.audio_upgrades.details",
-                image: "speedometer"
+                image: "speedometer",
+                tags: [WhatsNewTag(title: "Optimized", tone: .accent)]
             ),
             WhatsNewItem(
                 title: "new.personalization",
                 subtitle: "new.personalization.details",
-                image: "paintpalette.fill"
+                image: "paintpalette.fill",
+                tags: nil
             ),
         ],
         onContinue: {}

--- a/Features/WhatsNewFeature/Sources/whats-new.plist
+++ b/Features/WhatsNewFeature/Sources/whats-new.plist
@@ -16,6 +16,15 @@
 					<string>new.reading_layouts.details</string>
 					<key>image</key>
 					<string>book</string>
+					<key>tags</key>
+					<array>
+						<dict>
+							<key>title</key>
+							<string>reading.selector.badge.large-screen-optimized</string>
+							<key>tone</key>
+							<string>accent</string>
+						</dict>
+					</array>
 				</dict>
 				<dict>
 					<key>title</key>
@@ -24,6 +33,15 @@
 					<string>new.experimental_naskh.details</string>
 					<key>image</key>
 					<string>flask</string>
+					<key>tags</key>
+					<array>
+						<dict>
+							<key>title</key>
+							<string>reading.selector.badge.experimental</string>
+							<key>tone</key>
+							<string>red</string>
+						</dict>
+					</array>
 				</dict>
 				<dict>
 					<key>title</key>

--- a/UI/NoorUI/Sources/Components/NoorTag.swift
+++ b/UI/NoorUI/Sources/Components/NoorTag.swift
@@ -1,0 +1,85 @@
+//
+//  NoorTag.swift
+//
+
+import SwiftUI
+
+public struct NoorTag: Hashable {
+    public enum Tone: String, Codable {
+        case accent
+        case neutral
+        case yellow
+        case red
+    }
+
+    public let title: String
+    public let tone: Tone
+
+    public init(title: String, tone: Tone) {
+        self.title = title
+        self.tone = tone
+    }
+}
+
+public struct NoorTagView: View {
+    @ScaledMetric private var dotSize = 6.0
+
+    private let tag: NoorTag
+
+    public init(_ tag: NoorTag) {
+        self.tag = tag
+    }
+
+    public var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .frame(width: dotSize, height: dotSize)
+                .accessibilityHidden(true)
+
+            Text(tag.title)
+                .font(.caption2.bold())
+                .textCase(.uppercase)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .foregroundStyle(foregroundColor)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(Capsule().fill(backgroundColor))
+    }
+
+    private var foregroundColor: Color {
+        switch tag.tone {
+        case .accent:
+            return .accentColor
+        case .neutral:
+            return Color(uiColor: .secondaryLabel)
+        case .yellow:
+            return .orange
+        case .red:
+            return .red
+        }
+    }
+
+    private var backgroundColor: Color {
+        switch tag.tone {
+        case .accent:
+            return Color.accentColor.opacity(0.1)
+        case .neutral:
+            return Color(uiColor: .secondaryLabel).opacity(0.1)
+        case .yellow:
+            return Color.yellow.opacity(0.15)
+        case .red:
+            return Color.red.opacity(0.1)
+        }
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading) {
+        NoorTagView(NoorTag(title: "Optimized", tone: .accent))
+        NoorTagView(NoorTag(title: "Informational", tone: .neutral))
+        NoorTagView(NoorTag(title: "Attention", tone: .yellow))
+        NoorTagView(NoorTag(title: "Experimental", tone: .red))
+    }
+    .padding()
+}


### PR DESCRIPTION
## Summary

- add a reusable `NoorTag` component with accent, neutral, yellow, and red visual tones
- migrate Reading Selector badges to feature-assigned tags
- decode and render tags on What's New cards for optimized Mushafs and the experimental Naskh layout

## Impact

Tag presentation is now shared while each feature remains responsible for assigning localized titles and visual tones. The UI component has no knowledge of product concepts such as optimized or experimental.

## Validation

- `make format-lint`
- `make build-no-sync TARGET=NoorUI`
- `make build-no-sync TARGET=ReadingSelectorFeature`
- `make build-no-sync TARGET=WhatsNewFeature`
- `make run-example-no-sync-whats-new EXAMPLE_NO_SYNC_SIMULATOR='iPhone 17 Pro,26.1'`
- simulator visual and accessibility inspection with `axe`
- `make test-no-sync`: build passed and completed test bundles were green; stopped after an unrelated existing `translations.db` SQLite test hang

## Screenshot

<img width="300" alt="What's New tags" src="https://github.com/user-attachments/assets/7dd06944-9fcd-47a6-8bb2-13c3fb6cd06d">