### PR TITLE
fix(translations): publish coherent list snapshots

### DIFF
--- a/Features/QuranTranslationFeature/Sources/ContentTranslationViewModel.swift
+++ b/Features/QuranTranslationFeature/Sources/ContentTranslationViewModel.swift
@@ -17,6 +17,12 @@ import TranslationService
 import UIx
 import VLogging
 
+struct LoadedTranslationContent {
+    var verses: [AyahNumber] = []
+    var translations: [Translation] = []
+    var verseTexts: [AyahNumber: VerseText] = [:]
+}
+
 @MainActor
 public final class ContentTranslationViewModel: ObservableObject {
     // MARK: Lifecycle
@@ -78,12 +84,8 @@ public final class ContentTranslationViewModel: ObservableObject {
         }
     }
 
-    @Published var translations: [Translation] = [] {
-        didSet { recordListUpdate(reason: "translations_loaded") }
-    }
-
-    @Published var verseTexts: [AyahNumber: VerseText] = [:] {
-        didSet { recordListUpdate(reason: "verse_texts_loaded") }
+    @Published private(set) var loadedContent = LoadedTranslationContent() {
+        didSet { recordListUpdate(reason: "content_loaded") }
     }
 
     @Published var expandedTranslations: [AyahNumber: [Translation: [Range<String.Index>]]] = [:] {
@@ -98,6 +100,14 @@ public final class ContentTranslationViewModel: ObservableObject {
     @Published var footnote: TranslationFootnote?
 
     @Published var scrollToItem: TranslationItemId?
+
+    var translations: [Translation] {
+        loadedContent.translations
+    }
+
+    var verseTexts: [AyahNumber: VerseText] {
+        loadedContent.verseTexts
+    }
 
     var items: [TranslationItem] {
         guard let page = verseTexts.first?.key.page else {
@@ -184,7 +194,7 @@ public final class ContentTranslationViewModel: ObservableObject {
                 }
             }
 
-            let isLastVerseInTheView = verses.last == verse
+            let isLastVerseInTheView = loadedContent.verses.last == verse
             if !isLastVerseInTheView {
                 items.append(.verseSeparator(TranslationVerseSeparator(verse: verse), color))
             }
@@ -200,14 +210,34 @@ public final class ContentTranslationViewModel: ObservableObject {
 
     func load() async {
         do {
-            logger.info("Loading translations data; selectedTranslations='\(selectedTranslations)'; verses='\(verses)'")
+            let requestedVerses = verses
+            let requestedTranslationIds = selectedTranslations
+            logger.info("Loading translations data; selectedTranslations='\(requestedTranslationIds)'; verses='\(requestedVerses)'")
+
             let localTranslations = try await localTranslationsRetriever.getLocalTranslations()
-            translations = selectedTranslationsPreferences.selectedTranslations(from: localTranslations)
+            try Task.checkCancellation()
 
-            let verses = verses
-            verseTexts = try await dataService.textForVerses(verses, translations: translations)
+            let translationsById = Dictionary(uniqueKeysWithValues: localTranslations.map { ($0.id, $0) })
+            let requestedTranslations = requestedTranslationIds.compactMap { translationsById[$0] }
+            let requestedVerseTexts = try await dataService.textForVerses(
+                requestedVerses,
+                translations: requestedTranslations
+            )
+            try Task.checkCancellation()
 
+            guard requestedVerses == verses, requestedTranslationIds == selectedTranslations else {
+                logger.info("Discarding stale translations data")
+                return
+            }
+
+            commitLoadedContent(
+                verses: requestedVerses,
+                translations: requestedTranslations,
+                verseTexts: requestedVerseTexts
+            )
             scrollToVerseIfNeeded()
+        } catch is CancellationError {
+            logger.info("Cancelled translations data load")
         } catch {
             // TODO: should show error to the user
             crasher.recordError(error, reason: "Failed to retrieve quran page details")
@@ -226,6 +256,18 @@ public final class ContentTranslationViewModel: ObservableObject {
 
     func ayahAtPoint(_ point: CGPoint) -> AyahNumber? {
         tracker.itemAtPoint(point)?.ayah
+    }
+
+    func commitLoadedContent(
+        verses: [AyahNumber],
+        translations: [Translation],
+        verseTexts: [AyahNumber: VerseText]
+    ) {
+        loadedContent = LoadedTranslationContent(
+            verses: verses,
+            translations: translations,
+            verseTexts: verseTexts
+        )
     }
 
     // MARK: Private
@@ -291,7 +333,7 @@ public final class ContentTranslationViewModel: ObservableObject {
     }
 
     private func performOnTranslationText(translationId: Translation.ID, sura: Int, ayah: Int, _ body: (AyahNumber, Translation, TranslationString) -> Void) {
-        guard let quran = verses.first?.quran else {
+        guard let quran = loadedContent.verses.first?.quran else {
             return
         }
         let ayah = AyahNumber(quran: quran, sura: sura, ayah: ayah)

--- a/Features/QuranTranslationFeature/Tests/ContentTranslationViewModelTests.swift
+++ b/Features/QuranTranslationFeature/Tests/ContentTranslationViewModelTests.swift
@@ -1,0 +1,80 @@
+//
+//  ContentTranslationViewModelTests.swift
+//
+
+import Combine
+import QuranKit
+import QuranText
+import XCTest
+@testable import QuranTranslationFeature
+
+@MainActor
+final class ContentTranslationViewModelTests: XCTestCase {
+    func testCommitLoadedContentPublishesOneCoherentSnapshot() {
+        let sut = makeSUT()
+        let verse = Quran.hafsMadani1405.firstVerse
+        let firstTranslation = makeTranslation(id: 1)
+        sut.commitLoadedContent(
+            verses: [verse],
+            translations: [firstTranslation],
+            verseTexts: [verse: makeVerseText(translationCount: 1)]
+        )
+
+        var snapshots: [[Int]] = []
+        let cancellable = sut.$loadedContent
+            .dropFirst()
+            .sink { content in
+                snapshots.append([
+                    content.translations.count,
+                    content.verseTexts[verse]?.translations.count ?? -1,
+                ])
+            }
+
+        sut.commitLoadedContent(
+            verses: [verse],
+            translations: [firstTranslation, makeTranslation(id: 2)],
+            verseTexts: [verse: makeVerseText(translationCount: 2)]
+        )
+
+        XCTAssertEqual(snapshots, [[2, 2]])
+        withExtendedLifetime(cancellable) { }
+    }
+
+    private func makeSUT() -> ContentTranslationViewModel {
+        let unavailableURL = URL(fileURLWithPath: "/tmp/unavailable-quran-translation-test")
+        return ContentTranslationViewModel(
+            localTranslationsRetriever: .init(databasesURL: unavailableURL),
+            dataService: .init(databasesURL: unavailableURL, quranFileURL: unavailableURL),
+            highlightsService: .init()
+        )
+    }
+
+    private func makeTranslation(id: Translation.ID) -> Translation {
+        Translation(
+            id: id,
+            displayName: "Translation \(id)",
+            translator: nil,
+            translatorForeign: nil,
+            fileURL: URL(string: "https://example.com/translation-\(id).zip")!,
+            fileName: "translation-\(id).db",
+            languageCode: "en",
+            version: 1
+        )
+    }
+
+    private func makeVerseText(translationCount: Int) -> VerseText {
+        VerseText(
+            arabicText: "Arabic",
+            translations: (0 ..< translationCount).map { index in
+                .string(.init(
+                    text: "Translation \(index)",
+                    quranRanges: [],
+                    footnoteRanges: [],
+                    footnotes: []
+                ))
+            },
+            arabicPrefix: [],
+            arabicSuffix: []
+        )
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -706,13 +706,16 @@ private func featuresTargets() -> [[Target]] {
             "NoorUI",
         ]),
 
-        target(type, name: "QuranTranslationFeature", hasTests: false, dependencies: [
+        target(type, name: "QuranTranslationFeature", dependencies: [
             "AppDependencies",
             "NoorUI",
             "ReadingService",
             "QuranPagesFeature",
             "QuranLocalization",
             "QuranTextKit",
+        ], testDependencies: [
+            "QuranKit",
+            "QuranText",
         ]),
 
         target(type, name: "QuranContentFeature", hasTests: false, dependencies: [

--- a/QuranEngine-Package.xctestplan
+++ b/QuranEngine-Package.xctestplan
@@ -245,6 +245,13 @@
     {
       "target" : {
         "containerPath" : "container:",
+        "identifier" : "QuranTranslationFeatureTests",
+        "name" : "QuranTranslationFeatureTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
         "identifier" : "SettingsFeatureTests",
         "name" : "SettingsFeatureTests"
       }


### PR DESCRIPTION
## Summary
- keep the last complete translation rows visible while replacement data loads
- publish translation metadata and verse text in one coherent observable update
- reject cancelled and stale async results
- add QuranTranslationFeature regression coverage and include it in the package test plan

## Crashlytics
Firebase group: https://console.firebase.google.com/u/1/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/27840b0a684f5d45083b3c2ae9fe958e

This PR fixes one real signature inside that mixed group: iOS/iPadOS 15.8.x `UITableViewUpdateSupport` / `SwiftUI.UpdateCoalescingTableView` internal-inconsistency crashes. Observed transitions include 114→228 translation rows and out-of-range old-row counts while a selected translation changes.

The same Firebase group also contains a `UIPageViewController` containment crash and a modern SwiftUI collection-scroll bounds crash. Those are separate root causes and are intentionally not marked fixed by this PR.

## Root cause
`ContentTranslationViewModel.load()` published the replacement `translations` before its matching `verseTexts` arrived. The computed list intentionally returned `[]` during that mismatch, forcing SwiftUI through complete-list deletion and reinsertion. Concurrent `.task` loads could also commit stale results after cancellation.

The model now captures one request, loads it off-state, validates cancellation/current inputs, then atomically commits a coherent loaded-content value.

## Verification
- `make test-no-sync TARGET=QuranTranslationFeatureTests`
- `make test-sync TARGET=QuranTranslationFeatureTests`
- `make format-lint`

## Stack
Depends on #966.