### PR TITLE
Fix pager transition lifecycle crashes

### DIFF
--- a/UI/NoorUI/Sources/Pager/PageViewController.swift
+++ b/UI/NoorUI/Sources/Pager/PageViewController.swift
@@ -108,17 +108,17 @@ private struct _PageViewController<Element, Content>: UIViewControllerRepresenta
             return
         }
 
-        if !context.coordinator.transitionState.shouldApply(selection) {
+        guard context.coordinator.transitionState.requestProgrammaticTransition(to: selection) == .started else {
             context.coordinator.recordPager(
                 generation: context.coordinator.transitionGeneration,
-                phase: "manual_transition",
+                phase: "selection_deferred",
                 source: "external_selection_deferred",
                 visibleElement: visibleElement,
                 targetElement: selection,
                 pendingElement: selection,
-                gestureState: "dragging"
+                gestureState: context.coordinator.transitionState.isUserTransitionInProgress ? "dragging" : "none"
             )
-            logger.info("Cannot change page while user dragging in progress")
+            logger.info("Cannot change page while another pager transition is active")
             return
         }
 
@@ -143,7 +143,6 @@ private struct _PageViewController<Element, Content>: UIViewControllerRepresenta
             pendingElement: nil,
             gestureState: "none"
         )
-        context.coordinator.transitionState.programmaticTransitionWillBegin()
         logger.info("Pager programmatic transition started")
         pageViewController.setViewControllers(
             [viewController],
@@ -236,8 +235,14 @@ extension _PageViewController {
             _ pageViewController: UIPageViewController,
             willTransitionTo pendingViewControllers: [UIViewController]
         ) {
-            if transitionState.userTransitionWillBegin() {
+            switch transitionState.userTransitionWillBegin() {
+            case .started:
                 transitionGeneration += 1
+            case .continuedGesture:
+                break
+            case .ignored:
+                logger.info("Ignoring pager user transition while another transition is active")
+                return
             }
             let visibleElement = (pageViewController.viewControllers?.first as? PageContentController)?.element
             let pendingElement = (pendingViewControllers.first as? PageContentController)?.element
@@ -404,6 +409,17 @@ extension _PageViewController {
 struct PageTransitionState<Element: Equatable> {
     // MARK: Internal
 
+    enum UserTransitionStart: Equatable {
+        case started
+        case continuedGesture
+        case ignored
+    }
+
+    enum ProgrammaticTransitionRequest: Equatable {
+        case started
+        case deferred
+    }
+
     var isUserTransitionInProgress: Bool {
         phase == .userGesture || phase == .userTransition
     }
@@ -419,33 +435,29 @@ struct PageTransitionState<Element: Equatable> {
         return true
     }
 
-    mutating func userTransitionWillBegin() -> Bool {
+    mutating func userTransitionWillBegin() -> UserTransitionStart {
         switch phase {
         case .idle:
             phase = .userTransition
             pendingSelection = nil
-            return true
+            return .started
         case .userGesture:
             phase = .userTransition
-            return false
+            return .continuedGesture
         case .userTransition, .programmatic:
-            return false
+            return .ignored
         }
     }
 
-    mutating func programmaticTransitionWillBegin() {
-        precondition(phase == .idle)
+    mutating func requestProgrammaticTransition(to selection: Element) -> ProgrammaticTransitionRequest {
+        guard phase == .idle else {
+            pendingSelection = selection
+            return .deferred
+        }
+
         phase = .programmatic
         pendingSelection = nil
-    }
-
-    mutating func shouldApply(_ selection: Element) -> Bool {
-        guard phase != .idle else {
-            return true
-        }
-
-        pendingSelection = selection
-        return false
+        return .started
     }
 
     mutating func userGestureDidFinish(visibleElement: Element?) -> Element? {

--- a/UI/NoorUI/Sources/Pager/PageViewController.swift
+++ b/UI/NoorUI/Sources/Pager/PageViewController.swift
@@ -89,6 +89,7 @@ private struct _PageViewController<Element, Content>: UIViewControllerRepresenta
 
         pageViewController.dataSource = context.coordinator
         pageViewController.delegate = context.coordinator
+        context.coordinator.observePagingInteraction(in: pageViewController)
 
         pageViewController.view.backgroundColor = .clear
 
@@ -142,19 +143,19 @@ private struct _PageViewController<Element, Content>: UIViewControllerRepresenta
             pendingElement: nil,
             gestureState: "none"
         )
+        context.coordinator.transitionState.programmaticTransitionWillBegin()
         logger.info("Pager programmatic transition started")
         pageViewController.setViewControllers(
             [viewController],
             direction: direction,
             animated: animated
-        ) { [weak coordinator = context.coordinator] completed in
+        ) { [weak pageViewController, weak coordinator = context.coordinator] completed in
             coordinator?.finishProgrammaticTransition(
+                pageViewController: pageViewController,
                 generation: transitionGeneration,
                 phase: completed ? "idle" : "programmatic_incomplete",
                 source: transitionSource,
-                visibleElement: selection,
                 targetElement: selection,
-                pendingElement: nil,
                 gestureState: "none"
             )
             logger.info("Pager programmatic transition completed: \(completed)")
@@ -182,6 +183,13 @@ extension _PageViewController {
         var parent: _PageViewController
         var transitionState = PageTransitionState<Element>()
         private(set) var transitionGeneration = 0
+        private weak var pageViewController: UIPageViewController?
+
+        func observePagingInteraction(in pageViewController: UIPageViewController) {
+            self.pageViewController = pageViewController
+            let scrollView = pageViewController.view.subviews.first { $0 is UIScrollView } as? UIScrollView
+            scrollView?.panGestureRecognizer.addTarget(self, action: #selector(pagingPanGestureChanged(_:)))
+        }
 
         func pageViewController(
             _ pageViewController: UIPageViewController,
@@ -228,8 +236,9 @@ extension _PageViewController {
             _ pageViewController: UIPageViewController,
             willTransitionTo pendingViewControllers: [UIViewController]
         ) {
-            transitionState.userTransitionWillBegin()
-            transitionGeneration += 1
+            if transitionState.userTransitionWillBegin() {
+                transitionGeneration += 1
+            }
             let visibleElement = (pageViewController.viewControllers?.first as? PageContentController)?.element
             let pendingElement = (pendingViewControllers.first as? PageContentController)?.element
             recordPager(
@@ -252,17 +261,7 @@ extension _PageViewController {
         ) {
             let visibleElement = (pageViewController.viewControllers?.first as? PageContentController)?.element
             let pendingSelection = transitionState.userTransitionDidFinish(visibleElement: visibleElement)
-
-            if let visibleElement {
-                parent.selection = visibleElement
-            }
-
-            if let pendingSelection {
-                Task { @MainActor [weak self] in
-                    await Task.yield()
-                    self?.parent.selection = pendingSelection
-                }
-            }
+            reconcileSelection(visibleElement: visibleElement, pendingSelection: pendingSelection)
 
             recordPager(
                 generation: transitionGeneration,
@@ -298,27 +297,77 @@ extension _PageViewController {
         }
 
         func finishProgrammaticTransition(
+            pageViewController: UIPageViewController?,
             generation: Int,
             phase: String,
             source: String,
-            visibleElement: Element?,
             targetElement: Element?,
-            pendingElement: Element?,
             gestureState: String
         ) {
             guard generation == transitionGeneration else {
                 logger.info("Ignoring stale pager completion: \(generation), current: \(transitionGeneration)")
                 return
             }
+            let visibleElement = (pageViewController?.viewControllers?.first as? PageContentController)?.element
+            let pendingSelection = transitionState.programmaticTransitionDidFinish(visibleElement: visibleElement)
+            reconcileSelection(visibleElement: visibleElement, pendingSelection: pendingSelection)
             recordPager(
                 generation: generation,
                 phase: phase,
                 source: source,
                 visibleElement: visibleElement,
                 targetElement: targetElement,
-                pendingElement: pendingElement,
+                pendingElement: pendingSelection,
                 gestureState: gestureState
             )
+        }
+
+        @objc
+        private func pagingPanGestureChanged(_ gestureRecognizer: UIPanGestureRecognizer) {
+            switch gestureRecognizer.state {
+            case .began:
+                guard transitionState.userGestureWillBegin() else { return }
+                transitionGeneration += 1
+                let visibleElement = (pageViewController?.viewControllers?.first as? PageContentController)?.element
+                recordPager(
+                    generation: transitionGeneration,
+                    phase: "manual_interaction",
+                    source: "pan_gesture",
+                    visibleElement: visibleElement,
+                    targetElement: nil,
+                    pendingElement: nil,
+                    gestureState: "dragging"
+                )
+            case .ended, .cancelled, .failed:
+                guard transitionState.isGestureAwaitingPageTransition else { return }
+                let visibleElement = (pageViewController?.viewControllers?.first as? PageContentController)?.element
+                let pendingSelection = transitionState.userGestureDidFinish(visibleElement: visibleElement)
+                reconcileSelection(visibleElement: visibleElement, pendingSelection: pendingSelection)
+                recordPager(
+                    generation: transitionGeneration,
+                    phase: "idle",
+                    source: "pan_gesture",
+                    visibleElement: visibleElement,
+                    targetElement: visibleElement,
+                    pendingElement: pendingSelection,
+                    gestureState: "none"
+                )
+            default:
+                break
+            }
+        }
+
+        private func reconcileSelection(visibleElement: Element?, pendingSelection: Element?) {
+            if let visibleElement {
+                parent.selection = visibleElement
+            }
+
+            if let pendingSelection {
+                Task { @MainActor [weak self] in
+                    await Task.yield()
+                    self?.parent.selection = pendingSelection
+                }
+            }
         }
 
         func recordPager(
@@ -355,15 +404,43 @@ extension _PageViewController {
 struct PageTransitionState<Element: Equatable> {
     // MARK: Internal
 
-    private(set) var isUserTransitionInProgress = false
+    var isUserTransitionInProgress: Bool {
+        phase == .userGesture || phase == .userTransition
+    }
 
-    mutating func userTransitionWillBegin() {
-        isUserTransitionInProgress = true
+    var isGestureAwaitingPageTransition: Bool {
+        phase == .userGesture
+    }
+
+    mutating func userGestureWillBegin() -> Bool {
+        guard phase == .idle else { return false }
+        phase = .userGesture
+        pendingSelection = nil
+        return true
+    }
+
+    mutating func userTransitionWillBegin() -> Bool {
+        switch phase {
+        case .idle:
+            phase = .userTransition
+            pendingSelection = nil
+            return true
+        case .userGesture:
+            phase = .userTransition
+            return false
+        case .userTransition, .programmatic:
+            return false
+        }
+    }
+
+    mutating func programmaticTransitionWillBegin() {
+        precondition(phase == .idle)
+        phase = .programmatic
         pendingSelection = nil
     }
 
     mutating func shouldApply(_ selection: Element) -> Bool {
-        guard isUserTransitionInProgress else {
+        guard phase != .idle else {
             return true
         }
 
@@ -371,19 +448,38 @@ struct PageTransitionState<Element: Equatable> {
         return false
     }
 
-    mutating func userTransitionDidFinish(visibleElement: Element?) -> Element? {
-        isUserTransitionInProgress = false
-        defer { pendingSelection = nil }
+    mutating func userGestureDidFinish(visibleElement: Element?) -> Element? {
+        guard phase == .userGesture else { return nil }
+        return finishTransition(visibleElement: visibleElement)
+    }
 
-        guard pendingSelection != visibleElement else {
-            return nil
-        }
-        return pendingSelection
+    mutating func userTransitionDidFinish(visibleElement: Element?) -> Element? {
+        guard phase == .userTransition else { return nil }
+        return finishTransition(visibleElement: visibleElement)
+    }
+
+    mutating func programmaticTransitionDidFinish(visibleElement: Element?) -> Element? {
+        guard phase == .programmatic else { return nil }
+        return finishTransition(visibleElement: visibleElement)
     }
 
     // MARK: Private
 
+    private enum Phase {
+        case idle
+        case userGesture
+        case userTransition
+        case programmatic
+    }
+
+    private var phase = Phase.idle
     private var pendingSelection: Element?
+
+    private mutating func finishTransition(visibleElement: Element?) -> Element? {
+        phase = .idle
+        defer { pendingSelection = nil }
+        return pendingSelection == visibleElement ? nil : pendingSelection
+    }
 }
 
 extension _PageViewController {

--- a/UI/NoorUI/Tests/PageTransitionStateTests.swift
+++ b/UI/NoorUI/Tests/PageTransitionStateTests.swift
@@ -2,25 +2,25 @@ import XCTest
 @testable import NoorUI
 
 final class PageTransitionStateTests: XCTestCase {
-    func testSelectionAppliesWhenUserTransitionIsIdle() {
+    func testProgrammaticTransitionStartsWhenIdle() {
         var sut = PageTransitionState<Int>()
 
-        XCTAssertTrue(sut.shouldApply(2))
+        XCTAssertEqual(sut.requestProgrammaticTransition(to: 2), .started)
     }
 
     func testSelectionIsDeferredDuringUserTransition() {
         var sut = PageTransitionState<Int>()
-        _ = sut.userTransitionWillBegin()
+        XCTAssertEqual(sut.userTransitionWillBegin(), .started)
 
-        XCTAssertFalse(sut.shouldApply(2))
+        XCTAssertEqual(sut.requestProgrammaticTransition(to: 2), .deferred)
         XCTAssertTrue(sut.isUserTransitionInProgress)
     }
 
     func testLatestDeferredSelectionAppliesAfterUserTransition() {
         var sut = PageTransitionState<Int>()
         _ = sut.userTransitionWillBegin()
-        _ = sut.shouldApply(2)
-        _ = sut.shouldApply(3)
+        _ = sut.requestProgrammaticTransition(to: 2)
+        _ = sut.requestProgrammaticTransition(to: 3)
 
         let selection = sut.userTransitionDidFinish(visibleElement: 1)
 
@@ -31,7 +31,7 @@ final class PageTransitionStateTests: XCTestCase {
     func testVisibleDeferredSelectionIsDiscardedAfterUserTransition() {
         var sut = PageTransitionState<Int>()
         _ = sut.userTransitionWillBegin()
-        _ = sut.shouldApply(2)
+        _ = sut.requestProgrammaticTransition(to: 2)
 
         XCTAssertNil(sut.userTransitionDidFinish(visibleElement: 2))
     }
@@ -40,23 +40,23 @@ final class PageTransitionStateTests: XCTestCase {
         var sut = PageTransitionState<Int>()
         XCTAssertTrue(sut.userGestureWillBegin())
 
-        XCTAssertFalse(sut.shouldApply(2))
+        XCTAssertEqual(sut.requestProgrammaticTransition(to: 2), .deferred)
         XCTAssertTrue(sut.isGestureAwaitingPageTransition)
     }
 
     func testPageTransitionPreservesSelectionDeferredDuringEarlyGesture() {
         var sut = PageTransitionState<Int>()
         _ = sut.userGestureWillBegin()
-        _ = sut.shouldApply(2)
+        _ = sut.requestProgrammaticTransition(to: 2)
 
-        XCTAssertFalse(sut.userTransitionWillBegin())
+        XCTAssertEqual(sut.userTransitionWillBegin(), .continuedGesture)
         XCTAssertEqual(sut.userTransitionDidFinish(visibleElement: 1), 2)
     }
 
     func testGestureWithoutPageTransitionReplaysDeferredSelection() {
         var sut = PageTransitionState<Int>()
         _ = sut.userGestureWillBegin()
-        _ = sut.shouldApply(2)
+        _ = sut.requestProgrammaticTransition(to: 2)
 
         XCTAssertEqual(sut.userGestureDidFinish(visibleElement: 1), 2)
         XCTAssertFalse(sut.isUserTransitionInProgress)
@@ -64,10 +64,17 @@ final class PageTransitionStateTests: XCTestCase {
 
     func testSelectionIsDeferredDuringProgrammaticTransition() {
         var sut = PageTransitionState<Int>()
-        sut.programmaticTransitionWillBegin()
+        XCTAssertEqual(sut.requestProgrammaticTransition(to: 2), .started)
 
-        XCTAssertFalse(sut.shouldApply(3))
+        XCTAssertEqual(sut.requestProgrammaticTransition(to: 3), .deferred)
         XCTAssertEqual(sut.programmaticTransitionDidFinish(visibleElement: 2), 3)
-        XCTAssertTrue(sut.shouldApply(3))
+        XCTAssertEqual(sut.requestProgrammaticTransition(to: 3), .started)
+    }
+
+    func testUserTransitionIsIgnoredWhileProgrammaticTransitionIsActive() {
+        var sut = PageTransitionState<Int>()
+        _ = sut.requestProgrammaticTransition(to: 2)
+
+        XCTAssertEqual(sut.userTransitionWillBegin(), .ignored)
     }
 }

--- a/UI/NoorUI/Tests/PageTransitionStateTests.swift
+++ b/UI/NoorUI/Tests/PageTransitionStateTests.swift
@@ -10,7 +10,7 @@ final class PageTransitionStateTests: XCTestCase {
 
     func testSelectionIsDeferredDuringUserTransition() {
         var sut = PageTransitionState<Int>()
-        sut.userTransitionWillBegin()
+        _ = sut.userTransitionWillBegin()
 
         XCTAssertFalse(sut.shouldApply(2))
         XCTAssertTrue(sut.isUserTransitionInProgress)
@@ -18,7 +18,7 @@ final class PageTransitionStateTests: XCTestCase {
 
     func testLatestDeferredSelectionAppliesAfterUserTransition() {
         var sut = PageTransitionState<Int>()
-        sut.userTransitionWillBegin()
+        _ = sut.userTransitionWillBegin()
         _ = sut.shouldApply(2)
         _ = sut.shouldApply(3)
 
@@ -30,9 +30,44 @@ final class PageTransitionStateTests: XCTestCase {
 
     func testVisibleDeferredSelectionIsDiscardedAfterUserTransition() {
         var sut = PageTransitionState<Int>()
-        sut.userTransitionWillBegin()
+        _ = sut.userTransitionWillBegin()
         _ = sut.shouldApply(2)
 
         XCTAssertNil(sut.userTransitionDidFinish(visibleElement: 2))
+    }
+
+    func testSelectionIsDeferredAsSoonAsPagingGestureBegins() {
+        var sut = PageTransitionState<Int>()
+        XCTAssertTrue(sut.userGestureWillBegin())
+
+        XCTAssertFalse(sut.shouldApply(2))
+        XCTAssertTrue(sut.isGestureAwaitingPageTransition)
+    }
+
+    func testPageTransitionPreservesSelectionDeferredDuringEarlyGesture() {
+        var sut = PageTransitionState<Int>()
+        _ = sut.userGestureWillBegin()
+        _ = sut.shouldApply(2)
+
+        XCTAssertFalse(sut.userTransitionWillBegin())
+        XCTAssertEqual(sut.userTransitionDidFinish(visibleElement: 1), 2)
+    }
+
+    func testGestureWithoutPageTransitionReplaysDeferredSelection() {
+        var sut = PageTransitionState<Int>()
+        _ = sut.userGestureWillBegin()
+        _ = sut.shouldApply(2)
+
+        XCTAssertEqual(sut.userGestureDidFinish(visibleElement: 1), 2)
+        XCTAssertFalse(sut.isUserTransitionInProgress)
+    }
+
+    func testSelectionIsDeferredDuringProgrammaticTransition() {
+        var sut = PageTransitionState<Int>()
+        sut.programmaticTransitionWillBegin()
+
+        XCTAssertFalse(sut.shouldApply(3))
+        XCTAssertEqual(sut.programmaticTransitionDidFinish(visibleElement: 2), 3)
+        XCTAssertTrue(sut.shouldApply(3))
     }
 }


### PR DESCRIPTION
## Root cause

The previous pager fix deferred SwiftUI selection updates only after `UIPageViewControllerDelegate.willTransitionTo`. UIKit starts its interactive scroll before that delegate callback, leaving a race where a SwiftUI update could call `setViewControllers` while `_UIQueuingScrollView` was already transitioning. Programmatic transitions could also overlap one another.

This explains both crash signatures and the preceding `Failed to determine navigation direction for scroll` diagnostic.

## Fix

- Observe the paging scroll view pan gesture without replacing UIKit’s private scroll delegate.
- Make programmatic transition admission atomic: a request either starts from idle or is deferred, with no two-step check and no production precondition trap.
- Model user transition starts explicitly as started, continuation of the gesture already observed, or ignored, preserving the active transition generation only for the continuation case.
- Reconcile UIKit’s actual visible page before replaying the latest deferred selection.
- Add regression coverage for the pre-delegate gesture gap, cancelled gestures, overlapping programmatic updates, and every transition-admission outcome.

## Crashlytics

- [Foundation mixed group — `No view controller managing visible view`](https://console.firebase.google.com/u/1/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/27840b0a684f5d45083b3c2ae9fe958e)
- [CoreFoundation — `No view controller managing visible view`](https://console.firebase.google.com/u/1/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/7b07ff4108a83dc15ea88024a98bccb0)

The Foundation group also contains unrelated UITableView and UICollectionView failures fixed by the preceding translation snapshot and scroll-target PRs.

## Verification

- `make test-no-sync TARGET=NoorUITests`
- `make test-sync TARGET=NoorUITests`
- `make format-lint`
