### PR TITLE
Fix unnecessary note saves

### DIFF
--- a/Features/NoteEditorFeature/Sources/NoteEditorViewModel.swift
+++ b/Features/NoteEditorFeature/Sources/NoteEditorViewModel.swift
@@ -92,7 +92,7 @@ final class NoteEditorViewModel {
     }
 
     var shouldAutoSaveOnDismiss: Bool {
-        canSubmitNote
+        canSubmitNote && hasChanges
     }
 
     func fetchNote() async throws -> EditableNote {
@@ -135,6 +135,13 @@ final class NoteEditorViewModel {
 
         guard !hasNoteText || canSubmitNote else {
             return false
+        }
+
+        guard hasChanges else {
+            if dismissOnSave {
+                listener?.dismissNoteEditor()
+            }
+            return dismissOnSave
         }
 
         do {
@@ -209,6 +216,14 @@ final class NoteEditorViewModel {
 
     private var trimmedNoteText: String {
         noteText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var hasChanges: Bool {
+        #if QURAN_SYNC
+        return noteText != body
+        #else
+        return noteText != body || (editableNote?.selectedColor ?? note.color) != note.color
+        #endif
     }
 
     private var selectedColor: HighlightColor {

--- a/Features/NoteEditorFeature/Tests/NoteEditorViewModelTests.swift
+++ b/Features/NoteEditorFeature/Tests/NoteEditorViewModelTests.swift
@@ -116,6 +116,21 @@ final class NoteEditorViewModelTests: XCTestCase {
         XCTAssertFalse(sut.listener.didDismiss)
     }
 
+    func test_unchangedSyncedNote_dismissesWithoutSaving() async throws {
+        let note = try await createStoredNote(body: "Stored note")
+        let sut = makeSyncSUT(mode: .edit(note))
+        _ = try await sut.viewModel.fetchNote()
+
+        let didFinish = await sut.viewModel.commitEditsAndExit(dismissOnSave: true)
+        let notes = try await storedNotes()
+
+        XCTAssertTrue(didFinish)
+        XCTAssertFalse(sut.viewModel.shouldAutoSaveOnDismiss)
+        XCTAssertEqual(notes, [note])
+        XCTAssertTrue(sut.analytics.events.isEmpty)
+        XCTAssertTrue(sut.listener.didDismiss)
+    }
+
     func test_createDelete_dismissesWithoutRemovingSyncedNote() async throws {
         let sut = makeSyncSUT(mode: .create(verses: [ayah(1)]))
 
@@ -255,6 +270,18 @@ final class NoteEditorViewModelTests: XCTestCase {
         XCTAssertTrue(sut.viewModel.shouldAutoSaveOnDismiss)
         XCTAssertEqual(sut.noteService.setNoteCalls.count, 1)
         XCTAssertFalse(sut.listener.didDismiss)
+    }
+
+    func test_unchangedLegacyNote_dismissesWithoutSaving() async throws {
+        let sut = makeLegacySUT(noteBody: "Stored note", color: .blue)
+        _ = try await sut.viewModel.fetchNote()
+
+        let didFinish = await sut.viewModel.commitEditsAndExit(dismissOnSave: true)
+
+        XCTAssertTrue(didFinish)
+        XCTAssertFalse(sut.viewModel.shouldAutoSaveOnDismiss)
+        XCTAssertTrue(sut.noteService.setNoteCalls.isEmpty)
+        XCTAssertTrue(sut.listener.didDismiss)
     }
 
     func test_delete_removesLegacyNoteVersesAndDismisses() async {


### PR DESCRIPTION
## Summary

- skip persistence when an existing note body has not changed
- include highlight color when detecting no-sync edits
- avoid dismissal auto-save for unchanged notes
- add sync and no-sync regression coverage

## Root cause

The note editor treated every valid note body as eligible for auto-save and always called the persistence service when Done was tapped, even when the editable values matched the stored note.

## Impact

Opening and closing an unchanged note no longer updates its persistence record, sync metadata, or analytics. Color-only changes in no-sync mode continue to save.

## Validation

- `make test-no-sync TARGET=NoteEditorFeatureTests`
- `make test-sync TARGET=NoteEditorFeatureTests`
- `make format-lint`