### PR TITLE
fix(theme): keep a compact-height detent

### DIFF
--- a/Features/MoreMenuFeature/Sources/views/MoreMenuThemeSettings.swift
+++ b/Features/MoreMenuFeature/Sources/views/MoreMenuThemeSettings.swift
@@ -21,7 +21,7 @@ private class ThemeSettingsController<V: View>: UIHostingController<V> {
         sheetPresentationController?.prefersEdgeAttachedInCompactHeight = true
         sheetPresentationController?.widthFollowsPreferredContentSizeWhenEdgeAttached = true
 
-        sheetPresentationController?.detents = [.medium()]
+        sheetPresentationController?.detents = [.medium(), .large()]
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
## Summary
- keep the theme sheet at medium height in regular-height layouts
- add the large detent as UIKit’s compact-height fallback
- prevent `At least one detent must be active` when opening theme settings in landscape

## Verification
- `make format-lint`
- `make build-no-sync TARGET=MoreMenuFeature`