### PR TITLE
Fix iOS 26 theme sheet interaction crash

### DIFF
--- a/Features/MoreMenuFeature/Sources/views/MoreMenuThemeSettings.swift
+++ b/Features/MoreMenuFeature/Sources/views/MoreMenuThemeSettings.swift
@@ -12,16 +12,22 @@ import QuranText
 import SwiftUI
 import UIx
 
-private class ThemeSettingsController<V: View>: UIHostingController<V> {
+final class ThemeSettingsController<V: View>: UIHostingController<V> {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = nil
 
-        sheetPresentationController?.prefersGrabberVisible = true
-        sheetPresentationController?.prefersEdgeAttachedInCompactHeight = true
-        sheetPresentationController?.widthFollowsPreferredContentSizeWhenEdgeAttached = true
+        if let sheetPresentationController {
+            sheetPresentationController.prefersGrabberVisible = true
+            sheetPresentationController.prefersEdgeAttachedInCompactHeight = true
+            sheetPresentationController.widthFollowsPreferredContentSizeWhenEdgeAttached = true
+            sheetPresentationController.detents = [.medium(), .large()]
 
-        sheetPresentationController?.detents = [.medium(), .large()]
+            // Keep the SwiftUI scroll view and the sheet's detent gesture independent.
+            // UIKit otherwise adjusts the scroll view from _UISheetInteraction while
+            // live theme changes are relaying out that same scroll view.
+            sheetPresentationController.prefersScrollingExpandsWhenScrolledToEdge = false
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Features/MoreMenuFeature/Tests/ThemeSettingsControllerTests.swift
+++ b/Features/MoreMenuFeature/Tests/ThemeSettingsControllerTests.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+import XCTest
+@testable import MoreMenuFeature
+
+@MainActor
+final class ThemeSettingsControllerTests: XCTestCase {
+    func testSheetContentScrollDoesNotDriveDetentInteraction() throws {
+        let sut = ThemeSettingsController(rootView: EmptyView())
+        sut.modalPresentationStyle = .formSheet
+
+        sut.loadViewIfNeeded()
+
+        let sheet = try XCTUnwrap(sut.sheetPresentationController)
+        XCTAssertFalse(sheet.prefersScrollingExpandsWhenScrolledToEdge)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -637,7 +637,7 @@ private func featuresTargets() -> [[Target]] {
             "ReadingService",
         ]),
 
-        target(type, name: "MoreMenuFeature", hasTests: false, dependencies: [
+        target(type, name: "MoreMenuFeature", dependencies: [
             "NoorUI",
             "QuranTextKit",
             "WordTextService",

--- a/QuranEngine-Package.xctestplan
+++ b/QuranEngine-Package.xctestplan
@@ -21,6 +21,13 @@
     {
       "target" : {
         "containerPath" : "container:",
+        "identifier" : "MoreMenuFeatureTests",
+        "name" : "MoreMenuFeatureTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
         "identifier" : "CrashingTests",
         "name" : "CrashingTests"
       }


### PR DESCRIPTION
## Root cause

This is not an app-owned `NSMutableArray` race. Every event crashes on the main thread inside `_UISheetInteraction` while it adjusts a `UIScrollView` during `handlePan`. The events are all iOS 26 and the breadcrumbs show the live theme settings sheet changing styles immediately before the pan.

The theme sheet uses a SwiftUI `ScrollView`, live theme relayouts, and medium/large detents. With the default `prefersScrollingExpandsWhenScrolledToEdge = true`, UIKit makes one pan gesture own both content scrolling and detent expansion. That leaves UIKit’s private sheet scroll tracking vulnerable while the SwiftUI content is being relaid out.

The earlier stable-detent fixes removed detent mutation, but did not remove this shared gesture ownership.

## Fix

- Keep content scrolling independent from sheet detent expansion.
- Preserve direct grabber resizing between medium and large detents.
- Add an owning-module regression test for the sheet configuration.

## Crashlytics

- [CoreFoundation — `_UISheetInteraction` / `removeObjectIdenticalTo:`](https://console.firebase.google.com/u/1/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/a364bbb08c7d551a37069061d481d43e)

## Verification

- `make test-no-sync TARGET=MoreMenuFeatureTests`
- `make test-sync TARGET=MoreMenuFeatureTests`
- `make format-lint`