### PR TITLE
fix(theme): keep sheet detents stable

### DIFF
--- a/Features/MoreMenuFeature/Sources/views/MoreMenuThemeSettings.swift
+++ b/Features/MoreMenuFeature/Sources/views/MoreMenuThemeSettings.swift
@@ -36,12 +36,6 @@ private class ThemeSettingsController<V: View>: UIHostingController<V> {
     override func preferredContentSizeDidChange(forChildContentContainer container: UIContentContainer) {
         super.preferredContentSizeDidChange(forChildContentContainer: container)
         preferredContentSize = container.preferredContentSize
-
-        if #available(iOS 16.0, *) {
-            let height = preferredContentSize.height
-            sheetPresentationController?.detents = [.custom(resolver: { _ in height })]
-            sheetPresentationController?.invalidateDetents()
-        }
     }
 }
 

--- a/Features/MoreMenuFeature/Sources/views/MoreMenuThemeSettings.swift
+++ b/Features/MoreMenuFeature/Sources/views/MoreMenuThemeSettings.swift
@@ -21,11 +21,7 @@ private class ThemeSettingsController<V: View>: UIHostingController<V> {
         sheetPresentationController?.prefersEdgeAttachedInCompactHeight = true
         sheetPresentationController?.widthFollowsPreferredContentSizeWhenEdgeAttached = true
 
-        if #available(iOS 16.0, *) {
-            sheetPresentationController?.detents = [.custom(resolver: { _ in 400 })]
-        } else {
-            sheetPresentationController?.detents = [.medium()]
-        }
+        sheetPresentationController?.detents = [.medium()]
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
## Summary
- use UIKit’s adaptive `.medium()` detent for the theme-settings sheet
- keep the detent stable after presentation
- retain preferred-content-size updates without mutating UIKit detents during interaction

## Crashlytics
Fixes the two 2.6.1 `_UISheetInteraction` `NSRangeException` signatures triggered while changing theme/font settings and dragging the sheet.

## Verification
- `make format-lint`
- `make build-no-sync TARGET=MoreMenuFeature`