### PR TITLE
feat(sync): add analytics and logging

### DIFF
--- a/Domain/AnnotationsService/Sources/AnalyticsLibrary+Events.swift
+++ b/Domain/AnnotationsService/Sources/AnalyticsLibrary+Events.swift
@@ -16,15 +16,15 @@ extension AnalyticsLibrary {
         logEvent(name, value: verses.count.description)
     }
 
-    func highlight(verses: [AyahNumber]) {
+    public func highlight(verses: [AyahNumber]) {
         logVersesEvent("HighlightVersesNum", verses: verses)
     }
 
-    func unhighlight(verses: some Collection<AyahNumber>) {
+    public func unhighlight(verses: some Collection<AyahNumber>) {
         logVersesEvent("UnhighlightVersesNum", verses: verses)
     }
 
-    func updateNote(verses: Set<AyahNumber>) {
+    public func updateNote(verses: Set<AyahNumber>) {
         logVersesEvent("UpdateNoteVersesNum", verses: verses)
     }
 }

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsBuilder.swift
@@ -29,6 +29,7 @@ public struct BookmarkAyahsBuilder {
             verses: verses,
             collections: collections,
             highlights: highlights,
+            analytics: container.analytics,
             ayahBookmarkCollectionService: container.ayahBookmarkCollectionService(),
             ayahHighlightService: container.ayahHighlightService()
         )

--- a/Features/BookmarksFeature/Sources/BookmarkAyahsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkAyahsViewModel.swift
@@ -3,6 +3,7 @@
 //  BookmarkAyahsViewModel.swift
 //
 
+import Analytics
 import AnnotationsService
 import Combine
 import Foundation
@@ -30,10 +31,12 @@ final class BookmarkAyahsViewModel: ObservableObject {
         verses: [AyahNumber],
         collections: [AyahBookmarkCollection],
         highlights: [AyahNumber: HighlightColor] = [:],
+        analytics: AnalyticsLibrary,
         ayahBookmarkCollectionService: AyahBookmarkCollectionService,
         ayahHighlightService: MobileSyncAyahHighlightService
     ) {
         self.verses = Self.unique(verses)
+        self.analytics = analytics
         self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
         self.ayahHighlightService = ayahHighlightService
         updateCollections(collections)
@@ -91,9 +94,11 @@ final class BookmarkAyahsViewModel: ObservableObject {
         do {
             if let color {
                 try await ayahHighlightService.setHighlight(color, for: verses)
+                analytics.highlight(verses: verses)
                 HighlightPreferences.shared.lastUsedHighlightColor = color
             } else {
                 try await ayahHighlightService.removeHighlight(for: verses)
+                analytics.unhighlight(verses: verses)
             }
         } catch is CancellationError {
             highlightSelection = previousSelection
@@ -134,6 +139,7 @@ final class BookmarkAyahsViewModel: ObservableObject {
             case .unselected:
                 try await ayahBookmarkCollectionService.removeAyahs(verses, fromCollectionWithID: id)
             }
+            logger.info("Quran Sync: updated bookmark collection membership for \(verses.count) ayah(s)")
         } catch is CancellationError {
             collectionSelections[id] = previousSelection
         } catch {
@@ -163,6 +169,7 @@ final class BookmarkAyahsViewModel: ObservableObject {
             newCollectionName = ""
             isPresentingAddCollection = false
         } catch {
+            logger.error("Quran Sync: failed to create bookmark collection: \(error)")
             self.error = error
         }
     }
@@ -171,6 +178,7 @@ final class BookmarkAyahsViewModel: ObservableObject {
 
     private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
     private let ayahHighlightService: MobileSyncAyahHighlightService
+    private let analytics: AnalyticsLibrary
 
     private func updateCollections(_ collections: [AyahBookmarkCollection]) {
         let collections = BookmarkCollectionsViewModel.sorted(collections)
@@ -213,6 +221,7 @@ final class BookmarkAyahsViewModel: ObservableObject {
             }
         } catch {
             guard !Task.isCancelled else { return }
+            logger.error("Quran Sync: failed to observe collections in bookmark editor: \(error)")
             self.error = error
         }
     }
@@ -225,6 +234,7 @@ final class BookmarkAyahsViewModel: ObservableObject {
             }
         } catch {
             guard !Task.isCancelled else { return }
+            logger.error("Quran Sync: failed to observe highlights in bookmark editor: \(error)")
             self.error = error
         }
     }

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsBuilder.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsBuilder.swift
@@ -28,6 +28,7 @@ struct BookmarkCollectionsBuilder {
             }
         )
         let viewModel = BookmarkCollectionsViewModel(
+            analytics: container.analytics,
             authenticationClient: container.authenticationClient,
             ayahBookmarkCollectionService: collectionService,
             ayahHighlightService: highlightService,

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -3,9 +3,11 @@
 //  BookmarkCollectionsViewModel.swift
 //
 
+import Analytics
 import AnnotationsService
 import AuthenticationClient
 import Combine
+import FeaturesSupport
 import Foundation
 import QuranAnnotations
 import QuranKit
@@ -19,6 +21,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     // MARK: Lifecycle
 
     init(
+        analytics: AnalyticsLibrary,
         authenticationClient: any AuthenticationClient,
         ayahBookmarkCollectionService: AyahBookmarkCollectionService,
         ayahHighlightService: MobileSyncAyahHighlightService,
@@ -28,6 +31,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         navigateToPage: @escaping (Page) -> Void,
         navigateToAyah: @escaping (AyahNumber) -> Void
     ) {
+        self.analytics = analytics
         self.authenticationClient = authenticationClient
         self.ayahBookmarkCollectionService = ayahBookmarkCollectionService
         self.ayahHighlightService = ayahHighlightService
@@ -104,6 +108,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         async let observeHighlights: Void = observeHighlights()
         async let observeReadingBookmark: Void = observeReadingBookmark()
         isAuthenticated = await authenticationClient.safelyRestoreState() == .authenticated
+        logger.info("Quran Sync: restored authentication from Bookmarks. Authenticated: \(isAuthenticated)")
         _ = await (observeCollections, observeHighlights, observeReadingBookmark)
     }
 
@@ -112,10 +117,14 @@ final class BookmarkCollectionsViewModel: ObservableObject {
             return
         }
 
+        analytics.quranSyncSignIn(from: .bookmarks)
+        logger.info("Quran Sync: starting sign in from Bookmarks")
         do {
             try await authenticationClient.login(on: navigationController)
             isAuthenticated = await authenticationClient.authenticationState == .authenticated
+            logger.info("Quran Sync: sign in completed from Bookmarks. Authenticated: \(isAuthenticated)")
         } catch AuthenticationClientError.cancelled {
+            logger.info("Quran Sync: sign in cancelled from Bookmarks")
             return
         } catch {
             logger.error("Failed to login to Quran.com from bookmarks: \(error)")
@@ -124,6 +133,8 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     }
 
     func dismissSyncBanner() {
+        analytics.quranSyncSignInBannerDismissed(from: .bookmarks)
+        logger.info("Quran Sync: sign-in banner dismissed from Bookmarks")
         isSyncBannerDismissed = true
         preferences.isCollectionsSyncBannerDismissed = true
     }
@@ -142,6 +153,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         do {
             try await ayahBookmarkCollectionService.createCollection(named: name)
         } catch {
+            logger.error("Quran Sync: failed to create bookmark collection: \(error)")
             self.error = error
         }
     }
@@ -164,6 +176,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
         do {
             try await ayahBookmarkCollectionService.removeCollection(id: collection.collection.id)
         } catch {
+            logger.error("Quran Sync: failed to remove bookmark collection: \(error)")
             self.error = error
         }
     }
@@ -201,6 +214,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
 
     // MARK: Private
 
+    private let analytics: AnalyticsLibrary
     private let authenticationClient: any AuthenticationClient
     private let ayahBookmarkCollectionService: AyahBookmarkCollectionService
     private let ayahHighlightService: MobileSyncAyahHighlightService
@@ -229,6 +243,8 @@ final class BookmarkCollectionsViewModel: ObservableObject {
                 self.highlights = highlights
             }
         } catch {
+            guard !Task.isCancelled else { return }
+            logger.error("Quran Sync: failed to observe highlights in Bookmarks: \(error)")
             self.error = error
         }
     }
@@ -243,6 +259,8 @@ final class BookmarkCollectionsViewModel: ObservableObject {
                 }
             }
         } catch {
+            guard !Task.isCancelled else { return }
+            logger.error("Quran Sync: failed to observe collections in Bookmarks: \(error)")
             self.error = error
         }
     }
@@ -267,6 +285,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
                     return
                 } catch {
                     guard !Task.isCancelled else { return }
+                    logger.error("Quran Sync: failed to observe reading bookmark in Bookmarks: \(error)")
                     self?.error = error
                 }
             }

--- a/Features/BookmarksFeature/Tests/BookmarkAyahsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkAyahsViewModelTests.swift
@@ -1,4 +1,5 @@
 #if QURAN_SYNC
+import Analytics
 import MobileSync
 import MobileSyncTestSupport
 import NoorUI
@@ -24,10 +25,12 @@ final class BookmarkAyahsViewModelTests: XCTestCase {
 
     func test_selectingHighlightImmediatelyPersistsAcrossSuras() async throws {
         let fixture = try await makeFixture()
+        let analytics = AnalyticsRecorder()
         let sut = BookmarkAyahsViewModel(
             verses: verses,
             collections: fixture.collections,
             highlights: fixture.highlights,
+            analytics: analytics,
             ayahBookmarkCollectionService: fixture.collectionService,
             ayahHighlightService: fixture.highlightService
         )
@@ -38,6 +41,7 @@ final class BookmarkAyahsViewModelTests: XCTestCase {
         XCTAssertEqual(stored[verses[0]], .green)
         XCTAssertEqual(stored[verses[1]], .green)
         XCTAssertEqual(sut.highlightSelection, .color(.green))
+        XCTAssertEqual(analytics.events, [.init(name: "HighlightVersesNum", value: "2")])
     }
 
     func test_togglingMixedCollectionImmediatelyAddsAllSelectedAyahs() async throws {
@@ -46,6 +50,7 @@ final class BookmarkAyahsViewModelTests: XCTestCase {
             verses: verses,
             collections: fixture.collections,
             highlights: fixture.highlights,
+            analytics: AnalyticsRecorder(),
             ayahBookmarkCollectionService: fixture.collectionService,
             ayahHighlightService: fixture.highlightService
         )
@@ -61,10 +66,12 @@ final class BookmarkAyahsViewModelTests: XCTestCase {
 
     func test_removingHighlightImmediatelyRemovesSelectedAyahs() async throws {
         let fixture = try await makeFixture()
+        let analytics = AnalyticsRecorder()
         let sut = BookmarkAyahsViewModel(
             verses: verses,
             collections: fixture.collections,
             highlights: fixture.highlights,
+            analytics: analytics,
             ayahBookmarkCollectionService: fixture.collectionService,
             ayahHighlightService: fixture.highlightService
         )
@@ -74,6 +81,7 @@ final class BookmarkAyahsViewModelTests: XCTestCase {
         XCTAssertNil(stored[verses[0]])
         XCTAssertNil(stored[verses[1]])
         XCTAssertEqual(sut.highlightSelection, .none)
+        XCTAssertEqual(analytics.events, [.init(name: "UnhighlightVersesNum", value: "2")])
     }
 
     func test_mixedHighlightSelectionCanBeRemoved() async throws {
@@ -83,6 +91,7 @@ final class BookmarkAyahsViewModelTests: XCTestCase {
             verses: verses,
             collections: fixture.collections,
             highlights: try await storedHighlights(),
+            analytics: AnalyticsRecorder(),
             ayahBookmarkCollectionService: fixture.collectionService,
             ayahHighlightService: fixture.highlightService
         )
@@ -103,6 +112,7 @@ final class BookmarkAyahsViewModelTests: XCTestCase {
             verses: verses,
             collections: fixture.collections,
             highlights: try await storedHighlights(),
+            analytics: AnalyticsRecorder(),
             ayahBookmarkCollectionService: fixture.collectionService,
             ayahHighlightService: fixture.highlightService
         )
@@ -189,6 +199,19 @@ final class BookmarkAyahsViewModelTests: XCTestCase {
             $0.collection.name.caseInsensitiveCompare(name) == .orderedSame
         }
         return Set(collection?.bookmarks.map { "\($0.sura):\($0.ayah)" } ?? [])
+    }
+}
+
+private struct AnalyticsEvent: Equatable {
+    let name: String
+    let value: String
+}
+
+private final class AnalyticsRecorder: AnalyticsLibrary, @unchecked Sendable {
+    private(set) var events: [AnalyticsEvent] = []
+
+    func logEvent(_ name: String, value: String) {
+        events.append(.init(name: name, value: value))
     }
 }
 #endif

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -1,4 +1,5 @@
 #if QURAN_SYNC
+import Analytics
 import AuthenticationClient
 import AuthenticationClientFake
 import Combine
@@ -242,13 +243,19 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
     func test_login_setsAuthenticated_whenLoginSucceeds() async {
         let client = AuthenticationClientFake()
         client.authenticationStateValue = .authenticated
+        let analytics = AnalyticsRecorder()
         let navigationController = UINavigationController()
-        let sut = makeSUT(authenticationClient: client, navigationController: navigationController)
+        let sut = makeSUT(
+            analytics: analytics,
+            authenticationClient: client,
+            navigationController: navigationController
+        )
 
         await sut.loginToQuranCom()
 
         XCTAssertTrue(sut.isAuthenticated)
         XCTAssertEqual(client.events, [.login, .readAuthenticationState])
+        XCTAssertEqual(analytics.events, [.init(name: "QuranSyncSignIn", value: "bookmarks")])
         XCTAssertNil(sut.error)
     }
 
@@ -280,13 +287,18 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
     }
 
     func test_dismissSyncBanner_persistsDismissal() {
-        let sut = makeSUT()
+        let analytics = AnalyticsRecorder()
+        let sut = makeSUT(analytics: analytics)
 
         sut.dismissSyncBanner()
 
         XCTAssertTrue(sut.isSyncBannerDismissed)
         XCTAssertTrue(AuthenticationPreferences.shared.isCollectionsSyncBannerDismissed)
         XCTAssertFalse(sut.shouldShowSyncBanner)
+        XCTAssertEqual(
+            analytics.events,
+            [.init(name: "QuranSyncSignInBannerDismissed", value: "bookmarks")]
+        )
     }
 
     func test_createPendingCollection_persistsThroughRealMobileSyncDatabase() async throws {
@@ -470,6 +482,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
     }
 
     private func makeSUT(
+        analytics: AnalyticsLibrary = AnalyticsRecorder(),
         authenticationClient: any AuthenticationClient = UnavailableAuthenticationClient(),
         collectionService: AyahBookmarkCollectionService? = nil,
         readingBookmarkService: MobileSyncReadingBookmarkService? = nil,
@@ -487,6 +500,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
             navigateToAyah: { _ in }
         )
         return BookmarkCollectionsViewModel(
+            analytics: analytics,
             authenticationClient: authenticationClient,
             ayahBookmarkCollectionService: collectionService,
             ayahHighlightService: makeHighlightService(),
@@ -586,5 +600,18 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
 private enum TestError: Error, Equatable {
     case collectionNotFound
     case loginFailed
+}
+
+private struct AnalyticsEvent: Equatable {
+    let name: String
+    let value: String
+}
+
+private final class AnalyticsRecorder: AnalyticsLibrary, @unchecked Sendable {
+    private(set) var events: [AnalyticsEvent] = []
+
+    func logEvent(_ name: String, value: String) {
+        events.append(.init(name: name, value: value))
+    }
 }
 #endif

--- a/Features/FeaturesSupport/Sources/QuranSyncAnalytics.swift
+++ b/Features/FeaturesSupport/Sources/QuranSyncAnalytics.swift
@@ -1,0 +1,23 @@
+#if QURAN_SYNC
+import Analytics
+
+public enum QuranSyncAuthenticationSource: String, Sendable {
+    case bookmarks
+    case notes
+    case settings
+}
+
+public extension AnalyticsLibrary {
+    func quranSyncSignIn(from source: QuranSyncAuthenticationSource) {
+        logEvent("QuranSyncSignIn", value: source.rawValue)
+    }
+
+    func quranSyncSignOut(from source: QuranSyncAuthenticationSource) {
+        logEvent("QuranSyncSignOut", value: source.rawValue)
+    }
+
+    func quranSyncSignInBannerDismissed(from source: QuranSyncAuthenticationSource) {
+        logEvent("QuranSyncSignInBannerDismissed", value: source.rawValue)
+    }
+}
+#endif

--- a/Features/NotesFeature/Sources/NotesBuilder.swift
+++ b/Features/NotesFeature/Sources/NotesBuilder.swift
@@ -41,6 +41,7 @@ public struct NotesBuilder {
         #if QURAN_SYNC
         let noteService = container.mobileSyncNoteService()
         let viewModel = NotesViewModel(
+            analytics: container.analytics,
             authenticationClient: container.authenticationClient,
             navigationController: navigationController,
             noteService: noteService,

--- a/Features/NotesFeature/Sources/NotesViewModel.swift
+++ b/Features/NotesFeature/Sources/NotesViewModel.swift
@@ -9,7 +9,9 @@
 import Analytics
 import Combine
 #else
+import Analytics
 import AuthenticationClient
+import FeaturesSupport
 #endif
 import AnnotationsService
 import Crashing
@@ -31,6 +33,7 @@ final class NotesViewModel: ObservableObject {
 
     #if QURAN_SYNC
     init(
+        analytics: AnalyticsLibrary,
         authenticationClient: any AuthenticationClient,
         navigationController: UINavigationController,
         noteService: MobileSyncNoteService,
@@ -39,6 +42,7 @@ final class NotesViewModel: ObservableObject {
         navigateTo: @escaping (AyahNumber) -> Void,
         editNote: @escaping (Note) -> Void
     ) {
+        self.analytics = analytics
         self.authenticationClient = authenticationClient
         self.navigationController = navigationController
         self.noteService = noteService
@@ -100,12 +104,15 @@ final class NotesViewModel: ObservableObject {
     func start() async {
         #if QURAN_SYNC
         isAuthenticated = await authenticationClient.safelyRestoreState() == .authenticated
+        logger.info("Quran Sync: restored authentication from Notes. Authenticated: \(isAuthenticated)")
         do {
             let sequence = noteService.notesSequence(quran: readingPreferences.reading.quran)
             for try await notes in sequence {
                 self.notes = await noteItems(with: notes)
             }
         } catch {
+            guard !Task.isCancelled else { return }
+            logger.error("Quran Sync: failed to observe notes: \(error)")
             self.error = error
         }
         #else
@@ -130,10 +137,14 @@ final class NotesViewModel: ObservableObject {
             return
         }
 
+        analytics.quranSyncSignIn(from: .notes)
+        logger.info("Quran Sync: starting sign in from Notes")
         do {
             try await authenticationClient.login(on: navigationController)
             isAuthenticated = await authenticationClient.authenticationState == .authenticated
+            logger.info("Quran Sync: sign in completed from Notes. Authenticated: \(isAuthenticated)")
         } catch AuthenticationClientError.cancelled {
+            logger.info("Quran Sync: sign in cancelled from Notes")
             return
         } catch {
             logger.error("Failed to login to Quran.com from notes: \(error)")
@@ -142,6 +153,8 @@ final class NotesViewModel: ObservableObject {
     }
 
     func dismissSyncBanner() {
+        analytics.quranSyncSignInBannerDismissed(from: .notes)
+        logger.info("Quran Sync: sign-in banner dismissed from Notes")
         isSyncBannerDismissed = true
         preferences.isNotesSyncBannerDismissed = true
     }
@@ -159,9 +172,11 @@ final class NotesViewModel: ObservableObject {
 
     func deleteItem(_ item: NoteItem) async {
         #if QURAN_SYNC
+        logger.info("Quran Sync: deleting note spanning \(item.note.verses.count) ayah(s)")
         do {
             try await noteService.removeNote(item.note)
         } catch {
+            logger.error("Quran Sync: failed to delete note: \(error)")
             self.error = error
         }
         #else
@@ -208,13 +223,13 @@ final class NotesViewModel: ObservableObject {
 
     // MARK: Private
 
+    private let analytics: AnalyticsLibrary
     #if QURAN_SYNC
     private let authenticationClient: any AuthenticationClient
     private let noteService: MobileSyncNoteService
     private weak var navigationController: UINavigationController?
     private let preferences = AuthenticationPreferences.shared
     #else
-    private let analytics: AnalyticsLibrary
     private let noteService: NoteService
     #endif
     private let textService: QuranTextDataService

--- a/Features/NotesFeature/Tests/NotesViewModelTests.swift
+++ b/Features/NotesFeature/Tests/NotesViewModelTests.swift
@@ -1,4 +1,5 @@
 #if QURAN_SYNC
+import Analytics
 import AnnotationsService
 import AuthenticationClient
 import AuthenticationClientFake
@@ -42,6 +43,7 @@ final class NotesViewModelTests: XCTestCase {
         let item = NoteItem(note: note, quranText: "Verse")
         let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-quran-database")
         let sut = NotesViewModel(
+            analytics: AnalyticsRecorder(),
             authenticationClient: UnavailableAuthenticationClient(),
             navigationController: UINavigationController(),
             noteService: noteService,
@@ -69,6 +71,7 @@ final class NotesViewModelTests: XCTestCase {
         try await noteService.createNote(body: "Observed note", startAyah: ayah, endAyah: ayah)
         let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-quran-database")
         let sut = NotesViewModel(
+            analytics: AnalyticsRecorder(),
             authenticationClient: UnavailableAuthenticationClient(),
             navigationController: UINavigationController(),
             noteService: noteService,
@@ -115,12 +118,14 @@ final class NotesViewModelTests: XCTestCase {
     func test_login_setsAuthenticated_whenLoginSucceeds() async {
         let client = AuthenticationClientFake()
         client.authenticationStateValue = .authenticated
-        let sut = makeSUT(authenticationClient: client)
+        let analytics = AnalyticsRecorder()
+        let sut = makeSUT(analytics: analytics, authenticationClient: client)
 
         await sut.loginToQuranCom()
 
         XCTAssertTrue(sut.isAuthenticated)
         XCTAssertEqual(client.events, [.login, .readAuthenticationState])
+        XCTAssertEqual(analytics.events, [.init(name: "QuranSyncSignIn", value: "notes")])
         XCTAssertNil(sut.error)
     }
 
@@ -150,13 +155,18 @@ final class NotesViewModelTests: XCTestCase {
     }
 
     func test_dismissSyncBanner_persistsDismissal() {
-        let sut = makeSUT()
+        let analytics = AnalyticsRecorder()
+        let sut = makeSUT(analytics: analytics)
 
         sut.dismissSyncBanner()
 
         XCTAssertTrue(sut.isSyncBannerDismissed)
         XCTAssertTrue(AuthenticationPreferences.shared.isNotesSyncBannerDismissed)
         XCTAssertFalse(sut.shouldShowSyncBanner)
+        XCTAssertEqual(
+            analytics.events,
+            [.init(name: "QuranSyncSignInBannerDismissed", value: "notes")]
+        )
     }
 
     func test_prepareNotesForSharing_usesShareableVerseText() async throws {
@@ -170,6 +180,7 @@ final class NotesViewModelTests: XCTestCase {
         )
         let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-translations-database")
         let sut = NotesViewModel(
+            analytics: AnalyticsRecorder(),
             authenticationClient: UnavailableAuthenticationClient(),
             navigationController: UINavigationController(),
             noteService: noteService,
@@ -207,6 +218,7 @@ final class NotesViewModelTests: XCTestCase {
         let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-quran-database")
         var navigatedAyah: AyahNumber?
         let sut = NotesViewModel(
+            analytics: AnalyticsRecorder(),
             authenticationClient: UnavailableAuthenticationClient(),
             navigationController: UINavigationController(),
             noteService: noteService,
@@ -233,10 +245,12 @@ final class NotesViewModelTests: XCTestCase {
     }
 
     private func makeSUT(
+        analytics: AnalyticsLibrary = AnalyticsRecorder(),
         authenticationClient: any AuthenticationClient = UnavailableAuthenticationClient()
     ) -> NotesViewModel {
         let unavailableDatabase = URL(fileURLWithPath: "/tmp/unavailable-quran-database")
         return NotesViewModel(
+            analytics: analytics,
             authenticationClient: authenticationClient,
             navigationController: navigationController,
             noteService: noteService,
@@ -271,5 +285,18 @@ final class NotesViewModelTests: XCTestCase {
 
 private enum TestError: Error {
     case loginFailed
+}
+
+private struct AnalyticsEvent: Equatable {
+    let name: String
+    let value: String
+}
+
+private final class AnalyticsRecorder: AnalyticsLibrary, @unchecked Sendable {
+    private(set) var events: [AnalyticsEvent] = []
+
+    func logEvent(_ name: String, value: String) {
+        events.append(.init(name: name, value: value))
+    }
 }
 #endif

--- a/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
+++ b/Features/SettingsFeature/Sources/SettingsRootViewModel.swift
@@ -8,6 +8,7 @@
 import Analytics
 import AudioDownloadsFeature
 import Combine
+import FeaturesSupport
 import Localization
 #if QURAN_SYNC
 import AuthenticationClient
@@ -201,6 +202,7 @@ final class SettingsRootViewModel: ObservableObject {
     func refreshAuthenticationState() async {
         isAuthenticated = await authenticationClient.safelyRestoreState() == .authenticated
         loggedInUser = isAuthenticated ? await authenticationClient.loggedInUser : nil
+        logger.info("Quran Sync: restored authentication from Settings. Authenticated: \(isAuthenticated)")
     }
 
     func loginToQuranCom() async {
@@ -208,11 +210,15 @@ final class SettingsRootViewModel: ObservableObject {
             return
         }
 
+        analytics.quranSyncSignIn(from: .settings)
+        logger.info("Quran Sync: starting sign in from Settings")
         do {
             try await authenticationClient.login(on: viewController)
             isAuthenticated = await authenticationClient.authenticationState == .authenticated
             loggedInUser = isAuthenticated ? await authenticationClient.loggedInUser : nil
+            logger.info("Quran Sync: sign in completed from Settings. Authenticated: \(isAuthenticated)")
         } catch AuthenticationClientError.cancelled {
+            logger.info("Quran Sync: sign in cancelled from Settings")
             return
         } catch {
             logger.error("Failed to login to Quran.com: \(error)")
@@ -221,10 +227,13 @@ final class SettingsRootViewModel: ObservableObject {
     }
 
     func logoutFromQuranCom() async {
+        analytics.quranSyncSignOut(from: .settings)
+        logger.info("Quran Sync: starting sign out from Settings")
         do {
             try await authenticationClient.logout()
             isAuthenticated = false
             loggedInUser = nil
+            logger.info("Quran Sync: sign out succeeded from Settings")
         } catch {
             logger.error("Failed to logout from Quran.com: \(error)")
             self.error = error

--- a/Features/SettingsFeature/Tests/SettingsRootViewModelTests.swift
+++ b/Features/SettingsFeature/Tests/SettingsRootViewModelTests.swift
@@ -63,15 +63,21 @@ final class SettingsRootViewModelTests: XCTestCase {
     func test_login_updatesAuthenticationStateAndEmail() async {
         let client = AuthenticationClientFake()
         client.authenticationStateValue = .authenticated
+        let analytics = AnalyticsRecorder()
         client.loggedInUserValue = makeUser(email: "user@example.com")
         let navigationController = UINavigationController()
-        let sut = makeSUT(authenticationClient: client, navigationController: navigationController)
+        let sut = makeSUT(
+            analytics: analytics,
+            authenticationClient: client,
+            navigationController: navigationController
+        )
 
         await sut.loginToQuranCom()
 
         XCTAssertTrue(sut.isAuthenticated)
         XCTAssertEqual(sut.currentUserEmail, "user@example.com")
         XCTAssertEqual(client.events, [.login, .readAuthenticationState, .readLoggedInUser])
+        XCTAssertEqual(analytics.events, [.init(name: "QuranSyncSignIn", value: "settings")])
         XCTAssertNil(sut.error)
     }
 
@@ -113,8 +119,9 @@ final class SettingsRootViewModelTests: XCTestCase {
 
     func test_logout_clearsAuthenticationStateAndEmail() async {
         let client = AuthenticationClientFake()
+        let analytics = AnalyticsRecorder()
         client.loggedInUserValue = makeUser(email: "user@example.com")
-        let sut = makeSUT(authenticationClient: client)
+        let sut = makeSUT(analytics: analytics, authenticationClient: client)
         sut.isAuthenticated = true
         sut.loggedInUser = makeUser(email: "user@example.com")
 
@@ -123,6 +130,7 @@ final class SettingsRootViewModelTests: XCTestCase {
         XCTAssertFalse(sut.isAuthenticated)
         XCTAssertNil(sut.currentUserEmail)
         XCTAssertEqual(client.events, [.logout])
+        XCTAssertEqual(analytics.events, [.init(name: "QuranSyncSignOut", value: "settings")])
         XCTAssertNil(sut.error)
     }
 
@@ -137,13 +145,14 @@ final class SettingsRootViewModelTests: XCTestCase {
     // MARK: Private
 
     private func makeSUT(
+        analytics: AnalyticsLibrary = AnalyticsRecorder(),
         authenticationClient: (any AuthenticationClient)?,
         navigationController: UINavigationController? = nil
     ) -> SettingsRootViewModel {
         let navigationController = navigationController ?? UINavigationController()
         let container = AppDependenciesStub(authenticationClient: authenticationClient ?? UnavailableAuthenticationClient())
         return SettingsRootViewModel(
-            analytics: AnalyticsSpy(),
+            analytics: analytics,
             reviewService: ReviewService(analytics: AnalyticsSpy()),
             authenticationClient: authenticationClient ?? UnavailableAuthenticationClient(),
             audioDownloadsBuilder: AudioDownloadsBuilder(container: container),
@@ -159,6 +168,19 @@ final class SettingsRootViewModelTests: XCTestCase {
         guard case .notAuthenticated = error as? AuthenticationClientError else {
             return XCTFail("Expected notAuthenticated, got \(String(describing: error))", file: file, line: line)
         }
+    }
+}
+
+private struct AnalyticsEvent: Equatable {
+    let name: String
+    let value: String
+}
+
+private final class AnalyticsRecorder: AnalyticsLibrary, @unchecked Sendable {
+    private(set) var events: [AnalyticsEvent] = []
+
+    func logEvent(_ name: String, value: String) {
+        events.append(.init(name: name, value: value))
     }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -657,6 +657,7 @@ private func featuresTargets() -> [[Target]] {
         ]),
 
         target(type, name: "BookmarksFeature", dependencies: [
+            "Analytics",
             "AppDependencies",
             "AuthenticationClient",
             "FeaturesSupport",
@@ -723,6 +724,7 @@ private func featuresTargets() -> [[Target]] {
         ]),
 
         target(type, name: "NotesFeature", dependencies: [
+            "Analytics",
             "AnnotationsService",
             "AuthenticationClient",
             "QuranTextKit",
@@ -789,6 +791,7 @@ private func featuresTargets() -> [[Target]] {
         target(type, name: "SettingsFeature", dependencies: [
             "AppDependencies",
             "AuthenticationClient",
+            "FeaturesSupport",
             "SettingsService",
             "NoorUI",
             "VLogging",


### PR DESCRIPTION
## Summary

- track Quran Sync sign-in, sign-out, and sign-in banner dismissal by source
- restore highlight and unhighlight analytics parity for synced highlights
- add privacy-safe operational logging for authentication, bookmark collections, notes, and sync observers
- add regression coverage for the new analytics events

## Testing

- `make format-lint`
- `make test-sync TARGET=BookmarksFeatureTests`
- `make test-sync TARGET=NotesFeatureTests`
- `make test-sync TARGET=SettingsFeatureTests`
- `make test-no-sync TARGET=BookmarksFeatureTests`
- `make test-no-sync TARGET=NotesFeatureTests`
- `make test-sync TARGET=UtilitiesTests`

## Note

A full `make test-sync` run stalled in unchanged `UtilitiesTests` after other suites passed. The isolated Utilities test target passed 33/33 immediately.