### PR TITLE
Refine 2.6.1 What's New

### DIFF
--- a/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -274,7 +274,7 @@
 
 // Reading layouts
 "new.reading_layouts" = "مصاحف مدنية جديدة";
-"new.reading_layouts.details" = "* تمت إضافة مصحف المدينة ١٤٣٩ ومصحف المدينة ١٤٤١ كتخطيطين جديدين للقراءة - بفضل @ahmedre.\n* تم تحسين استعادة تنزيل صفحات القراءة والتعامل مع الملفات غير المكتملة - بفضل @ahmedre.";
+"new.reading_layouts.details" = "* تمت إضافة مصحفي المدينة ١٤٣٩ و١٤٤١، وقد حُسِّنا لملء الشاشة بالكامل — بفضل @ahmedre.";
 
 // Experimental Naskh
 "new.experimental_naskh" = "خط النسخ التجريبي";

--- a/Core/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -320,7 +320,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Neue Madani-Mushafs";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Madani Mushaf 1439 und Madani Mushaf 1441 als neue Leselayouts hinzugefügt – dank @ahmedre.\n* Wiederherstellung von Leseseiten-Downloads und Umgang mit unvollständigen Dateien verbessert – dank @ahmedre.";
+"new.reading_layouts.details" = "* Madani Mushaf 1439 und 1441 hinzugefügt, optimiert, um den gesamten Bildschirm auszufüllen – dank @ahmedre.";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -300,7 +300,7 @@
 
 // Reading layouts
 "new.reading_layouts" = "New Madani Mushafs";
-"new.reading_layouts.details" = "* Added Madani Mushaf 1439 and Madani Mushaf 1441 reading layouts - thanks to @ahmedre.\n* Improved reading download recovery and handling of incomplete files - thanks to @ahmedre.";
+"new.reading_layouts.details" = "* Added Madani Mushaf 1439 and 1441, optimized to fill the entire screen — thanks to @ahmedre.";
 
 // Experimental Naskh
 "new.experimental_naskh" = "Experimental Naskh Script";

--- a/Core/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -320,7 +320,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Nuevos mushafs de Medina";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Se añadieron los diseños de lectura Mushaf de Medina 1439 y Mushaf de Medina 1441, gracias a @ahmedre.\n* Se mejoró la recuperación de descargas de páginas de lectura y el manejo de archivos incompletos, gracias a @ahmedre.";
+"new.reading_layouts.details" = "* Se añadieron los Mushaf de Medina 1439 y 1441, optimizados para ocupar toda la pantalla — gracias a @ahmedre.";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -322,7 +322,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "مصحف‌های جدید مدینه";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* چیدمان‌های مطالعهٔ مصحف مدینه ۱۴۳۹ و مصحف مدینه ۱۴۴۱ اضافه شدند - با تشکر از @ahmedre.\n* بازیابی دانلود صفحات مطالعه و مدیریت فایل‌های ناقص بهبود یافت - با تشکر از @ahmedre.";
+"new.reading_layouts.details" = "* مصحف‌های مدینه ۱۴۳۹ و ۱۴۴۱ اضافه شدند؛ برای پر کردن تمام صفحه بهینه‌سازی شده‌اند — با تشکر از @ahmedre.";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -320,7 +320,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Nouveaux mushafs de Médine";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Ajout des mises en page de lecture Mushaf de Médine 1439 et Mushaf de Médine 1441, grâce à @ahmedre.\n* Amélioration de la récupération des téléchargements de pages de lecture et de la gestion des fichiers incomplets, grâce à @ahmedre.";
+"new.reading_layouts.details" = "* Ajout des Mushafs de Médine 1439 et 1441, optimisés pour occuper tout l’écran — grâce à @ahmedre.";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/kk.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/kk.lproj/Localizable.strings
@@ -304,7 +304,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Жаңа Мәдина мұсхафтары";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Мәдина мұсхафы 1439 және Мәдина мұсхафы 1441 оқу үлгілері қосылды — @ahmedre-ға рақмет.\n* Оқу беттерін жүктеуді қалпына келтіру және толық емес файлдарды өңдеу жақсартылды — @ahmedre-ға рақмет.";
+"new.reading_layouts.details" = "* Мәдина мұсхафы 1439 және 1441 қосылды, бүкіл экранды толтыру үшін оңтайландырылған — @ahmedre-ға рақмет.";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -303,7 +303,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Mushaf Madani Baharu";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Susun atur bacaan Mushaf Madani 1439 dan Mushaf Madani 1441 telah ditambah — terima kasih kepada @ahmedre.\n* Pemulihan muat turun halaman bacaan dan pengendalian fail yang tidak lengkap telah ditambah baik — terima kasih kepada @ahmedre.";
+"new.reading_layouts.details" = "* Mushaf Madani 1439 dan 1441 ditambah, dioptimumkan untuk memenuhi seluruh skrin — terima kasih kepada @ahmedre.";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -232,7 +232,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Nieuwe Madani-mushafs";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* De leesindelingen Madani Mushaf 1439 en Madani Mushaf 1441 zijn toegevoegd — met dank aan @ahmedre.\n* Het herstellen van downloads van leespagina’s en het verwerken van onvolledige bestanden is verbeterd — met dank aan @ahmedre.";
+"new.reading_layouts.details" = "* Madani Mushaf 1439 en 1441 toegevoegd, geoptimaliseerd om het volledige scherm te vullen — met dank aan @ahmedre.";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/pt.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/pt.lproj/Localizable.strings
@@ -321,7 +321,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Novos mushafs de Medina";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Foram adicionados os layouts de leitura Mushaf de Medina 1439 e Mushaf de Medina 1441, graças a @ahmedre.\n* A recuperação de downloads das páginas de leitura e o tratamento de arquivos incompletos foram aprimorados, graças a @ahmedre.";
+"new.reading_layouts.details" = "* Adicionados os Mushafs de Medina 1439 e 1441, otimizados para preencher toda a tela — graças a @ahmedre.";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -320,7 +320,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Новые мединские мусхафы";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Добавлены варианты чтения «Мединский мусхаф 1439» и «Мединский мусхаф 1441» — благодаря @ahmedre.\n* Улучшено восстановление загрузок страниц для чтения и обработка неполных файлов — благодаря @ahmedre.";
+"new.reading_layouts.details" = "* Добавлены «Мединский мусхаф 1439» и «Мединский мусхаф 1441», оптимизированные для отображения во весь экран — благодаря @ahmedre.";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -262,7 +262,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Yeni Medine Mushafları";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Medine Mushafı 1439 ve Medine Mushafı 1441 okuma düzenleri eklendi — @ahmedre sayesinde.\n* Okuma sayfası indirmelerini kurtarma ve eksik dosyaları işleme geliştirildi — @ahmedre sayesinde.";
+"new.reading_layouts.details" = "* Medine Mushafı 1439 ve 1441 eklendi; ekranın tamamını dolduracak şekilde optimize edildi — @ahmedre sayesinde.";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ug.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ug.lproj/Localizable.strings
@@ -323,7 +323,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "يېڭى مەدىنە مۇشاپلىرى";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* مەدىنە مۇشاپى 1439 ۋە مەدىنە مۇشاپى 1441 ئوقۇش كۆرۈنۈشلىرى قوشۇلدى — @ahmedre غا رەھمەت.\n* ئوقۇش بەتلىرىنى چۈشۈرۈشنى ئەسلىگە كەلتۈرۈش ۋە تولۇق بولمىغان ھۆججەتلەرنى بىر تەرەپ قىلىش ياخشىلاندى — @ahmedre غا رەھمەت.";
+"new.reading_layouts.details" = "* مەدىنە مۇشاپى 1439 ۋە 1441 قوشۇلدى، پۈتۈن ئېكراننى تولدۇرۇش ئۈچۈن ئەلالاشتۇرۇلدى — @ahmedre غا رەھمەت.";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/uz.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/uz.lproj/Localizable.strings
@@ -322,7 +322,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Yangi Madina mushaflari";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Madina mushafi 1439 va Madina mushafi 1441 o‘qish ko‘rinishlari qo‘shildi — @ahmedre ga rahmat.\n* O‘qish sahifalarini yuklab olishni tiklash va to‘liq bo‘lmagan fayllarni boshqarish yaxshilandi — @ahmedre ga rahmat.";
+"new.reading_layouts.details" = "* Madina mushafi 1439 va 1441 qo‘shildi, butun ekranni to‘ldirish uchun optimallashtirildi — @ahmedre ga rahmat.";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -229,7 +229,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Các Mushaf Madani mới";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Đã thêm bố cục đọc Mushaf Madani 1439 và Mushaf Madani 1441 — cảm ơn @ahmedre.\n* Cải thiện khả năng khôi phục tải xuống trang đọc và xử lý tệp chưa hoàn chỉnh — cảm ơn @ahmedre.";
+"new.reading_layouts.details" = "* Đã thêm Mushaf Madani 1439 và 1441, được tối ưu hóa để hiển thị toàn màn hình — cảm ơn @ahmedre.";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/zh.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/zh.lproj/Localizable.strings
@@ -321,7 +321,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "全新麦地那穆沙夫";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* 新增麦地那穆沙夫 1439 和麦地那穆沙夫 1441 阅读布局 — 感谢 @ahmedre。\n* 改进阅读页面下载恢复及不完整文件的处理 — 感谢 @ahmedre。";
+"new.reading_layouts.details" = "* 新增麦地那穆沙夫 1439 和 1441，已优化为全屏显示 — 感谢 @ahmedre。";
 
 // Experimental Naskh
 // Metadata: Translated by ChatGPT; human review required.

--- a/Features/WhatsNewFeature/Sources/AppWhatsNewController.swift
+++ b/Features/WhatsNewFeature/Sources/AppWhatsNewController.swift
@@ -64,6 +64,7 @@ public class AppWhatsNewController {
 
         navigationController.setViewControllers([announcementViewController], animated: false)
         navigationController.modalPresentationStyle = .pageSheet
+        navigationController.isModalInPresentation = true
         navigationController.sheetPresentationController?.detents = [.large()]
 
         parent.present(navigationController, animated: true)

--- a/Features/WhatsNewFeature/Sources/whats-new.plist
+++ b/Features/WhatsNewFeature/Sources/whats-new.plist
@@ -6,7 +6,7 @@
 	<array>
 		<dict>
 			<key>version</key>
-			<string>2.6.0</string>
+			<string>2.6.1</string>
 			<key>items</key>
 			<array>
 				<dict>


### PR DESCRIPTION
## Summary

- move the updated release notes to version 2.6.1
- remove the reading-download recovery item from the 2.6.1 release notes
- describe the Madani Mushaf 1439 and 1441 layouts as optimized to fill the entire screen across all 16 localizations
- prevent interactive sheet dismissal so Continue is the only dismissal path

## Why

Keep the release notes focused and ensure users complete the announcement flow explicitly.

## Validation

- `make format-lint`
- `plutil -lint Core/Localization/Sources/Resources/*.lproj/Localizable.strings`
- `plutil -lint Features/WhatsNewFeature/Sources/whats-new.plist`
- `make build-no-sync TARGET=WhatsNewFeature`
- `make build-sync TARGET=WhatsNewFeature`
- `make test-no-sync TARGET=LocalizationTests`
- `make test-sync TARGET=LocalizationTests`