### PR TITLE
fix(auth): handle typed authentication errors

### DIFF
--- a/Data/AuthenticationClient/Sources/AuthenticationClient.swift
+++ b/Data/AuthenticationClient/Sources/AuthenticationClient.swift
@@ -12,11 +12,29 @@ import MobileSync
 import UIKit
 
 public enum AuthenticationClientError: Error {
-    case errorAuthenticating(Error)
+    /// The user dismissed the interactive authentication flow.
+    case cancelled
 
-    /// Thrown when an operation, that needs authentication, is attempted while the client
-    /// hasn't been authenticated or if the client's access has been revoked.
-    case clientIsNotAuthenticated(Error)
+    /// An authenticated operation was attempted without a usable session.
+    case notAuthenticated(underlying: Error?)
+
+    /// Authentication could not reach the remote service.
+    case networkFailure(underlying: Error)
+
+    /// Authentication failed for a non-network reason.
+    case authenticationFailed(underlying: Error)
+
+    public var underlyingError: Error? {
+        switch self {
+        case .cancelled:
+            nil
+        case let .notAuthenticated(underlyingError):
+            underlyingError
+        case let .networkFailure(underlyingError),
+             let .authenticationFailed(underlyingError):
+            Optional(underlyingError)
+        }
+    }
 }
 
 public enum AuthenticationState: Equatable {

--- a/Data/AuthenticationClient/Sources/AuthenticationClientMobileSyncImpl.swift
+++ b/Data/AuthenticationClient/Sources/AuthenticationClientMobileSyncImpl.swift
@@ -8,9 +8,8 @@ import VLogging
 public final actor AuthenticationClientMobileSyncImpl: AuthenticationClient {
     // MARK: Lifecycle
 
-    public init(authService: SyncAuthService, quranDataService: QuranDataService) {
+    public init(authService: SyncAuthService) {
         self.authService = authService
-        self.quranDataService = quranDataService
     }
 
     // MARK: Public
@@ -28,7 +27,7 @@ public final actor AuthenticationClientMobileSyncImpl: AuthenticationClient {
             try await authService.signInWithReauthentication()
         } catch {
             logger.error("Failed to login via mobile sync: \(error)")
-            throw AuthenticationClientError.errorAuthenticating(error)
+            throw AuthenticationClientError(error)
         }
     }
 
@@ -38,16 +37,16 @@ public final actor AuthenticationClientMobileSyncImpl: AuthenticationClient {
             return authenticationState
         } catch {
             logger.error("Failed to restore mobile sync auth state: \(error)")
-            throw AuthenticationClientError.clientIsNotAuthenticated(error)
+            throw AuthenticationClientError(error)
         }
     }
 
     public func logout() async throws(AuthenticationClientError) {
         do {
-            try await quranDataService.logout(clearLocalData: true)
+            try await authService.signOut()
         } catch {
             logger.error("Failed to logout via mobile sync: \(error)")
-            throw AuthenticationClientError.errorAuthenticating(error)
+            throw AuthenticationClientError(error)
         }
     }
 
@@ -62,16 +61,36 @@ public final actor AuthenticationClientMobileSyncImpl: AuthenticationClient {
 
     public func getAuthenticationHeaders() async throws(AuthenticationClientError) -> [String: String] {
         do {
-            return try await authService.authenticationHeaders()
+            let headers = try await authService.authenticationHeaders()
+            guard !headers.isEmpty else {
+                throw AuthenticationClientError.notAuthenticated(underlying: nil)
+            }
+            return headers
+        } catch let error as AuthenticationClientError {
+            throw error
+        } catch let error as MobileSyncAuthenticationError {
+            throw AuthenticationClientError(error)
         } catch {
-            throw AuthenticationClientError.clientIsNotAuthenticated(error)
+            throw .authenticationFailed(underlying: error)
         }
     }
 
     // MARK: Private
 
     private let authService: SyncAuthService
-    private let quranDataService: QuranDataService
+}
+
+private extension AuthenticationClientError {
+    init(_ error: MobileSyncAuthenticationError) {
+        switch error {
+        case .cancelled:
+            self = .cancelled
+        case let .networkFailure(underlyingError):
+            self = .networkFailure(underlying: underlyingError)
+        case let .authenticationFailed(underlyingError):
+            self = .authenticationFailed(underlying: underlyingError)
+        }
+    }
 }
 
 #endif

--- a/Data/AuthenticationClient/Tests/AuthenticationClientMobileSyncTests.swift
+++ b/Data/AuthenticationClient/Tests/AuthenticationClientMobileSyncTests.swift
@@ -26,8 +26,7 @@ final class AuthenticationClientMobileSyncTests: XCTestCase {
             endAyah: 1
         )
         let client = AuthenticationClientMobileSyncImpl(
-            authService: database.authService,
-            quranDataService: database.quranDataService
+            authService: database.authService
         )
 
         try await client.logout()

--- a/Data/AuthenticationClient/Tests/AuthenticationClientTests.swift
+++ b/Data/AuthenticationClient/Tests/AuthenticationClientTests.swift
@@ -17,13 +17,24 @@ final class AuthenticationClientTests: XCTestCase {
 
     func testSafelyRestoreStateReturnsCurrentStateOnFailure() async {
         let sut = AuthenticationClientFake()
-        sut.restoreStateResult = .failure(.clientIsNotAuthenticated(NSError(domain: "test", code: 1)))
+        sut.restoreStateResult = .failure(.notAuthenticated(underlying: NSError(domain: "test", code: 1)))
         sut.authenticationStateValue = .authenticated
 
         let state = await sut.safelyRestoreState()
 
         XCTAssertEqual(state, .authenticated)
         XCTAssertEqual(sut.events, [.restoreState, .readAuthenticationState])
+    }
+
+    func testAuthenticationClientErrorPreservesInspectableUnderlyingError() {
+        let underlyingError = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+        let error = AuthenticationClientError.networkFailure(underlying: underlyingError)
+
+        guard case let .networkFailure(inspectedError) = error else {
+            return XCTFail("Expected networkFailure")
+        }
+        XCTAssertEqual(inspectedError as NSError, underlyingError)
+        XCTAssertEqual(error.underlyingError as NSError?, underlyingError)
     }
 }
 

--- a/Data/AuthenticationClientFake/Sources/AuthenticationClientFake.swift
+++ b/Data/AuthenticationClientFake/Sources/AuthenticationClientFake.swift
@@ -78,7 +78,7 @@ public final class UnavailableAuthenticationClient: AuthenticationClient {
     }
 
     public func login(on _: UIViewController) async throws(AuthenticationClientError) {
-        throw .clientIsNotAuthenticated(UnavailableAuthenticationClientError())
+        throw .notAuthenticated(underlying: nil)
     }
 
     public func restoreState() async throws(AuthenticationClientError) -> AuthenticationState {
@@ -86,18 +86,16 @@ public final class UnavailableAuthenticationClient: AuthenticationClient {
     }
 
     public func logout() async throws(AuthenticationClientError) {
-        throw .clientIsNotAuthenticated(UnavailableAuthenticationClientError())
+        throw .notAuthenticated(underlying: nil)
     }
 
     public func authenticate(request _: URLRequest) async throws(AuthenticationClientError) -> URLRequest {
-        throw .clientIsNotAuthenticated(UnavailableAuthenticationClientError())
+        throw .notAuthenticated(underlying: nil)
     }
 
     public func getAuthenticationHeaders() async throws(AuthenticationClientError) -> [String: String] {
-        throw .clientIsNotAuthenticated(UnavailableAuthenticationClientError())
+        throw .notAuthenticated(underlying: nil)
     }
 }
-
-private struct UnavailableAuthenticationClientError: Error {}
 
 #endif

--- a/Example/QuranEngineApp/Classes/Container.swift
+++ b/Example/QuranEngineApp/Classes/Container.swift
@@ -47,8 +47,7 @@ class Container: AppDependencies {
 
     private(set) lazy var authenticationClient: any AuthenticationClient = {
         let authService = syncAppGraph.authService
-        let quranDataService = syncAppGraph.quranDataService
-        return AuthenticationClientMobileSyncImpl(authService: authService, quranDataService: quranDataService)
+        return AuthenticationClientMobileSyncImpl(authService: authService)
     }()
     #endif
 

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -114,7 +114,9 @@ final class BookmarkCollectionsViewModel: ObservableObject {
 
         do {
             try await authenticationClient.login(on: navigationController)
-            isAuthenticated = true
+            isAuthenticated = await authenticationClient.authenticationState == .authenticated
+        } catch AuthenticationClientError.cancelled {
+            return
         } catch {
             logger.error("Failed to login to Quran.com from bookmarks: \(error)")
             self.error = error

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -228,7 +228,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
 
     func test_start_fallsBackToCurrentState_whenRestoreFails() async {
         let client = AuthenticationClientFake()
-        client.restoreStateResult = .failure(.clientIsNotAuthenticated(NSError(domain: "test", code: 1)))
+        client.restoreStateResult = .failure(.notAuthenticated(underlying: NSError(domain: "test", code: 1)))
         client.authenticationStateValue = .authenticated
         let sut = makeSUT(authenticationClient: client)
 
@@ -241,28 +241,42 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
 
     func test_login_setsAuthenticated_whenLoginSucceeds() async {
         let client = AuthenticationClientFake()
+        client.authenticationStateValue = .authenticated
         let navigationController = UINavigationController()
         let sut = makeSUT(authenticationClient: client, navigationController: navigationController)
 
         await sut.loginToQuranCom()
 
         XCTAssertTrue(sut.isAuthenticated)
-        XCTAssertEqual(client.events, [.login])
+        XCTAssertEqual(client.events, [.login, .readAuthenticationState])
         XCTAssertNil(sut.error)
     }
 
     func test_login_setsError_whenLoginFails() async {
         let client = AuthenticationClientFake()
-        client.loginResult = .failure(.clientIsNotAuthenticated(TestError.loginFailed))
+        client.loginResult = .failure(.authenticationFailed(underlying: TestError.loginFailed))
         let navigationController = UINavigationController()
         let sut = makeSUT(authenticationClient: client, navigationController: navigationController)
 
         await sut.loginToQuranCom()
 
         XCTAssertFalse(sut.isAuthenticated)
-        guard case .clientIsNotAuthenticated = sut.error as? AuthenticationClientError else {
-            return XCTFail("Expected clientIsNotAuthenticated, got \(String(describing: sut.error))")
+        guard case .authenticationFailed = sut.error as? AuthenticationClientError else {
+            return XCTFail("Expected authenticationFailed, got \(String(describing: sut.error))")
         }
+    }
+
+    func test_login_ignoresCancellation() async {
+        let client = AuthenticationClientFake()
+        client.loginResult = .failure(.cancelled)
+        let navigationController = UINavigationController()
+        let sut = makeSUT(authenticationClient: client, navigationController: navigationController)
+
+        await sut.loginToQuranCom()
+
+        XCTAssertFalse(sut.isAuthenticated)
+        XCTAssertEqual(client.events, [.login])
+        XCTAssertNil(sut.error)
     }
 
     func test_dismissSyncBanner_persistsDismissal() {

--- a/Features/NotesFeature/Sources/NotesViewModel.swift
+++ b/Features/NotesFeature/Sources/NotesViewModel.swift
@@ -132,7 +132,9 @@ final class NotesViewModel: ObservableObject {
 
         do {
             try await authenticationClient.login(on: navigationController)
-            isAuthenticated = true
+            isAuthenticated = await authenticationClient.authenticationState == .authenticated
+        } catch AuthenticationClientError.cancelled {
+            return
         } catch {
             logger.error("Failed to login to Quran.com from notes: \(error)")
             self.error = error

--- a/Features/NotesFeature/Tests/NotesViewModelTests.swift
+++ b/Features/NotesFeature/Tests/NotesViewModelTests.swift
@@ -114,26 +114,39 @@ final class NotesViewModelTests: XCTestCase {
 
     func test_login_setsAuthenticated_whenLoginSucceeds() async {
         let client = AuthenticationClientFake()
+        client.authenticationStateValue = .authenticated
         let sut = makeSUT(authenticationClient: client)
 
         await sut.loginToQuranCom()
 
         XCTAssertTrue(sut.isAuthenticated)
-        XCTAssertEqual(client.events, [.login])
+        XCTAssertEqual(client.events, [.login, .readAuthenticationState])
         XCTAssertNil(sut.error)
     }
 
     func test_login_setsError_whenLoginFails() async {
         let client = AuthenticationClientFake()
-        client.loginResult = .failure(.clientIsNotAuthenticated(TestError.loginFailed))
+        client.loginResult = .failure(.authenticationFailed(underlying: TestError.loginFailed))
         let sut = makeSUT(authenticationClient: client)
 
         await sut.loginToQuranCom()
 
         XCTAssertFalse(sut.isAuthenticated)
-        guard case .clientIsNotAuthenticated = sut.error as? AuthenticationClientError else {
-            return XCTFail("Expected clientIsNotAuthenticated, got \(String(describing: sut.error))")
+        guard case .authenticationFailed = sut.error as? AuthenticationClientError else {
+            return XCTFail("Expected authenticationFailed, got \(String(describing: sut.error))")
         }
+    }
+
+    func test_login_ignoresCancellation() async {
+        let client = AuthenticationClientFake()
+        client.loginResult = .failure(.cancelled)
+        let sut = makeSUT(authenticationClient: client)
+
+        await sut.loginToQuranCom()
+
+        XCTAssertFalse(sut.isAuthenticated)
+        XCTAssertEqual(client.events, [.login])
+        XCTAssertNil(sut.error)
     }
 
     func test_dismissSyncBanner_persistsDismissal() {

--- a/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
@@ -210,8 +210,10 @@ final class SettingsRootViewModel: ObservableObject {
 
         do {
             try await authenticationClient.login(on: viewController)
-            isAuthenticated = true
-            loggedInUser = await authenticationClient.loggedInUser
+            isAuthenticated = await authenticationClient.authenticationState == .authenticated
+            loggedInUser = isAuthenticated ? await authenticationClient.loggedInUser : nil
+        } catch AuthenticationClientError.cancelled {
+            return
         } catch {
             logger.error("Failed to login to Quran.com: \(error)")
             self.error = error

--- a/Features/SettingsFeature/Tests/SettingsRootViewModelTests.swift
+++ b/Features/SettingsFeature/Tests/SettingsRootViewModelTests.swift
@@ -48,7 +48,7 @@ final class SettingsRootViewModelTests: XCTestCase {
 
     func test_refreshAuthenticationState_fallsBackToCurrentState_whenRestoreFails() async {
         let client = AuthenticationClientFake()
-        client.restoreStateResult = .failure(.clientIsNotAuthenticated(NSError(domain: "test", code: 1)))
+        client.restoreStateResult = .failure(.notAuthenticated(underlying: NSError(domain: "test", code: 1)))
         client.authenticationStateValue = .authenticated
         client.loggedInUserValue = makeUser(email: "user@example.com")
         let sut = makeSUT(authenticationClient: client)
@@ -62,6 +62,7 @@ final class SettingsRootViewModelTests: XCTestCase {
 
     func test_login_updatesAuthenticationStateAndEmail() async {
         let client = AuthenticationClientFake()
+        client.authenticationStateValue = .authenticated
         client.loggedInUserValue = makeUser(email: "user@example.com")
         let navigationController = UINavigationController()
         let sut = makeSUT(authenticationClient: client, navigationController: navigationController)
@@ -70,7 +71,34 @@ final class SettingsRootViewModelTests: XCTestCase {
 
         XCTAssertTrue(sut.isAuthenticated)
         XCTAssertEqual(sut.currentUserEmail, "user@example.com")
-        XCTAssertEqual(client.events, [.login, .readLoggedInUser])
+        XCTAssertEqual(client.events, [.login, .readAuthenticationState, .readLoggedInUser])
+        XCTAssertNil(sut.error)
+    }
+
+    func test_login_doesNotSetErrorWhenLoginCompletesWithoutAuthentication() async {
+        let client = AuthenticationClientFake()
+        let navigationController = UINavigationController()
+        let sut = makeSUT(authenticationClient: client, navigationController: navigationController)
+
+        await sut.loginToQuranCom()
+
+        XCTAssertFalse(sut.isAuthenticated)
+        XCTAssertNil(sut.currentUserEmail)
+        XCTAssertEqual(client.events, [.login, .readAuthenticationState])
+        XCTAssertNil(sut.error)
+    }
+
+    func test_login_doesNotSetErrorWhenUserCancels() async {
+        let client = AuthenticationClientFake()
+        client.loginResult = .failure(.cancelled)
+        let navigationController = UINavigationController()
+        let sut = makeSUT(authenticationClient: client, navigationController: navigationController)
+
+        await sut.loginToQuranCom()
+
+        XCTAssertFalse(sut.isAuthenticated)
+        XCTAssertNil(sut.currentUserEmail)
+        XCTAssertEqual(client.events, [.login])
         XCTAssertNil(sut.error)
     }
 
@@ -128,8 +156,8 @@ final class SettingsRootViewModelTests: XCTestCase {
     }
 
     private func assertClientIsNotAuthenticated(_ error: Error?, file: StaticString = #filePath, line: UInt = #line) {
-        guard case .clientIsNotAuthenticated = error as? AuthenticationClientError else {
-            return XCTFail("Expected clientIsNotAuthenticated, got \(String(describing: error))", file: file, line: line)
+        guard case .notAuthenticated = error as? AuthenticationClientError else {
+            return XCTFail("Expected notAuthenticated, got \(String(describing: error))", file: file, line: line)
         }
     }
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quran/mobile-sync-spm.git",
       "state" : {
-        "revision" : "8a7b6bf0acacb32d2759cdc3fc13e92fbbfcc47d",
-        "version" : "0.1.17"
+        "revision" : "e76b8ebc4cc4170b1567bee268dbe2abf088bb8d",
+        "version" : "0.1.18"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let mobileSyncPackageDependency: Package.Dependency = {
     if let localMobileSyncPackagePath, !localMobileSyncPackagePath.isEmpty {
         return .package(path: localMobileSyncPackagePath)
     }
-    return .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.16")
+    return .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.18")
 }()
 
 let mobileSyncPackageDependencies: [Package.Dependency] =


### PR DESCRIPTION
## Summary

- replace generic authentication failures with inspectable `AuthenticationClientError` cases
- distinguish cancellation, unauthenticated state, network failure, and authentication failure
- map the typed MobileSync Swift errors while preserving underlying errors
- silently handle expected OAuth cancellation in Settings, Notes, and Bookmarks
- read the actual authentication state after the interactive flow instead of assuming success
- route logout through the typed authentication service
- consume the released `mobile-sync-spm` `v0.1.18` package

## Root cause

The system consent Cancel action and the web authentication sheet dismissal produce different low-level OAuth errors. Both were wrapped as generic authentication failures, so feature view models treated expected user cancellation as an actionable error and presented an alert.

Separately, provider-session logout used `ASWebAuthenticationSession`, which caused iOS to show a sign-in consent dialog during sign-out. quran/mobile-sync#238 makes normal logout non-interactive while retaining local clearing and refresh-token revocation.

## Related PRs and release order

- quran/mobile-sync#237 — Kotlin typed authentication exceptions (merged)
- quran/mobile-sync#238 — silent native logout (merged)
- quran/mobile-sync-spm#18 — Swift typed-error bridge (merged and tagged `v0.1.18`)
- quran/quran-ios#950 — application handling and cancellation UX (this PR)

The upstream releases are complete. This PR updates the published Swift package dependency from `0.1.16` to `0.1.18` and resolves `Package.resolved` to the `v0.1.18` revision.

Required order:

1. Verify the published-dependency sync and no-sync gates.
2. Merge this PR.

## Validation

- `mobile-sync-spm` release wrapper `30910526977` completed successfully
- published-dependency `make test-sync TARGET=AuthenticationClientTests`: 4 tests passed
- published-dependency `make test-no-sync TARGET=AuthenticationClientTests`: build/test command succeeded
- full `make test-sync-local-debug` test plan passed previously
- full `make test-no-sync` test plan passed previously
- `make format-lint` passed previously
- iOS Simulator verified both cancellation paths return silently without an error alert
