### PR TITLE
fix(images): handle missing Quran page files

### DIFF
--- a/Domain/ImageService/Sources/ImageDataService.swift
+++ b/Domain/ImageService/Sources/ImageDataService.swift
@@ -12,6 +12,19 @@ import VLogging
 import WordFramePersistence
 import WordFrameService
 
+public enum ImageDataServiceError: Error {
+    case imageNotFound(page: Page, url: URL)
+}
+
+extension ImageDataServiceError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .imageNotFound(let page, let url):
+            return "No image found for page '\(page)' at '\(url.path)'"
+        }
+    }
+}
+
 public struct ImageDataService {
     // MARK: Lifecycle
 
@@ -31,12 +44,13 @@ public struct ImageDataService {
     }
 
     public func imageForPage(_ page: Page) async throws -> ImagePage {
+        try Task.checkCancellation()
         let imageURL = imageURLForPage(page)
         guard let image = UIImage(contentsOfFile: imageURL.path) else {
             logFiles(directory: imagesURL) // <reading>/images/width/
             logFiles(directory: imagesURL.deletingLastPathComponent()) // <reading>/images/
             logFiles(directory: imagesURL.deletingLastPathComponent().deletingLastPathComponent()) // <reading>/
-            fatalError("No image found for page '\(page)'")
+            throw ImageDataServiceError.imageNotFound(page: page, url: imageURL)
         }
 
         // preload the image

--- a/Domain/ImageService/Tests/ImageDataServiceTests.swift
+++ b/Domain/ImageService/Tests/ImageDataServiceTests.swift
@@ -71,6 +71,23 @@ class ImageDataServiceTests: XCTestCase {
         XCTAssertNil(wordFrames.wordAtLocation(.zero, imageScale: verticalScaling))
     }
 
+    func testGettingMissingImageThrows() async throws {
+        let imagesURL = TestResources.testDataURL.appendingPathComponent("missing-images")
+        let page = quran.pages[0]
+        service = ImageDataService(
+            ayahInfoDatabase: TestResources.resourceURL("hafs_1405_ayahinfo.db"),
+            imagesURL: imagesURL
+        )
+
+        do {
+            _ = try await service.imageForPage(page)
+            XCTFail("Expected a missing image error")
+        } catch let ImageDataServiceError.imageNotFound(errorPage, url) {
+            XCTAssertEqual(errorPage, page)
+            XCTAssertEqual(url, imagesURL.appendingPathComponent("page001.png"))
+        }
+    }
+
     @MainActor
     func testGettingImageAtPage1() async throws {
         let page = quran.pages[0]

--- a/Features/QuranImageFeature/Sources/ContentImageViewModel.swift
+++ b/Features/QuranImageFeature/Sources/ContentImageViewModel.swift
@@ -13,6 +13,7 @@ import NoorUI
 import QuranAnnotations
 import QuranGeometry
 import QuranKit
+import ReadingService
 import SwiftUI
 import VLogging
 
@@ -78,8 +79,17 @@ class ContentImageViewModel: ObservableObject {
     }
 
     func loadImagePage() async {
+        guard ReadingPreferences.shared.reading == reading else {
+            return
+        }
+
         do {
-            imagePage = try await imageDataService.imageForPage(page)
+            let imagePage = try await imageDataService.imageForPage(page)
+            try Task.checkCancellation()
+            guard ReadingPreferences.shared.reading == reading else {
+                return
+            }
+            self.imagePage = imagePage
 
             if reading == .hafs_1421 {
                 suraHeaderLocations = try await imageDataService.suraHeaders(page)
@@ -87,7 +97,12 @@ class ContentImageViewModel: ObservableObject {
             }
 
             scrollToVerseIfNeeded()
+        } catch is CancellationError {
+            return
         } catch {
+            guard ReadingPreferences.shared.reading == reading else {
+                return
+            }
             // TODO: should show error to the user
             crasher.recordError(error, reason: "Failed to retrieve quran image details")
         }


### PR DESCRIPTION
## Summary
- replace the fatal error for missing page images with a typed, recoverable error
- ignore cancelled or stale image loads after a reading changes
- cover missing image files with a regression test

## Root cause
Crashlytics breadcrumbs show a reading switch from downloaded `hafs_1440` to bundled `hafs_1405`. The old reading directory can be removed while an in-flight content task still tries to load its page image, which previously terminated the app.

## Testing
- `make format-lint`
- `make test-no-sync TARGET=ImageServiceTests`
- `make test-sync TARGET=ImageServiceTests`
