### PR TITLE
fix(quran): validate deferred scroll targets

### DIFF
--- a/Features/QuranTranslationFeature/Sources/ContentTranslationView.swift
+++ b/Features/QuranTranslationFeature/Sources/ContentTranslationView.swift
@@ -69,6 +69,8 @@ private struct ContentTranslationViewBody: View {
         .openTranslationURL(openURL)
         .trackCollection(with: tracker)
         .sheet(item: $footnote) { $0 }
-        .quranScrolling(scrollToValue: scrollToItem)
+        .quranScrolling(scrollToValue: scrollToItem) { item in
+            items.contains { $0.id == item } ? item : nil
+        }
     }
 }

--- a/UI/NoorUI/Sources/Features/Quran/QuranScrollingViewModifier.swift
+++ b/UI/NoorUI/Sources/Features/Quran/QuranScrollingViewModifier.swift
@@ -20,6 +20,21 @@ final class QuranScrollScheduler: ObservableObject {
         }
     }
 
+    func scheduleScroll<Value, ID>(
+        to value: Value?,
+        transform: @escaping @MainActor (Value) -> ID?,
+        action: @escaping @MainActor (ID) -> Void
+    ) {
+        guard let value else {
+            cancel()
+            return
+        }
+        schedule {
+            guard let id = transform(value) else { return }
+            action(id)
+        }
+    }
+
     func cancel() {
         task?.cancel()
         task = nil
@@ -52,9 +67,7 @@ struct QuranScrollingViewModifier<Value: Equatable, ID: Hashable>: ViewModifier 
     }
 
     private func scheduleScroll(to value: Value?, using scrollView: ScrollViewProxy) {
-        guard let value else { return }
-        scheduler.schedule {
-            guard let id = transform(value) else { return }
+        scheduler.scheduleScroll(to: value, transform: transform) { id in
             withAnimation(.easeInOut(duration: 0.25)) {
                 scrollView.scrollTo(id, anchor: anchor)
             }

--- a/UI/NoorUI/Tests/QuranScrollSchedulerTests.swift
+++ b/UI/NoorUI/Tests/QuranScrollSchedulerTests.swift
@@ -18,4 +18,31 @@ final class QuranScrollSchedulerTests: XCTestCase {
 
         await fulfillment(of: [latestScroll, staleScroll], timeout: 0.1)
     }
+
+    func testRemovingScrollTargetCancelsPendingScroll() async {
+        let scheduler = QuranScrollScheduler()
+        let staleScroll = expectation(description: "Stale scroll is cancelled")
+        staleScroll.isInverted = true
+
+        scheduler.scheduleScroll(to: 1, transform: { $0 }) { _ in
+            staleScroll.fulfill()
+        }
+        scheduler.scheduleScroll(to: nil as Int?, transform: { $0 }) { _ in
+            XCTFail("A removed target must not scroll")
+        }
+
+        await fulfillment(of: [staleScroll], timeout: 0.1)
+    }
+
+    func testInvalidScrollTargetDoesNotRunAction() async {
+        let scheduler = QuranScrollScheduler()
+        let invalidScroll = expectation(description: "Invalid scroll does not run")
+        invalidScroll.isInverted = true
+
+        scheduler.scheduleScroll(to: 1, transform: { _ in nil as Int? }) { _ in
+            invalidScroll.fulfill()
+        }
+
+        await fulfillment(of: [invalidScroll], timeout: 0.1)
+    }
 }


### PR DESCRIPTION
## Summary
- cancel yielded Quran scroll work when its target is removed
- validate translation targets against the current rendered item IDs at execution time
- cover removed and invalid deferred-scroll requests

## Crashlytics
Firebase group: https://console.firebase.google.com/u/1/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/27840b0a684f5d45083b3c2ae9fe958e

This PR fixes the modern SwiftUI collection signature inside that mixed group:

`Attempted to scroll the collection view to an out-of-bounds section (0) when there are only 0 sections.`

The event is an iPadOS 26.5.2 translation-mode crash after adding a second translation. Its stack enters `SwiftUI.UpdateCoalescingCollectionView.updateContent()` through `UICollectionView._validateScrollingTargetIndexPath`.

## Root cause
`QuranScrollScheduler` yields before invoking `ScrollViewProxy.scrollTo`. Removing the value during that yield did not cancel the already queued operation, and translation mode passed the stale ID without checking that the rebuilt snapshot still contained it.

#967 removes the transient incoherent translation snapshot. This PR independently enforces the scroll invariant: a deferred command may execute only while its target exists in the current rendered snapshot.

## Verification
- `make test-no-sync TARGET=NoorUITests`
- `make test-sync TARGET=NoorUITests`
- `make format-lint`

## Stack
Depends on #967, which depends on #966.