### PR TITLE
feat(crashing): add structured crash context

### DIFF
--- a/Core/Crashing/Sources/CrashContext.swift
+++ b/Core/Crashing/Sources/CrashContext.swift
@@ -1,0 +1,243 @@
+//
+//  CrashContext.swift
+//
+
+import Locking
+
+/// A low-cardinality snapshot of application state attached to subsequent crash reports.
+///
+/// Ordered transitions belong in logs. This type records only the latest committed state.
+public final class CrashContext {
+    // MARK: Lifecycle
+
+    init(crasher: Crasher) {
+        self.crasher = crasher
+    }
+
+    // MARK: Public
+
+    public func setApplicationState(_ state: String) {
+        set(state, forKey: .appState)
+    }
+
+    public func setProtectedDataAvailable(_ available: Bool) {
+        set(available, forKey: .protectedDataAvailable)
+    }
+
+    public func setStartupPhase(_ phase: String) {
+        set(phase, forKey: .startupPhase)
+    }
+
+    public func setScreen(_ screen: String) {
+        set(screen, forKey: .uiScreen)
+    }
+
+    public func setOverlay(_ overlay: String) {
+        set(overlay, forKey: .uiOverlay)
+    }
+
+    public func setSelectedTab(_ tab: String) {
+        set(tab, forKey: .uiSelectedTab)
+    }
+
+    public func setNavigationPhase(_ phase: String) {
+        set(phase, forKey: .uiNavigationPhase)
+    }
+
+    public func setReading(id: String) {
+        set(id, forKey: .readingId)
+    }
+
+    public func setQuranMode(_ mode: String, selectedTranslationCount: Int) {
+        set(mode, forKey: .quranMode)
+        set(selectedTranslationCount, forKey: .selectedTranslationCount)
+    }
+
+    public func setSyncState(_ state: String) {
+        set(state, forKey: .syncState)
+    }
+
+    public func setPager(
+        generation: Int,
+        phase: String,
+        source: String,
+        visibleItem: String,
+        targetItem: String,
+        pendingItem: String,
+        gestureState: String
+    ) {
+        set(generation, forKey: .pagerTransitionGeneration)
+        set(phase, forKey: .pagerPhase)
+        set(source, forKey: .pagerTransitionSource)
+        set(visibleItem, forKey: .pagerVisibleItem)
+        set(targetItem, forKey: .pagerTargetItem)
+        set(pendingItem, forKey: .pagerPendingItem)
+        set(gestureState, forKey: .pagerGestureState)
+    }
+
+    public func setActiveList(
+        owner: String,
+        mode: String,
+        generation: Int,
+        sectionCount: Int,
+        rowCount: Int
+    ) {
+        set(owner, forKey: .activeListOwner)
+        set(mode, forKey: .activeListMode)
+        set(generation, forKey: .activeListGeneration)
+        set(sectionCount, forKey: .activeListSectionCount)
+        set(rowCount, forKey: .activeListRowCount)
+    }
+
+    public func clearActiveList(owner: String) {
+        let currentOwner: String? = value(forKey: .activeListOwner)
+        guard currentOwner == owner else { return }
+        set("none", forKey: .activeListOwner)
+        set("none", forKey: .activeListMode)
+        set(0, forKey: .activeListGeneration)
+        set(0, forKey: .activeListSectionCount)
+        set(0, forKey: .activeListRowCount)
+    }
+
+    public func recordListUpdate(
+        owner: String,
+        reason: String,
+        rowsBefore: Int,
+        rowsAfter: Int,
+        generation: Int
+    ) {
+        set(owner, forKey: .lastListUpdateOwner)
+        set(reason, forKey: .lastListUpdateReason)
+        set(rowsBefore, forKey: .lastListRowsBefore)
+        set(rowsAfter, forKey: .lastListRowsAfter)
+        set(generation, forKey: .lastListUpdateGeneration)
+    }
+
+    public func setPresentation(owner: String, kind: String, phase: String, interactive: Bool) {
+        set(owner, forKey: .presentationOwner)
+        set(kind, forKey: .presentationKind)
+        set(phase, forKey: .presentationPhase)
+        set(interactive, forKey: .presentationInteractive)
+    }
+
+    public func clearPresentation(owner: String) {
+        let currentOwner: String? = value(forKey: .presentationOwner)
+        guard currentOwner == owner else { return }
+        set("none", forKey: .presentationOwner)
+        set("none", forKey: .presentationKind)
+        set("idle", forKey: .presentationPhase)
+        set(false, forKey: .presentationInteractive)
+    }
+
+    public func setPersistence(store: String, operation: String, phase: String, retryCount: Int = 0) {
+        set(store, forKey: .persistenceStore)
+        set(operation, forKey: .persistenceOperation)
+        set(phase, forKey: .persistencePhase)
+        set(retryCount, forKey: .persistenceRetryCount)
+    }
+
+    public func setAudioState(_ state: String) {
+        set(state, forKey: .audioState)
+    }
+
+    public func setAudioReciter(id: Int?) {
+        set(id.map(String.init) ?? "none", forKey: .audioReciterId)
+    }
+
+    public func setPlayingAyah(sura: Int, ayah: Int) {
+        set(sura, forKey: .audioPlayingSura)
+        set(ayah, forKey: .audioPlayingAyah)
+    }
+
+    public func clearPlayingAyah() {
+        set(0, forKey: .audioPlayingSura)
+        set(0, forKey: .audioPlayingAyah)
+    }
+
+    public func setVisiblePages(_ pages: [Int]) {
+        set(pages.min() ?? 0, forKey: .quranVisiblePageMinimum)
+        set(pages.max() ?? 0, forKey: .quranVisiblePageMaximum)
+        set(pages.count, forKey: .quranVisiblePageCount)
+    }
+
+    public func setAdvancedAudioOptionsPhase(_ phase: String) {
+        set(phase, forKey: .advancedAudioOptionsPhase)
+    }
+
+    // MARK: Private
+
+    private let crasher: Crasher
+    private let values = Protected<[String: AnyHashable]>([:])
+
+    private func set<T: Hashable>(_ value: T, forKey key: CrasherKey<T>) {
+        let changed = values.sync { values in
+            guard values[key.key] != AnyHashable(value) else { return false }
+            values[key.key] = AnyHashable(value)
+            return true
+        }
+        if changed {
+            crasher.setValue(value, forKey: key)
+        }
+    }
+
+    private func value<T: Hashable>(forKey key: CrasherKey<T>) -> T? {
+        values.value[key.key]?.base as? T
+    }
+}
+
+public let crashContext = CrashContext(crasher: crasher)
+
+private extension CrasherKeyBase {
+    static let appState = CrasherKey<String>(key: "app_state")
+    static let protectedDataAvailable = CrasherKey<Bool>(key: "protected_data_available")
+    static let startupPhase = CrasherKey<String>(key: "startup_phase")
+
+    static let uiScreen = CrasherKey<String>(key: "ui_screen")
+    static let uiOverlay = CrasherKey<String>(key: "ui_overlay")
+    static let uiSelectedTab = CrasherKey<String>(key: "ui_selected_tab")
+    static let uiNavigationPhase = CrasherKey<String>(key: "ui_navigation_phase")
+
+    static let readingId = CrasherKey<String>(key: "reading_id")
+    static let quranMode = CrasherKey<String>(key: "quran_mode")
+    static let selectedTranslationCount = CrasherKey<Int>(key: "selected_translation_count")
+    static let syncState = CrasherKey<String>(key: "sync_state")
+
+    static let pagerPhase = CrasherKey<String>(key: "pager_phase")
+    static let pagerTransitionGeneration = CrasherKey<Int>(key: "pager_transition_generation")
+    static let pagerTransitionSource = CrasherKey<String>(key: "pager_transition_source")
+    static let pagerVisibleItem = CrasherKey<String>(key: "pager_visible_item")
+    static let pagerTargetItem = CrasherKey<String>(key: "pager_target_item")
+    static let pagerPendingItem = CrasherKey<String>(key: "pager_pending_item")
+    static let pagerGestureState = CrasherKey<String>(key: "pager_gesture_state")
+
+    static let activeListOwner = CrasherKey<String>(key: "active_list_owner")
+    static let activeListMode = CrasherKey<String>(key: "active_list_mode")
+    static let activeListGeneration = CrasherKey<Int>(key: "active_list_generation")
+    static let activeListSectionCount = CrasherKey<Int>(key: "active_list_section_count")
+    static let activeListRowCount = CrasherKey<Int>(key: "active_list_row_count")
+    static let lastListUpdateOwner = CrasherKey<String>(key: "last_list_update_owner")
+    static let lastListUpdateReason = CrasherKey<String>(key: "last_list_update_reason")
+    static let lastListRowsBefore = CrasherKey<Int>(key: "last_list_rows_before")
+    static let lastListRowsAfter = CrasherKey<Int>(key: "last_list_rows_after")
+    static let lastListUpdateGeneration = CrasherKey<Int>(key: "last_list_update_generation")
+
+    static let presentationOwner = CrasherKey<String>(key: "presentation_owner")
+    static let presentationKind = CrasherKey<String>(key: "presentation_kind")
+    static let presentationPhase = CrasherKey<String>(key: "presentation_phase")
+    static let presentationInteractive = CrasherKey<Bool>(key: "presentation_interactive")
+
+    static let persistenceStore = CrasherKey<String>(key: "persistence_store")
+    static let persistenceOperation = CrasherKey<String>(key: "persistence_operation")
+    static let persistencePhase = CrasherKey<String>(key: "persistence_phase")
+    static let persistenceRetryCount = CrasherKey<Int>(key: "persistence_retry_count")
+
+    static let audioState = CrasherKey<String>(key: "audio_state")
+    static let audioReciterId = CrasherKey<String>(key: "audio_reciter_id")
+    static let audioPlayingSura = CrasherKey<Int>(key: "audio_playing_sura")
+    static let audioPlayingAyah = CrasherKey<Int>(key: "audio_playing_ayah")
+    static let advancedAudioOptionsPhase = CrasherKey<String>(key: "advanced_audio_options_phase")
+
+    static let quranVisiblePageMinimum = CrasherKey<Int>(key: "quran_visible_page_minimum")
+    static let quranVisiblePageMaximum = CrasherKey<Int>(key: "quran_visible_page_maximum")
+    static let quranVisiblePageCount = CrasherKey<Int>(key: "quran_visible_page_count")
+}

--- a/Core/Crashing/Sources/Crasher.swift
+++ b/Core/Crashing/Sources/Crasher.swift
@@ -21,28 +21,28 @@
 import Foundation
 import Locking
 
-public class CrasherKeyBase {}
+class CrasherKeyBase {}
 
-public final class CrasherKey<Type>: CrasherKeyBase {
+final class CrasherKey<Type>: CrasherKeyBase {
     // MARK: Lifecycle
 
-    public init(key: String) {
+    init(key: String) {
         self.key = key
     }
 
-    // MARK: Public
+    // MARK: Internal
 
-    public let key: String
+    let key: String
 }
 
 public protocol CrashInfoHandler {
-    func setValue<T>(_ value: T?, forKey key: CrasherKey<T>)
+    func setCustomValue(_ value: Any, forKey key: String)
     func recordError(_ error: Error, reason: String, file: StaticString, line: UInt)
 }
 
 private struct NoOpCrashInfoHandler: CrashInfoHandler {
-    func setValue<T>(_ value: T?, forKey key: CrasherKey<T>) {
-        print("[NoOpCrashInfoHandler] setValue called. Don't use NoOpCrashInfoHandler in production")
+    func setCustomValue(_ value: Any, forKey key: String) {
+        print("[NoOpCrashInfoHandler] setCustomValue called. Don't use NoOpCrashInfoHandler in production")
     }
 
     func recordError(_ error: Error, reason: String, file: StaticString, line: UInt) {
@@ -74,21 +74,29 @@ public enum CrashInfoSystem {
 public struct Crasher {
     // MARK: Lifecycle
 
-    public init() {
+    init() {
         handler = CrashInfoSystem.factory()
     }
 
-    // MARK: Public
+    init(handler: CrashInfoHandler) {
+        self.handler = handler
+    }
 
-    public let handler: CrashInfoHandler
+    // MARK: Public
 
     public func recordError(_ error: Error, reason: String, file: StaticString = #file, line: UInt = #line) {
         handler.recordError(error, reason: reason, file: file, line: line)
     }
 
-    public func setValue<T>(_ value: T?, forKey key: CrasherKey<T>) {
-        handler.setValue(value, forKey: key)
+    // MARK: Internal
+
+    func setValue<T>(_ value: T, forKey key: CrasherKey<T>) {
+        handler.setCustomValue(value, forKey: key.key)
     }
+
+    // MARK: Private
+
+    private let handler: CrashInfoHandler
 }
 
 extension Crasher {

--- a/Core/Crashing/Tests/CrashContextTests.swift
+++ b/Core/Crashing/Tests/CrashContextTests.swift
@@ -1,0 +1,131 @@
+import XCTest
+@testable import Crashing
+
+final class CrashContextTests: XCTestCase {
+    func testListStateRecordsActiveAndLastUpdateContexts() {
+        let handler = RecordingCrashInfoHandler()
+        let sut = CrashContext(crasher: Crasher(handler: handler))
+
+        sut.setActiveList(owner: "home", mode: "suras", generation: 1, sectionCount: 30, rowCount: 114)
+        sut.recordListUpdate(owner: "home", reason: "mode_change", rowsBefore: 240, rowsAfter: 114, generation: 2)
+
+        XCTAssertEqual(handler.value(for: "active_list_owner") as? String, "home")
+        XCTAssertEqual(handler.value(for: "active_list_row_count") as? Int, 114)
+        XCTAssertEqual(handler.value(for: "last_list_update_reason") as? String, "mode_change")
+        XCTAssertEqual(handler.value(for: "last_list_rows_before") as? Int, 240)
+        XCTAssertEqual(handler.value(for: "last_list_rows_after") as? Int, 114)
+    }
+
+    func testClearingStaleListOwnerDoesNotClearNewOwner() {
+        let handler = RecordingCrashInfoHandler()
+        let sut = CrashContext(crasher: Crasher(handler: handler))
+        sut.setActiveList(owner: "home", mode: "suras", generation: 1, sectionCount: 30, rowCount: 114)
+        sut.setActiveList(owner: "settings", mode: "root", generation: 1, sectionCount: 5, rowCount: 20)
+
+        sut.clearActiveList(owner: "home")
+
+        XCTAssertEqual(handler.value(for: "active_list_owner") as? String, "settings")
+        XCTAssertEqual(handler.value(for: "active_list_row_count") as? Int, 20)
+    }
+
+    func testDuplicateValuesAreNotWrittenAgain() {
+        let handler = RecordingCrashInfoHandler()
+        let sut = CrashContext(crasher: Crasher(handler: handler))
+
+        sut.setApplicationState("active")
+        sut.setApplicationState("active")
+
+        XCTAssertEqual(handler.writeCount(for: "app_state"), 1)
+    }
+
+    func testPagerContextUsesLatestTransitionSnapshot() {
+        let handler = RecordingCrashInfoHandler()
+        let sut = CrashContext(crasher: Crasher(handler: handler))
+
+        sut.setPager(
+            generation: 4,
+            phase: "manual_transition",
+            source: "user_gesture",
+            visibleItem: "10",
+            targetItem: "11",
+            pendingItem: "11",
+            gestureState: "dragging"
+        )
+
+        XCTAssertEqual(handler.value(for: "pager_phase") as? String, "manual_transition")
+        XCTAssertEqual(handler.value(for: "pager_transition_generation") as? Int, 4)
+        XCTAssertEqual(handler.value(for: "pager_transition_source") as? String, "user_gesture")
+        XCTAssertEqual(handler.value(for: "pager_visible_item") as? String, "10")
+        XCTAssertEqual(handler.value(for: "pager_target_item") as? String, "11")
+        XCTAssertEqual(handler.value(for: "pager_gesture_state") as? String, "dragging")
+    }
+
+    func testClearingStalePresentationOwnerDoesNotClearNewPresentation() {
+        let handler = RecordingCrashInfoHandler()
+        let sut = CrashContext(crasher: Crasher(handler: handler))
+        sut.setPresentation(owner: "reciter_list", kind: "sheet", phase: "presented", interactive: false)
+        sut.setPresentation(owner: "advanced_audio_options", kind: "sheet", phase: "presenting", interactive: false)
+
+        sut.clearPresentation(owner: "reciter_list")
+
+        XCTAssertEqual(handler.value(for: "presentation_owner") as? String, "advanced_audio_options")
+        XCTAssertEqual(handler.value(for: "presentation_phase") as? String, "presenting")
+    }
+
+    func testAudioContextUsesPrimitiveValuesAndExplicitEmptyState() {
+        let handler = RecordingCrashInfoHandler()
+        let sut = CrashContext(crasher: Crasher(handler: handler))
+
+        sut.setAudioReciter(id: 7)
+        sut.setPlayingAyah(sura: 2, ayah: 255)
+
+        XCTAssertEqual(handler.value(for: "audio_reciter_id") as? String, "7")
+        XCTAssertEqual(handler.value(for: "audio_playing_sura") as? Int, 2)
+        XCTAssertEqual(handler.value(for: "audio_playing_ayah") as? Int, 255)
+
+        sut.clearPlayingAyah()
+        sut.setAudioReciter(id: nil)
+
+        XCTAssertEqual(handler.value(for: "audio_reciter_id") as? String, "none")
+        XCTAssertEqual(handler.value(for: "audio_playing_sura") as? Int, 0)
+        XCTAssertEqual(handler.value(for: "audio_playing_ayah") as? Int, 0)
+    }
+
+    func testVisiblePageContextRecordsNormalizedRangeAndCount() {
+        let handler = RecordingCrashInfoHandler()
+        let sut = CrashContext(crasher: Crasher(handler: handler))
+
+        sut.setVisiblePages([46, 45])
+
+        XCTAssertEqual(handler.value(for: "quran_visible_page_minimum") as? Int, 45)
+        XCTAssertEqual(handler.value(for: "quran_visible_page_maximum") as? Int, 46)
+        XCTAssertEqual(handler.value(for: "quran_visible_page_count") as? Int, 2)
+
+        sut.setVisiblePages([])
+
+        XCTAssertEqual(handler.value(for: "quran_visible_page_minimum") as? Int, 0)
+        XCTAssertEqual(handler.value(for: "quran_visible_page_maximum") as? Int, 0)
+        XCTAssertEqual(handler.value(for: "quran_visible_page_count") as? Int, 0)
+    }
+}
+
+private final class RecordingCrashInfoHandler: CrashInfoHandler {
+    private var values: [String: Any] = [:]
+    private var writes: [String: Int] = [:]
+
+    func setCustomValue(_ value: Any, forKey key: String) {
+        values[key] = value
+        writes[key, default: 0] += 1
+    }
+
+    func recordError(_ error: Error, reason: String, file: StaticString, line: UInt) {
+    }
+
+    func value(for key: String) -> Any? {
+        values[key]
+    }
+
+    func writeCount(for key: String) -> Int {
+        writes[key, default: 0]
+    }
+}

--- a/Data/CoreDataPersistence/Sources/CoreDataStack.swift
+++ b/Data/CoreDataPersistence/Sources/CoreDataStack.swift
@@ -7,6 +7,7 @@
 //
 
 import CoreData
+import Crashing
 import Foundation
 import Utilities
 import VLogging
@@ -43,18 +44,25 @@ public class CoreDataStack {
 
     /// A persistent container that can load cloud-backed and non-cloud stores.
     lazy var persistentContainer: NSPersistentContainer = {
+        crashContext.setPersistence(store: name, operation: "load_store", phase: "starting")
+        logger.info("Core Data store load starting: \(name)")
         let container = newPersistenceContainer()
 
         // Enable history tracking and remote notifications
         guard let description = container.persistentStoreDescriptions.first else {
+            crashContext.setPersistence(store: name, operation: "load_store", phase: "missing_description")
             fatalError("###\(#function): Failed to retrieve a persistent store description.")
         }
         description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
         description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
 
         container.loadPersistentStores(completionHandler: { _, error in
-            guard let error = error as NSError? else { return }
-            fatalError("###\(#function): Failed to load persistent store: \(error)")
+            if let error = error as NSError? {
+                crashContext.setPersistence(store: self.name, operation: "load_store", phase: "failed")
+                fatalError("###\(#function): Failed to load persistent store: \(error)")
+            }
+            crashContext.setPersistence(store: self.name, operation: "load_store", phase: "ready")
+            logger.info("Core Data store loaded: \(self.name)")
         })
 
         container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
@@ -65,6 +73,7 @@ public class CoreDataStack {
         do {
             try container.viewContext.setQueryGenerationFrom(.current)
         } catch {
+            crashContext.setPersistence(store: name, operation: "pin_generation", phase: "failed")
             fatalError("###\(#function): Failed to pin viewContext to the current generation:\(error)")
         }
 
@@ -108,13 +117,16 @@ public class CoreDataStack {
     /// Handle remote store change notifications (.NSPersistentStoreRemoteChange).
     @objc
     private func storeRemoteChange(_ notification: Notification) {
+        crashContext.setPersistence(store: name, operation: "merge_remote_change", phase: "queued")
         logger.info("Merging changes from the other persistent store coordinator.")
 
         // Process persistent history to merge changes from other coordinators.
         historyQueue.addOperation {
             let taskContext = self.newBackgroundContext()
             taskContext.performAndWait {
+                crashContext.setPersistence(store: self.name, operation: "merge_remote_change", phase: "executing")
                 self.historyProcessor.processNewHistory(using: taskContext)
+                crashContext.setPersistence(store: self.name, operation: "merge_remote_change", phase: "ready")
             }
         }
     }

--- a/Data/VerseTextPersistence/Sources/GRDBVerseTextPersistence.swift
+++ b/Data/VerseTextPersistence/Sources/GRDBVerseTextPersistence.swift
@@ -5,6 +5,7 @@
 //  Created by Mohamed Afifi on 2023-05-23.
 //
 
+import Crashing
 import Foundation
 import GRDB
 import QuranKit
@@ -138,11 +139,13 @@ private struct GRDBVerseTextPersistence {
     let db: DatabaseConnection
 
     func textForVerse<T>(_ verse: AyahNumber, transform: @escaping (Row, Quran) throws -> T) async throws -> T {
-        try await db.read { db in
-            if let text = try textForVerse(using: db, verse: verse, transform: transform) {
-                return text
+        try await perform(operation: "text_for_verse") {
+            try await db.read { db in
+                if let text = try textForVerse(using: db, verse: verse, transform: transform) {
+                    return text
+                }
+                throw PersistenceError.general("Cannot find any records for verse '\(verse)'")
             }
-            throw PersistenceError.general("Cannot find any records for verse '\(verse)'")
         }
     }
 
@@ -150,41 +153,47 @@ private struct GRDBVerseTextPersistence {
         _ verses: [AyahNumber],
         transform: @escaping (Row, Quran) throws -> T
     ) async throws -> [AyahNumber: T] {
-        try await db.read { db in
-            var dictionary: [AyahNumber: T] = [:]
-            for verse in verses {
-                dictionary[verse] = try textForVerse(using: db, verse: verse, transform: transform)
+        try await perform(operation: "text_for_verses") {
+            try await db.read { db in
+                var dictionary: [AyahNumber: T] = [:]
+                for verse in verses {
+                    dictionary[verse] = try textForVerse(using: db, verse: verse, transform: transform)
+                }
+                return dictionary
             }
-            return dictionary
         }
     }
 
     // MARK: - Search
 
     func autocomplete(term: String) async throws -> [String] {
-        try await db.read { db in
-            let request = SQLRequest<String>("""
-            SELECT text
-            FROM \(sql: searchTable)
-            WHERE text match \(term) || '*'
-            LIMIT 100
-            """)
-            let rows = try request.fetchAll(db)
-            return rows
+        try await perform(operation: "autocomplete") {
+            try await db.read { db in
+                let request = SQLRequest<String>("""
+                SELECT text
+                FROM \(sql: searchTable)
+                WHERE text match \(term) || '*'
+                LIMIT 100
+                """)
+                let rows = try request.fetchAll(db)
+                return rows
+            }
         }
     }
 
     func search(for term: String, quran: Quran) async throws -> [(verse: AyahNumber, text: String)] {
-        try await db.read { db in
-            // TODO: Use match for FTS.
-            // Use like to match "_" in the Arabic regex as `match` treats "_" as a regular character.
-            let request = SQLRequest<Row>("""
-            SELECT text, sura, ayah
-            FROM \(sql: searchTable)
-            WHERE text like '%' || \(term) || '%'
-            """)
-            let rows = try request.fetchAll(db)
-            return rowsToResults(rows, quran: quran)
+        try await perform(operation: "search") {
+            try await db.read { db in
+                // TODO: Use match for FTS.
+                // Use like to match "_" in the Arabic regex as `match` treats "_" as a regular character.
+                let request = SQLRequest<Row>("""
+                SELECT text, sura, ayah
+                FROM \(sql: searchTable)
+                WHERE text like '%' || \(term) || '%'
+                """)
+                let rows = try request.fetchAll(db)
+                return rowsToResults(rows, quran: quran)
+            }
         }
     }
 
@@ -192,6 +201,19 @@ private struct GRDBVerseTextPersistence {
 
     private let textTable: String
     private let searchTable = "verses"
+
+    private func perform<T>(operation: String, body: () async throws -> T) async throws -> T {
+        let store = "verse_text_\(textTable)"
+        crashContext.setPersistence(store: store, operation: operation, phase: "executing")
+        do {
+            let result = try await body()
+            crashContext.setPersistence(store: store, operation: operation, phase: "ready")
+            return result
+        } catch {
+            crashContext.setPersistence(store: store, operation: operation, phase: "failed")
+            throw error
+        }
+    }
 
     private func textForVerse<T>(
         using db: Database,

--- a/Features/AppStructureFeature/Sources/App/AppInteractor.swift
+++ b/Features/AppStructureFeature/Sources/App/AppInteractor.swift
@@ -33,8 +33,11 @@ final class AppInteractor {
         presenter?.setViewControllers(viewControllers, animated: false)
 
         guard supportsCloudKit else {
+            crashContext.setSyncState("unavailable")
             return
         }
+
+        crashContext.setSyncState("checking_account")
 
         // log cloud kit logged in status
         DispatchQueue.global().asyncAfter(deadline: .now() + 10) {
@@ -52,9 +55,11 @@ final class AppInteractor {
     private nonisolated func logIsLoggedIntoCloudKit() {
         CKContainer.default().accountStatus { [analytics] status, error in
             if let error {
+                crashContext.setSyncState("account_check_failed")
                 logger.error("Error while checking account status \(error)")
                 analytics.cloudkitLoggedIn(.error)
             } else {
+                crashContext.setSyncState(status == .available ? "account_available" : "account_unavailable")
                 analytics.cloudkitLoggedIn(status == .available ? .ok : .fail)
                 if status == .available {
                     self.logLastPagesMatch()
@@ -70,6 +75,7 @@ final class AppInteractor {
         db.fetch(withQuery: query, inZoneWith: zone.zoneID, desiredKeys: nil, resultsLimit: CKQueryOperation.maximumResults) { [analytics] result in
             switch result {
             case let .failure(error):
+                crashContext.setSyncState("verification_failed")
                 logger.error("Error while accessing CloudKit \(error)")
                 analytics.cloudkitLastPagesMatch(.error)
             case let .success(output):
@@ -79,8 +85,10 @@ final class AppInteractor {
                     do {
                         let cdLastPages = try await self.lastPagePersistence.retrieveAll()
                         let inSync = Set(cdLastPages.map(\.page)).isSubset(of: ckLastPages)
+                        crashContext.setSyncState(inSync ? "verified" : "verification_mismatch")
                         analytics.cloudkitLastPagesMatch(inSync ? .ok : .fail)
                     } catch {
+                        crashContext.setSyncState("verification_failed")
                         crasher.recordError(error, reason: "Failed to retrieve last pages from persistence.")
                     }
                 }

--- a/Features/AppStructureFeature/Sources/App/AppViewController.swift
+++ b/Features/AppStructureFeature/Sources/App/AppViewController.swift
@@ -19,7 +19,9 @@
 //
 
 import Analytics
+import Crashing
 import UIKit
+import VLogging
 import WhatsNewFeature
 
 protocol AppPresenter: UITabBarController {
@@ -56,9 +58,13 @@ class AppViewController: UITabBarController, UITabBarControllerDelegate, AppPres
     override func viewDidLoad() {
         super.viewDidLoad()
         delegate = self
+        updateCrashContext(selectedIndex: selectedIndex)
     }
 
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        crashContext.setNavigationPhase("tab_switching")
+        updateCrashContext(selectedIndex: tabBarController.selectedIndex)
+        crashContext.setNavigationPhase("idle")
         let targetMask = tabBarController.supportedInterfaceOrientations
         if let currentMask = tabBarController.view.window?.windowScene?.interfaceOrientation.asMask {
             if !targetMask.contains(currentMask) {
@@ -84,8 +90,17 @@ class AppViewController: UITabBarController, UITabBarControllerDelegate, AppPres
     private let whatsNewController: AppWhatsNewController
     private var hasStartedPostLaunchPresentation = false
 
+    private let tabNames = ["home", "notes", "bookmarks", "search", "settings"]
+
     private var visibleViewController: UIViewController? {
         presentedViewController ?? selectedViewController
+    }
+
+    private func updateCrashContext(selectedIndex: Int) {
+        let tab = tabNames.indices.contains(selectedIndex) ? tabNames[selectedIndex] : "unknown"
+        crashContext.setSelectedTab(tab)
+        crashContext.setScreen(tab)
+        logger.info("Crash context: selected tab \(tab)")
     }
 }
 

--- a/Features/AppStructureFeature/Sources/Launch/CrashApplicationObserver.swift
+++ b/Features/AppStructureFeature/Sources/Launch/CrashApplicationObserver.swift
@@ -1,0 +1,83 @@
+//
+//  CrashApplicationObserver.swift
+//
+
+import Crashing
+import UIKit
+import VLogging
+
+@MainActor
+final class CrashApplicationObserver {
+    // MARK: Lifecycle
+
+    deinit {
+        for observer in observers {
+            notificationCenter.removeObserver(observer)
+        }
+    }
+
+    // MARK: Internal
+
+    func start() {
+        guard observers.isEmpty else { return }
+
+        updateApplicationContext()
+        observe(UIApplication.didBecomeActiveNotification, state: "active")
+        observe(UIApplication.willResignActiveNotification, state: "inactive")
+        observe(UIApplication.didEnterBackgroundNotification, state: "background")
+        observe(UIApplication.willEnterForegroundNotification, state: "inactive")
+
+        observers.append(
+            notificationCenter.addObserver(
+                forName: UIApplication.protectedDataDidBecomeAvailableNotification,
+                object: nil,
+                queue: .main
+            ) { _ in
+                crashContext.setProtectedDataAvailable(true)
+                logger.info("Crash context: protected data became available")
+            }
+        )
+        observers.append(
+            notificationCenter.addObserver(
+                forName: UIApplication.protectedDataWillBecomeUnavailableNotification,
+                object: nil,
+                queue: .main
+            ) { _ in
+                crashContext.setProtectedDataAvailable(false)
+                logger.info("Crash context: protected data will become unavailable")
+            }
+        )
+    }
+
+    // MARK: Private
+
+    private let notificationCenter = NotificationCenter.default
+    private var observers: [NSObjectProtocol] = []
+
+    private func updateApplicationContext() {
+        let application = UIApplication.shared
+        crashContext.setApplicationState(application.applicationState.crashContextValue)
+        crashContext.setProtectedDataAvailable(application.isProtectedDataAvailable)
+    }
+
+    private func observe(_ name: Notification.Name, state: String) {
+        observers.append(
+            notificationCenter.addObserver(forName: name, object: nil, queue: .main) { _ in
+                crashContext.setApplicationState(state)
+                crashContext.setProtectedDataAvailable(UIApplication.shared.isProtectedDataAvailable)
+                logger.info("Crash context: application state changed to \(state)")
+            }
+        )
+    }
+}
+
+private extension UIApplication.State {
+    var crashContextValue: String {
+        switch self {
+        case .active: "active"
+        case .inactive: "inactive"
+        case .background: "background"
+        @unknown default: "unknown"
+        }
+    }
+}

--- a/Features/AppStructureFeature/Sources/Launch/LaunchStartup.swift
+++ b/Features/AppStructureFeature/Sources/Launch/LaunchStartup.swift
@@ -9,6 +9,7 @@
 import AppMigrationFeature
 import AppMigrator
 import AudioUpdater
+import Crashing
 import SettingsService
 import UIKit
 import VLogging
@@ -34,6 +35,14 @@ public final class LaunchStartup {
     // MARK: Public
 
     public func launch(from window: UIWindow) {
+        crashApplicationObserver.start()
+        crashContext.setStartupPhase("launching")
+        #if QURAN_SYNC
+        crashContext.setSyncState("initializing")
+        #else
+        crashContext.setSyncState("disabled")
+        #endif
+        logger.info("Crash context: startup phase launching")
         upgradeIfNeeded(window: window)
     }
 
@@ -44,6 +53,7 @@ public final class LaunchStartup {
     private let appBuilder: AppBuilder
     private let audioUpdater: AudioUpdater
     private let reviewService: ReviewService
+    private let crashApplicationObserver = CrashApplicationObserver()
 
     private let appMigrator = AppMigrator()
     private var appViewController: UIViewController?
@@ -54,6 +64,8 @@ public final class LaunchStartup {
         case .noMigration:
             showApp(window: window)
         case let .migrate(blocksUI, titles):
+            crashContext.setStartupPhase("migrating")
+            logger.info("Crash context: startup phase migrating")
             if blocksUI {
                 logger.notice("Performing long upgrade task: \(titles)")
                 let migrationVC = MigrationViewController()
@@ -74,6 +86,8 @@ public final class LaunchStartup {
         }
 
         updateAudioIfNeeded()
+        crashContext.setStartupPhase("building_ui")
+        logger.info("Crash context: startup phase building_ui")
 
         let wasUpdated = window.rootViewController != nil
 
@@ -86,6 +100,8 @@ public final class LaunchStartup {
             appViewController.launch(from: window)
             reviewService.checkForReview(in: window)
         }
+        crashContext.setStartupPhase("ready")
+        logger.info("Crash context: startup phase ready")
     }
 
     private func registerMigrators() {

--- a/Features/AudioBannerFeature/Sources/AudioBannerViewModel.swift
+++ b/Features/AudioBannerFeature/Sources/AudioBannerViewModel.swift
@@ -36,6 +36,15 @@ private enum PlaybackState {
     case paused
     case stopped
     case downloading(progress: Double)
+
+    var crashContextValue: String {
+        switch self {
+        case .playing: "playing"
+        case .paused: "paused"
+        case .stopped: "stopped"
+        case .downloading: "downloading"
+        }
+    }
 }
 
 @MainActor
@@ -61,6 +70,10 @@ public final class AudioBannerViewModel: ObservableObject {
         self.reciterListBuilder = reciterListBuilder
         self.advancedAudioOptionsBuilder = advancedAudioOptionsBuilder
         playbackRate = AudioPreferences.shared.playbackRate
+        crashContext.setAudioState(playingState.crashContextValue)
+        crashContext.setAudioReciter(id: nil)
+        crashContext.clearPlayingAyah()
+        crashContext.setAdvancedAudioOptionsPhase("idle")
 
         setUpAudioPlayerActions()
         setUpRemoteCommandHandler()
@@ -157,6 +170,7 @@ public final class AudioBannerViewModel: ObservableObject {
 
     @Published private var playingState: PlaybackState = .stopped {
         didSet {
+            crashContext.setAudioState(playingState.crashContextValue)
             logger.info("AudioBanner: playingState updated to \(playingState) - reciter: \(String(describing: selectedReciter?.id))")
             if case .stopped = playingState {
                 onPlayingStateStopped()
@@ -177,7 +191,9 @@ public final class AudioBannerViewModel: ObservableObject {
 
     private func onPlayingStateStopped() {
         if let selectedReciter {
-            crasher.setValue(selectedReciter.id, forKey: .reciterId)
+            crashContext.setAudioReciter(id: selectedReciter.id)
+        } else {
+            crashContext.setAudioReciter(id: nil)
         }
         listener?.highlightReadingAyah(nil)
 
@@ -382,7 +398,7 @@ public final class AudioBannerViewModel: ObservableObject {
 
     private func playing(ayah: AyahNumber) {
         logger.info("AudioBanner: playing verse \(ayah)")
-        crasher.setValue(ayah, forKey: .playingAyah)
+        crashContext.setPlayingAyah(sura: ayah.sura.suraNumber, ayah: ayah.ayah)
         listener?.highlightReadingAyah(ayah)
     }
 
@@ -395,14 +411,12 @@ public final class AudioBannerViewModel: ObservableObject {
     private func playbackEnded() {
         logger.info("AudioBanner: onPlaybackOrDownloadingCompleted")
 
-        crasher.setValue(nil, forKey: .playingAyah)
-        crasher.setValue(false, forKey: .downloadingQuran)
+        crashContext.clearPlayingAyah()
         playingState = .stopped
     }
 
     private func startDownloading() {
         logger.info("AudioBanner: will start downloading")
-        crasher.setValue(true, forKey: .downloadingQuran)
         playingState = .downloading(progress: 0)
 
         guard let audioRange else {
@@ -421,7 +435,6 @@ public final class AudioBannerViewModel: ObservableObject {
     private func playingStarted() {
         logger.info("AudioBanner: playing started")
         cancellableTasks = []
-        crasher.setValue(false, forKey: .downloadingQuran)
         remoteCommandsHandler?.startListening()
         playingState = .playing
 
@@ -531,7 +544,11 @@ extension AudioBannerViewModel {
 extension AudioBannerViewModel: ReciterListListener {
     func presentReciterList() {
         logger.info("AudioBanner: reciters button tapped. State: \(playingState)")
-        modalRequest = .present(reciterListBuilder.build(withListener: self, standalone: true))
+        modalRequest = .present(
+            reciterListBuilder.build(withListener: self, standalone: true),
+            owner: "reciter_list",
+            kind: "sheet"
+        )
     }
 
     public func onSelectedReciterChanged(to reciter: Reciter) {
@@ -564,13 +581,20 @@ extension AudioBannerViewModel: AdvancedAudioOptionsListener {
         }
 
         guard let options = advancedAudioOptions else {
+            crashContext.setAdvancedAudioOptionsPhase("unavailable")
             logger.info("AudioBanner: showAdvancedAudioOptions couldn't construct advanced audio options")
             return
         }
-        modalRequest = .present(advancedAudioOptionsBuilder.build(withListener: self, options: options))
+        crashContext.setAdvancedAudioOptionsPhase("presentation_requested")
+        modalRequest = .present(
+            advancedAudioOptionsBuilder.build(withListener: self, options: options),
+            owner: "advanced_audio_options",
+            kind: "sheet"
+        )
     }
 
     public func updateAudioOptions(to newOptions: AdvancedAudioOptions) {
+        crashContext.setAdvancedAudioOptionsPhase("applying")
         logger.info("AudioBanner: playing advanced audio options \(newOptions)")
         selectReciter(newOptions.reciter)
         AudioPreferences.shared.verseDelay = newOptions.verseDelay
@@ -584,11 +608,13 @@ extension AudioBannerViewModel: AdvancedAudioOptionsListener {
             verseDelay: newOptions.verseDelay,
             repetitionDelay: newOptions.repetitionDelay
         )
+        crashContext.setAdvancedAudioOptionsPhase("applied")
     }
 
     public func dismissAudioOptions() {
         logger.info("AudioBanner: dismiss advanced audio options")
-        modalRequest = .dismiss
+        crashContext.setAdvancedAudioOptionsPhase("dismiss_requested")
+        modalRequest = .dismiss(owner: "advanced_audio_options")
     }
 }
 
@@ -596,10 +622,4 @@ private extension AnalyticsLibrary {
     func playFrom(menu: Bool) {
         logEvent("PlayAudioFrom", value: menu ? "Menu" : "AudioBar")
     }
-}
-
-private extension CrasherKeyBase {
-    static let reciterId = CrasherKey<Int>(key: "ReciterId")
-    static let downloadingQuran = CrasherKey<Bool>(key: "DownloadingQuran")
-    static let playingAyah = CrasherKey<AyahNumber>(key: "PlayingAyah")
 }

--- a/Features/HomeFeature/Sources/HomeViewController.swift
+++ b/Features/HomeFeature/Sources/HomeViewController.swift
@@ -27,6 +27,18 @@ final class HomeViewController: UIHostingController<HomeView> {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: Internal
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewModel.setListVisible(true)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        viewModel.setListVisible(false)
+    }
+
     // MARK: Private
 
     private let viewModel: HomeViewModel

--- a/Features/HomeFeature/Sources/HomeViewModel.swift
+++ b/Features/HomeFeature/Sources/HomeViewModel.swift
@@ -67,21 +67,46 @@ final class HomeViewModel: ObservableObject {
 
     // MARK: Internal
 
-    @Published var suras: [Sura] = []
-    @Published var quarters: [QuarterItem] = []
-    @Published var lastPages: [LastPage] = []
+    @Published var suras: [Sura] = [] {
+        didSet { recordListUpdate(reason: "suras_loaded") }
+    }
+
+    @Published var quarters: [QuarterItem] = [] {
+        didSet { recordListUpdate(reason: "quarters_loaded") }
+    }
+
+    @Published var lastPages: [LastPage] = [] {
+        didSet { recordListUpdate(reason: "last_pages_changed") }
+    }
+
     #if QURAN_SYNC
-    @Published var readingBookmark: ReadingPositionBookmark?
+    @Published var readingBookmark: ReadingPositionBookmark? {
+        didSet { recordListUpdate(reason: "reading_bookmark_changed") }
+    }
     #endif
 
-    @Published var surahSortOrder: SurahSortOrder = HomePreferences.shared.surahSortOrder
+    @Published var surahSortOrder: SurahSortOrder = HomePreferences.shared.surahSortOrder {
+        didSet { recordListUpdate(reason: "sort_order_changed") }
+    }
 
     @Published var collapsedJuzs: Set<Juz> = []
 
     @Published var type = HomeViewType.suras {
         didSet {
             logger.info("Home: \(type) selected")
+            recordListUpdate(reason: "mode_changed")
         }
+    }
+
+    func setListVisible(_ visible: Bool) {
+        isListVisible = visible
+        if visible {
+            crashContext.setScreen("home")
+            updateActiveListContext()
+        } else {
+            crashContext.clearActiveList(owner: "home")
+        }
+        logger.info("Crash context: home list visible=\(visible)")
     }
 
     func isJuzExpanded(_ juz: Juz) -> Bool {
@@ -94,6 +119,7 @@ final class HomeViewModel: ObservableObject {
         } else {
             collapsedJuzs.insert(juz)
         }
+        recordListUpdate(reason: "section_expansion_changed")
     }
 
     func start() async {
@@ -206,6 +232,7 @@ final class HomeViewModel: ObservableObject {
             .values()
 
         for await reading in readings {
+            crashContext.setReading(id: String(describing: reading))
             suras = reading.quran.suras
         }
     }
@@ -216,6 +243,7 @@ final class HomeViewModel: ObservableObject {
             .values()
 
         for await reading in readings {
+            crashContext.setReading(id: String(describing: reading))
             let quarters = reading.quran.quarters
             let quartersText = await textForQuarters(quarters)
             let quarterItems = quarters.map { QuarterItem(quarter: $0, ayahText: quartersText[$0] ?? "") }
@@ -244,5 +272,78 @@ final class HomeViewModel: ObservableObject {
         return quarters.reduce(into: [Quarter: QuranText]()) { partialResult, quarter in
             partialResult[quarter] = cleanedVersesText[quarter.firstVerse]
         }
+    }
+
+    private var isListVisible = false
+    private var listGeneration = 0
+    private var recordedRowCount = 0
+
+    private var listMode: String {
+        switch type {
+        case .suras: "suras"
+        case .juzs: "juzs"
+        }
+    }
+
+    private var listRowCount: Int {
+        var count = lastPages.count
+        #if QURAN_SYNC
+        if readingBookmark != nil {
+            count += 1
+        }
+        #endif
+        switch type {
+        case .suras:
+            count += suras.count
+        case .juzs:
+            count += quarters.count
+        }
+        return count
+    }
+
+    private var listSectionCount: Int {
+        var count = lastPages.isEmpty ? 0 : 1
+        #if QURAN_SYNC
+        if readingBookmark != nil {
+            count += 1
+        }
+        #endif
+        switch type {
+        case .suras:
+            count += Set(suras.map(\.page.startJuz)).count
+        case .juzs:
+            count += Set(quarters.map(\.quarter.juz)).count
+        }
+        return count
+    }
+
+    private func recordListUpdate(reason: String) {
+        let rowsBefore = recordedRowCount
+        let rowsAfter = listRowCount
+        listGeneration += 1
+        recordedRowCount = rowsAfter
+        crashContext.recordListUpdate(
+            owner: "home",
+            reason: reason,
+            rowsBefore: rowsBefore,
+            rowsAfter: rowsAfter,
+            generation: listGeneration
+        )
+        if isListVisible {
+            updateActiveListContext()
+        }
+        logger.info(
+            "Crash context: list update owner=home reason=\(reason) mode=\(listMode) generation=\(listGeneration) rows=\(rowsBefore)->\(rowsAfter) sections=\(listSectionCount)"
+        )
+    }
+
+    private func updateActiveListContext() {
+        crashContext.setActiveList(
+            owner: "home",
+            mode: listMode,
+            generation: listGeneration,
+            sectionCount: listSectionCount,
+            rowCount: listRowCount
+        )
     }
 }

--- a/Features/QuranContentFeature/Sources/ContentViewModel.swift
+++ b/Features/QuranContentFeature/Sources/ContentViewModel.swift
@@ -74,6 +74,8 @@ public final class ContentViewModel: ObservableObject {
             .sink { [weak self] in self?.quranMode = $0 }
             .store(in: &cancellables)
 
+        updateQuranModeCrashContext()
+
         #if !QURAN_SYNC
         loadNotes()
         #endif
@@ -110,7 +112,12 @@ public final class ContentViewModel: ObservableObject {
     let deps: Deps
     weak var listener: ContentListener?
 
-    @Published var quranMode: QuranMode
+    @Published var quranMode: QuranMode {
+        didSet {
+            updateQuranModeCrashContext()
+        }
+    }
+
     @Published var twoPagesEnabled: Bool
     @Published var geometryActions: [PageGeometryActions] = []
 
@@ -206,7 +213,8 @@ public final class ContentViewModel: ObservableObject {
 
         let pages = visiblePages
         let isTranslationView = deps.quranContentStatePreferences.quranMode == .translation
-        crasher.setValue(pages.map(\.pageNumber), forKey: .pages)
+        updateQuranModeCrashContext()
+        crashContext.setVisiblePages(pages.map(\.pageNumber))
         deps.analytics.showing(
             pages: pages,
             isTranslation: isTranslationView,
@@ -219,6 +227,25 @@ public final class ContentViewModel: ObservableObject {
         }
 
         updateLastPageTo(pages)
+    }
+
+    private func updateQuranModeCrashContext() {
+        let mode = quranMode == .translation ? "translation" : "arabic"
+        crashContext.setQuranMode(
+            mode,
+            selectedTranslationCount: deps.selectedTranslationsPreferences.selectedTranslationIds.count
+        )
+        if quranMode == .translation {
+            crashContext.setActiveList(
+                owner: "quran_translation",
+                mode: "translations",
+                generation: 0,
+                sectionCount: visiblePages.count,
+                rowCount: 0
+            )
+        } else {
+            crashContext.clearActiveList(owner: "quran_translation")
+        }
     }
 
     private func updateLastPageTo(_ pages: [Page]) {
@@ -234,10 +261,6 @@ public final class ContentViewModel: ObservableObject {
             .store(in: &cancellables)
     }
     #endif
-}
-
-private extension CrasherKeyBase {
-    static let pages = CrasherKey<[Int]>(key: "VisiblePages")
 }
 
 private extension AnalyticsLibrary {

--- a/Features/QuranTranslationFeature/Sources/ContentTranslationViewModel.swift
+++ b/Features/QuranTranslationFeature/Sources/ContentTranslationViewModel.swift
@@ -59,17 +59,36 @@ public final class ContentTranslationViewModel: ObservableObject {
 
     // MARK: Public
 
-    @Published public var showHeaderAndFooter = true
-    @Published public var verses: [AyahNumber] = []
+    @Published public var showHeaderAndFooter = true {
+        didSet { recordListUpdate(reason: "header_footer_changed") }
+    }
+
+    @Published public var verses: [AyahNumber] = [] {
+        didSet { recordListUpdate(reason: "verses_changed") }
+    }
 
     // MARK: Internal
 
     let tracker = CollectionTracker<TranslationItemId>()
 
-    @Published var selectedTranslations: [Translation.ID]
-    @Published var translations: [Translation] = []
-    @Published var verseTexts: [AyahNumber: VerseText] = [:]
-    @Published var expandedTranslations: [AyahNumber: [Translation: [Range<String.Index>]]] = [:]
+    @Published var selectedTranslations: [Translation.ID] {
+        didSet {
+            crashContext.setQuranMode("translation", selectedTranslationCount: selectedTranslations.count)
+            recordListUpdate(reason: "selection_changed")
+        }
+    }
+
+    @Published var translations: [Translation] = [] {
+        didSet { recordListUpdate(reason: "translations_loaded") }
+    }
+
+    @Published var verseTexts: [AyahNumber: VerseText] = [:] {
+        didSet { recordListUpdate(reason: "verse_texts_loaded") }
+    }
+
+    @Published var expandedTranslations: [AyahNumber: [Translation: [Range<String.Index>]]] = [:] {
+        didSet { recordListUpdate(reason: "translation_expanded") }
+    }
 
     @Published var translationFontSize: FontSize
     @Published var arabicFontSize: FontSize
@@ -214,11 +233,30 @@ public final class ContentTranslationViewModel: ObservableObject {
     private static let maxChunkSize = 800
 
     private var cancellables: Set<AnyCancellable> = []
+    private var listGeneration = 0
+    private var recordedRowCount = 0
     private let highlightsService: QuranHighlightsService
     private let dataService: QuranTextDataService
     private let localTranslationsRetriever: LocalTranslationsRetriever
     private let selectedTranslationsPreferences = SelectedTranslationsPreferences.shared
     private let fontSizePreferences = FontSizePreferences.shared
+
+    private func recordListUpdate(reason: String) {
+        let rowsBefore = recordedRowCount
+        let rowsAfter = items.count
+        listGeneration += 1
+        recordedRowCount = rowsAfter
+        crashContext.recordListUpdate(
+            owner: "quran_translation",
+            reason: reason,
+            rowsBefore: rowsBefore,
+            rowsAfter: rowsAfter,
+            generation: listGeneration
+        )
+        logger.info(
+            "Quran Translation list update: \(reason), rows: \(rowsBefore)->\(rowsAfter), generation: \(listGeneration)"
+        )
+    }
 
     private func cutoffChunkIfTruncationNeeded(_ string: String) -> Range<String.Index>? {
         guard let maxUntruncatedIndex = string.index(string.startIndex, offsetBy: Self.maxChunkSize, limitedBy: string.endIndex) else {

--- a/Features/QuranViewFeature/Sources/QuranViewController.swift
+++ b/Features/QuranViewFeature/Sources/QuranViewController.swift
@@ -19,6 +19,7 @@
 //
 
 import Combine
+import Crashing
 import Localization
 import NoorUI
 import QuranKit
@@ -103,12 +104,14 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        crashContext.setScreen("quran")
         UIApplication.shared.isIdleTimerDisabled = true
         navigationController?.setNavigationBarHidden(true, animated: animated)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        crashContext.clearActiveList(owner: "quran_translation")
         navigationController?.setNavigationBarHidden(false, animated: animated)
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -119,7 +119,7 @@ private func coreTargets() -> [[Target]] {
             "Locking",
         ]),
 
-        target(type, name: "Crashing", hasTests: false, dependencies: [
+        target(type, name: "Crashing", dependencies: [
             "Locking",
         ]),
 
@@ -181,6 +181,7 @@ private func uiTargets() -> [[Target]] {
     return [
         target(type, name: "ViewConstrainer", hasTests: false),
         target(type, name: "UIx", dependencies: [
+            "Crashing",
             "ViewConstrainer",
             "VLogging",
         ]),
@@ -313,6 +314,7 @@ private func dataTargets() -> [[Target]] {
         ]),
 
         target(type, name: "VerseTextPersistence", hasTests: false, dependencies: [
+            "Crashing",
             "SQLitePersistence",
             "QuranKit",
             "QuranText",
@@ -772,6 +774,7 @@ private func featuresTargets() -> [[Target]] {
         ]),
 
         target(type, name: "QuranViewFeature", dependencies: [
+            "Crashing",
             "AudioBannerFeature",
             "QuranContentFeature",
             "AyahMenuFeature",
@@ -819,6 +822,7 @@ private func featuresTargets() -> [[Target]] {
         ] + mobileSyncTargetDependencies),
 
         target(type, name: "AppStructureFeature", hasTests: false, dependencies: [
+            "Crashing",
             "HomeFeature",
             "BookmarksFeature",
             "NotesFeature",

--- a/QuranEngine-Package.xctestplan
+++ b/QuranEngine-Package.xctestplan
@@ -21,6 +21,13 @@
     {
       "target" : {
         "containerPath" : "container:",
+        "identifier" : "CrashingTests",
+        "name" : "CrashingTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
         "identifier" : "BatchDownloaderTests",
         "name" : "BatchDownloaderTests"
       }

--- a/UI/NoorUI/Sources/Pager/PageViewController.swift
+++ b/UI/NoorUI/Sources/Pager/PageViewController.swift
@@ -7,6 +7,7 @@
 
 // Most of the code is copied from https://github.com/benjaminsage/iPages
 
+import Crashing
 import SwiftUI
 import UIKit
 import VLogging
@@ -107,6 +108,15 @@ private struct _PageViewController<Element, Content>: UIViewControllerRepresenta
         }
 
         if !context.coordinator.transitionState.shouldApply(selection) {
+            context.coordinator.recordPager(
+                generation: context.coordinator.transitionGeneration,
+                phase: "manual_transition",
+                source: "external_selection_deferred",
+                visibleElement: visibleElement,
+                targetElement: selection,
+                pendingElement: selection,
+                gestureState: "dragging"
+            )
             logger.info("Cannot change page while user dragging in progress")
             return
         }
@@ -123,7 +133,32 @@ private struct _PageViewController<Element, Content>: UIViewControllerRepresenta
             .forward
         }
 
-        pageViewController.setViewControllers([viewController], direction: direction, animated: animated)
+        let transitionSource = visibleElement == nil ? "initial" : "external_selection"
+        let transitionGeneration = context.coordinator.beginPagerTransition(
+            phase: "programmatic_transition",
+            source: transitionSource,
+            visibleElement: visibleElement,
+            targetElement: selection,
+            pendingElement: nil,
+            gestureState: "none"
+        )
+        logger.info("Pager programmatic transition started")
+        pageViewController.setViewControllers(
+            [viewController],
+            direction: direction,
+            animated: animated
+        ) { [weak coordinator = context.coordinator] completed in
+            coordinator?.finishProgrammaticTransition(
+                generation: transitionGeneration,
+                phase: completed ? "idle" : "programmatic_incomplete",
+                source: transitionSource,
+                visibleElement: selection,
+                targetElement: selection,
+                pendingElement: nil,
+                gestureState: "none"
+            )
+            logger.info("Pager programmatic transition completed: \(completed)")
+        }
     }
 
     func makeController(_ element: Element) -> UIViewController {
@@ -146,6 +181,7 @@ extension _PageViewController {
 
         var parent: _PageViewController
         var transitionState = PageTransitionState<Element>()
+        private(set) var transitionGeneration = 0
 
         func pageViewController(
             _ pageViewController: UIPageViewController,
@@ -193,6 +229,19 @@ extension _PageViewController {
             willTransitionTo pendingViewControllers: [UIViewController]
         ) {
             transitionState.userTransitionWillBegin()
+            transitionGeneration += 1
+            let visibleElement = (pageViewController.viewControllers?.first as? PageContentController)?.element
+            let pendingElement = (pendingViewControllers.first as? PageContentController)?.element
+            recordPager(
+                generation: transitionGeneration,
+                phase: "manual_transition",
+                source: "user_gesture",
+                visibleElement: visibleElement,
+                targetElement: pendingElement,
+                pendingElement: pendingElement,
+                gestureState: "dragging"
+            )
+            logger.info("Pager manual transition started")
         }
 
         func pageViewController(
@@ -214,6 +263,91 @@ extension _PageViewController {
                     self?.parent.selection = pendingSelection
                 }
             }
+
+            recordPager(
+                generation: transitionGeneration,
+                phase: completed ? "idle" : "manual_cancelled",
+                source: "user_gesture",
+                visibleElement: visibleElement,
+                targetElement: visibleElement,
+                pendingElement: pendingSelection,
+                gestureState: "none"
+            )
+            logger.info("Pager manual transition finished: \(completed)")
+        }
+
+        func beginPagerTransition(
+            phase: String,
+            source: String,
+            visibleElement: Element?,
+            targetElement: Element?,
+            pendingElement: Element?,
+            gestureState: String
+        ) -> Int {
+            transitionGeneration += 1
+            recordPager(
+                generation: transitionGeneration,
+                phase: phase,
+                source: source,
+                visibleElement: visibleElement,
+                targetElement: targetElement,
+                pendingElement: pendingElement,
+                gestureState: gestureState
+            )
+            return transitionGeneration
+        }
+
+        func finishProgrammaticTransition(
+            generation: Int,
+            phase: String,
+            source: String,
+            visibleElement: Element?,
+            targetElement: Element?,
+            pendingElement: Element?,
+            gestureState: String
+        ) {
+            guard generation == transitionGeneration else {
+                logger.info("Ignoring stale pager completion: \(generation), current: \(transitionGeneration)")
+                return
+            }
+            recordPager(
+                generation: generation,
+                phase: phase,
+                source: source,
+                visibleElement: visibleElement,
+                targetElement: targetElement,
+                pendingElement: pendingElement,
+                gestureState: gestureState
+            )
+        }
+
+        func recordPager(
+            generation: Int,
+            phase: String,
+            source: String,
+            visibleElement: Element?,
+            targetElement: Element?,
+            pendingElement: Element?,
+            gestureState: String
+        ) {
+            crashContext.setPager(
+                generation: generation,
+                phase: phase,
+                source: source,
+                visibleItem: indexDescription(for: visibleElement),
+                targetItem: indexDescription(for: targetElement),
+                pendingItem: indexDescription(for: pendingElement),
+                gestureState: gestureState
+            )
+        }
+
+        private func indexDescription(for element: Element?) -> String {
+            guard let element,
+                  let index = parent.forEach.data.firstIndex(of: element)
+            else {
+                return "none"
+            }
+            return String(index)
         }
     }
 }

--- a/UI/UIx/Sources/UIKit/Miscellaneous/ModalPresentationCoordinator.swift
+++ b/UI/UIx/Sources/UIKit/Miscellaneous/ModalPresentationCoordinator.swift
@@ -3,13 +3,17 @@
 //
 //
 
+import Crashing
 import UIKit
+import VLogging
 
 public struct ModalPresentationRequest: Identifiable {
     // MARK: Lifecycle
 
-    private init(action: Action) {
+    private init(action: Action, owner: String, kind: String) {
         self.action = action
+        self.owner = owner
+        self.kind = kind
     }
 
     // MARK: Public
@@ -17,11 +21,19 @@ public struct ModalPresentationRequest: Identifiable {
     public let id = UUID()
 
     public static func present(_ viewController: UIViewController) -> Self {
-        Self(action: .present(viewController))
+        present(viewController, owner: "unspecified", kind: "modal")
+    }
+
+    public static func present(_ viewController: UIViewController, owner: String, kind: String) -> Self {
+        Self(action: .present(viewController), owner: owner, kind: kind)
     }
 
     public static var dismiss: Self {
-        Self(action: .dismiss)
+        dismiss(owner: "unspecified")
+    }
+
+    public static func dismiss(owner: String) -> Self {
+        Self(action: .dismiss, owner: owner, kind: "modal")
     }
 
     // MARK: Internal
@@ -32,6 +44,8 @@ public struct ModalPresentationRequest: Identifiable {
     }
 
     let action: Action
+    let owner: String
+    let kind: String
 }
 
 @MainActor
@@ -43,10 +57,24 @@ public final class ModalPresentationCoordinator: NSObject, ObservableObject, UIA
 
         switch request.action {
         case .present(let viewController):
+            presentationMetadata[ObjectIdentifier(viewController)] = (request.owner, request.kind)
+            crashContext.setPresentation(owner: request.owner, kind: request.kind, phase: "requested", interactive: false)
+            logger.info("Modal presentation requested: \(request.owner), kind: \(request.kind)")
             perform(stateMachine.requestPresentation(viewController))
         case .dismiss:
+            let owner = currentOwner ?? request.owner
+            crashContext.setPresentation(owner: owner, kind: currentKind ?? request.kind, phase: "dismiss_requested", interactive: false)
+            logger.info("Modal dismissal requested: \(owner)")
             perform(stateMachine.requestDismissal())
         }
+    }
+
+    public func presentationControllerWillDismiss(_ presentationController: UIPresentationController) {
+        recordCurrentPresentation(phase: "interactive_dismissing", interactive: true)
+    }
+
+    public func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
+        recordCurrentPresentation(phase: "interactive_dismissal_blocked", interactive: false)
     }
 
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
@@ -58,6 +86,9 @@ public final class ModalPresentationCoordinator: NSObject, ObservableObject, UIA
     private weak var presentingViewController: UIViewController?
     private weak var presentedViewController: UIViewController?
     private var stateMachine = ModalPresentationStateMachine<UIViewController>()
+    private var presentationMetadata: [ObjectIdentifier: (owner: String, kind: String)] = [:]
+    private var currentOwner: String?
+    private var currentKind: String?
 
     private func perform(_ action: ModalPresentationStateMachine<UIViewController>.Action?) {
         guard let action else { return }
@@ -72,21 +103,37 @@ public final class ModalPresentationCoordinator: NSObject, ObservableObject, UIA
 
     private func present(_ viewController: UIViewController) {
         guard let presentingViewController else {
+            if let metadata = presentationMetadata.removeValue(forKey: ObjectIdentifier(viewController)) {
+                crashContext.clearPresentation(owner: metadata.owner)
+            }
             stateMachine.cancel()
             return
         }
 
+        let metadata = presentationMetadata.removeValue(forKey: ObjectIdentifier(viewController)) ?? ("unspecified", "modal")
+        currentOwner = metadata.owner
+        currentKind = metadata.kind
+        recordCurrentPresentation(phase: "presenting", interactive: false)
         presentedViewController = viewController
         presentingViewController.present(viewController, animated: true) { [weak self, weak viewController] in
             guard let self, presentedViewController === viewController else { return }
+            recordCurrentPresentation(phase: "presented", interactive: false)
             perform(stateMachine.didPresent())
         }
         viewController.presentationController?.delegate = self
     }
 
     private func dismiss() {
+        recordCurrentPresentation(phase: "dismissing", interactive: false)
         guard let presentedViewController else {
-            perform(stateMachine.didDismiss())
+            let dismissedOwner = currentOwner
+            currentOwner = nil
+            currentKind = nil
+            let action = stateMachine.didDismiss()
+            if let dismissedOwner {
+                crashContext.clearPresentation(owner: dismissedOwner)
+            }
+            perform(action)
             return
         }
         presentedViewController.dismiss(animated: true) { [weak self, weak presentedViewController] in
@@ -98,7 +145,20 @@ public final class ModalPresentationCoordinator: NSObject, ObservableObject, UIA
     private func didDismiss(_ viewController: UIViewController) {
         guard presentedViewController === viewController else { return }
         presentedViewController = nil
-        perform(stateMachine.didDismiss())
+        let dismissedOwner = currentOwner
+        currentOwner = nil
+        currentKind = nil
+        let action = stateMachine.didDismiss()
+        if let dismissedOwner {
+            crashContext.clearPresentation(owner: dismissedOwner)
+            logger.info("Modal presentation dismissed: \(dismissedOwner)")
+        }
+        perform(action)
+    }
+
+    private func recordCurrentPresentation(phase: String, interactive: Bool) {
+        guard let currentOwner, let currentKind else { return }
+        crashContext.setPresentation(owner: currentOwner, kind: currentKind, phase: phase, interactive: interactive)
     }
 }
 

--- a/UI/UIx/Tests/ModalPresentationStateMachineTests.swift
+++ b/UI/UIx/Tests/ModalPresentationStateMachineTests.swift
@@ -3,10 +3,24 @@
 //
 //
 
+import UIKit
 import XCTest
 @testable import UIx
 
 final class ModalPresentationStateMachineTests: XCTestCase {
+    func testPresentationRequestPreservesDiagnosticMetadata() {
+        let viewController = UIViewController()
+
+        let request = ModalPresentationRequest.present(
+            viewController,
+            owner: "advanced_audio_options",
+            kind: "sheet"
+        )
+
+        XCTAssertEqual(request.owner, "advanced_audio_options")
+        XCTAssertEqual(request.kind, "sheet")
+    }
+
     func test_dismissalDuringPresentation_waitsForPresentationToFinish() {
         var sut = ModalPresentationStateMachine<Int>()
 


### PR DESCRIPTION
## Summary

- centralize low-cardinality Crashlytics state in `CrashContext`, with write deduplication and owner-aware clearing
- capture startup, app lifecycle, navigation, Quran mode, visible pages, list generations, pager transitions, modal presentation, persistence, sync, and audio state
- migrate legacy audio/page keys to stable primitives and remove the contradictory `DownloadingQuran` flag in favor of `audio_state`
- make `CrasherKey`, raw `setValue`, constructors, and handler storage internal/private; retain only the public host adapter and error-recording boundary
- add regression coverage for deduplication, stale-owner clearing, list/pager/presentation snapshots, audio state, and normalized page ranges

## Crashlytics issue mapping

| Crash area | Crashlytics issue(s) | Context added |
| --- | --- | --- |
| SwiftUI/UIKit list updates, `UITableView` internal inconsistency, and view-controller/pager navigation failures on iOS 15 | [Foundation `_userInfoForFileAndLine`](https://console.firebase.google.com/u/0/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/27840b0a684f5d45083b3c2ae9fe958e) | active list owner/mode, row and section counts, update generation/reason, Quran mode, selected translations, pager source/phase/items/gesture, presentation owner/phase, current screen |
| Quran text/rendering crash | [`AG::AttributeID::size() const`](https://console.firebase.google.com/u/0/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/77e125e11909c7fc1466b28e35e7e290) | reading ID, Quran mode, translation count, visible page range/count, current screen, lifecycle/protected-data state |
| Network/audio failure context | [`NSPOSIXErrorDomain (-9805)`](https://console.firebase.google.com/u/0/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/4d42d420761d3e8c4ebc6d6385ed06a6) | audio state, reciter, playing sura/ayah, application state, startup phase |
| Sync authentication failures | [`AuthenticationClientError (2)`](https://console.firebase.google.com/u/0/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios.sync/issues/f46ed956e774ee1852fdde4254e87db3) | sync phase, startup phase, persistence store/operation/phase, app lifecycle and protected-data availability |

The Foundation group contains multiple UIKit exception messages. These keys intentionally identify the active list/pager/presentation at crash time instead of assuming every event originated from Home or from one root cause.

## Integration note

The private app Crashlytics adapter must implement `setCustomValue(_:forKey:)`; the typed key API is no longer public.

## Validation

- `make format-lint`
- `make test-no-sync`
- `make test-sync`
- private Quran app simulator build using the local package
- `git diff --check`