### PR TITLE
fix(navigation): isolate SwiftUI hosting graphs

### DIFF
--- a/UI/UIx/Sources/SwiftUI/Views/CocoaNavigationView.swift
+++ b/UI/UIx/Sources/SwiftUI/Views/CocoaNavigationView.swift
@@ -62,18 +62,19 @@ public struct Navigator {
         animated: Bool = true,
         @ViewBuilder _ view: () -> some View
     ) {
+        guard let navigationController else { return }
         let view = view()
-            .environment(\.navigator, Navigator(navigationController: navigationController))
+            .environment(\.navigator, self)
         let viewController = ElementController(rootView: view, configuration: configuration)
         navigationController.pushViewController(viewController, animated: animated)
     }
 
     public func pop(animated: Bool = true) {
-        navigationController.popViewController(animated: animated)
+        navigationController?.popViewController(animated: animated)
     }
 
     public func popToRoot(animated: Bool = true) {
-        navigationController.popToRootViewController(animated: animated)
+        navigationController?.popToRootViewController(animated: animated)
     }
 
     public func present(
@@ -81,19 +82,42 @@ public struct Navigator {
         animated: Bool = true,
         @ViewBuilder _ view: () -> some View
     ) {
+        guard let navigationController else { return }
         let view = view()
-            .environment(\.navigator, Navigator(navigationController: navigationController))
+            .environment(\.navigator, self)
         let viewController = ElementController(rootView: view, configuration: configuration)
         navigationController.present(viewController, animated: animated)
     }
 
     public func dismiss(animated: Bool = true, completion: (() -> Void)? = nil) {
+        guard let navigationController else {
+            completion?()
+            return
+        }
         navigationController.dismiss(animated: animated, completion: completion)
     }
 
     // MARK: Internal
 
-    let navigationController: UINavigationController
+    init(navigationController: UINavigationController) {
+        navigationControllerReference = WeakNavigationControllerReference(navigationController)
+    }
+
+    var navigationController: UINavigationController? {
+        navigationControllerReference.value
+    }
+
+    // MARK: Private
+
+    private let navigationControllerReference: WeakNavigationControllerReference
+}
+
+private final class WeakNavigationControllerReference {
+    init(_ value: UINavigationController) {
+        self.value = value
+    }
+
+    weak var value: UINavigationController?
 }
 
 extension EnvironmentValues {
@@ -148,9 +172,11 @@ private struct NavigationViewBody<Root: View>: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> CocoaNavigationController {
         let navigationController = CocoaNavigationController()
-        let navigatorRoot = root
-            .environment(\.navigator, Navigator(navigationController: navigationController))
-        let controller = ElementController(rootView: AnyView(navigatorRoot), configuration: rootConfiguration)
+        let controller = makeNavigationRootController(
+            root: root,
+            navigator: Navigator(navigationController: navigationController),
+            configuration: rootConfiguration
+        )
         navigationController.setViewControllers([controller], animated: false)
         navigationController.delegate = context.coordinator
         navigationController.configuration = rootConfiguration
@@ -158,10 +184,11 @@ private struct NavigationViewBody<Root: View>: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ navigationController: CocoaNavigationController, context: Context) {
-        if let rootViewController = navigationController.viewControllers.first as? ElementController<AnyView> {
-            let navigatorRoot = root
-                .environment(\.navigator, Navigator(navigationController: navigationController))
-            rootViewController.rootView = AnyView(navigatorRoot)
+        if let rootViewController = navigationController.viewControllers.first as? ElementController<NavigationRootView<Root>> {
+            rootViewController.rootView = NavigationRootView(
+                root: root,
+                navigator: Navigator(navigationController: navigationController)
+            )
             rootViewController.configuration = rootConfiguration
         }
         navigationController.navigationBar.prefersLargeTitles = prefersLargeTitles
@@ -176,6 +203,27 @@ private struct NavigationViewBody<Root: View>: UIViewControllerRepresentable {
     func makeCoordinator() -> Coordinator {
         Coordinator()
     }
+}
+
+private struct NavigationRootView<Root: View>: View {
+    let root: Root
+    let navigator: Navigator
+
+    var body: some View {
+        root.environment(\.navigator, navigator)
+    }
+}
+
+@MainActor
+func makeNavigationRootController(
+    root: some View,
+    navigator: Navigator,
+    configuration: NavigationConfiguration?
+) -> UIViewController {
+    ElementController(
+        rootView: NavigationRootView(root: root, navigator: navigator),
+        configuration: configuration
+    )
 }
 
 private class CocoaNavigationController: UINavigationController {

--- a/UI/UIx/Tests/CocoaNavigationViewTests.swift
+++ b/UI/UIx/Tests/CocoaNavigationViewTests.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+import XCTest
+@testable import UIx
+
+@MainActor
+final class CocoaNavigationViewTests: XCTestCase {
+    func testNavigatorDoesNotRetainNavigationController() {
+        var navigationController: UINavigationController? = UINavigationController()
+        weak let weakNavigationController = navigationController
+        let navigator = Navigator(navigationController: navigationController!)
+
+        navigationController = nil
+
+        XCTAssertNil(weakNavigationController)
+        XCTAssertNil(navigator.navigationController)
+    }
+
+    func testRootHostingControllerUsesConcreteViewType() {
+        let navigationController = UINavigationController()
+        let rootController = makeNavigationRootController(
+            root: Text("Root"),
+            navigator: Navigator(navigationController: navigationController),
+            configuration: nil
+        )
+
+        XCTAssertFalse(String(reflecting: type(of: rootController)).contains("AnyView"))
+    }
+}


### PR DESCRIPTION
## Summary
- keep `CocoaNavigationView` root hosting types concrete instead of wrapping every update in `AnyView`
- make the environment `Navigator` hold its navigation controller weakly
- cover both graph-boundary type preservation and controller ownership

## Crashlytics
This one real root cause is split across three Firebase groups:

- `AG::AttributeID::size() const`: https://console.firebase.google.com/u/1/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/77e125e11909c7fc1466b28e35e7e290
- `<deduplicated_symbol>` abort: https://console.firebase.google.com/u/1/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/038cde45fb94b5512bba6dfbaf01568b
- `create_offset_attribute` abort: https://console.firebase.google.com/u/1/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/716c63e19ff316f29bbd1498676448ac

All ten 2.6.2 events are iOS 18 and converge on `PlaceholderInfo.makeItem` → `ModifiedElements.makeElements` → `Attribute.makeReusable` → `AG::Graph::add_indirect_attribute`. Crash reasons include:

- `AttributeGraph precondition failure: attribute references cannot cross graph namespaces.`
- `AttributeGraph precondition failure: invalid size for indirect attribute: 4 vs 1.`
- null dereference in `AG::AttributeID::size()` while creating the same indirect attribute

Crash screen classes consistently identify `UIx.ElementController<SwiftUI.AnyView>`.

## Root cause
`CocoaNavigationView` accepted a SwiftUI root from one graph, repeatedly erased it to `AnyView`, and assigned that erased value to a separate `UIHostingController` graph. Recent iOS 18 SwiftUI reusable-placeholder paths preserve indirect attributes across those updates and reject the cross-namespace reference.

The hosted root is now a stable concrete `NavigationRootView<Root>`. The environment navigator also no longer forms `UINavigationController → UIHostingController → SwiftUI environment → UINavigationController` retain cycles that keep stale hosting graphs alive.

## Verification
- `make test-no-sync TARGET=UIxTests`
- `make test-sync TARGET=UIxTests`
- `make format-lint`

## Stack
Depends on #968 → #967 → #966.