### PR TITLE
fix(ui): coalesce animated Quran scrolling

### DIFF
--- a/UI/NoorUI/Sources/Features/Quran/QuranScrollingViewModifier.swift
+++ b/UI/NoorUI/Sources/Features/Quran/QuranScrollingViewModifier.swift
@@ -7,27 +7,57 @@
 
 import SwiftUI
 
+@MainActor
+final class QuranScrollScheduler: ObservableObject {
+    private var task: Task<Void, Never>?
+
+    func schedule(_ action: @escaping @MainActor () -> Void) {
+        task?.cancel()
+        task = Task { @MainActor in
+            await Task.yield()
+            guard !Task.isCancelled else { return }
+            action()
+        }
+    }
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+    }
+}
+
+@MainActor
 struct QuranScrollingViewModifier<Value: Equatable, ID: Hashable>: ViewModifier {
     let scrollToValue: Value?
     let anchor: UnitPoint
     let transform: (Value) -> ID?
-    @State private var scrollToValueRequest: Value?
+    @StateObject private var scheduler = QuranScrollScheduler()
 
     func body(content: Content) -> some View {
         ScrollViewReader { scrollView in
             content
-                .onChange(of: scrollToValue) { scrollToValueRequest = $0 }
-                .onChange(of: scrollToValueRequest) { scrollToValue in
-                    if let scrollToValue, let id = transform(scrollToValue) {
-                        withAnimation {
-                            scrollView.scrollTo(id, anchor: anchor)
-                        }
-                        scrollToValueRequest = nil
-                    }
+                .onAppear {
+                    scheduleScroll(to: scrollToValue, using: scrollView)
+                }
+                .onChange(of: scrollToValue) {
+                    scheduleScroll(to: $0, using: scrollView)
+                }
+                .onSizeChange { _ in
+                    scheduleScroll(to: scrollToValue, using: scrollView)
+                }
+                .onDisappear {
+                    scheduler.cancel()
                 }
         }
-        .onSizeChange { _ in
-            scrollToValueRequest = scrollToValue
+    }
+
+    private func scheduleScroll(to value: Value?, using scrollView: ScrollViewProxy) {
+        guard let value else { return }
+        scheduler.schedule {
+            guard let id = transform(value) else { return }
+            withAnimation(.easeInOut(duration: 0.25)) {
+                scrollView.scrollTo(id, anchor: anchor)
+            }
         }
     }
 }

--- a/UI/NoorUI/Tests/QuranScrollSchedulerTests.swift
+++ b/UI/NoorUI/Tests/QuranScrollSchedulerTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import NoorUI
+
+@MainActor
+final class QuranScrollSchedulerTests: XCTestCase {
+    func testSchedulingNewScrollCancelsPendingScroll() async {
+        let scheduler = QuranScrollScheduler()
+        let staleScroll = expectation(description: "Stale scroll is cancelled")
+        staleScroll.isInverted = true
+        let latestScroll = expectation(description: "Latest scroll runs")
+
+        scheduler.schedule {
+            staleScroll.fulfill()
+        }
+        scheduler.schedule {
+            latestScroll.fulfill()
+        }
+
+        await fulfillment(of: [latestScroll, staleScroll], timeout: 0.1)
+    }
+}


### PR DESCRIPTION
## Summary
- replace the `@State` scroll-request feedback loop with a main-actor scheduler
- defer scrolling past the active SwiftUI update pass and coalesce stale requests
- preserve smooth scrolling with a 0.25-second ease-in-out animation
- cover scheduler coalescing with a regression test

## Root cause
Crashlytics shows `AttributeGraph` failures during audio-driven verse changes, with the old modifier mutating its own `@State` while SwiftUI was propagating geometry preferences. Deferring the scroll removes that re-entrant graph mutation without removing animation.

## Stack
- depends on #953
- merge #953 first, then retarget this PR to `main`

## Testing
- `make format-lint`
- `make test-no-sync TARGET=NoorUITests`
- `make test-sync TARGET=NoorUITests`
