### PR TITLE
Fix crashes from invalid verse search rows

### DIFF
--- a/Data/VerseTextPersistence/Sources/GRDBVerseTextPersistence.swift
+++ b/Data/VerseTextPersistence/Sources/GRDBVerseTextPersistence.swift
@@ -237,12 +237,40 @@ private struct GRDBVerseTextPersistence {
     }
 
     private func rowsToResults(_ rows: [Row], quran: Quran) -> [(verse: AyahNumber, text: String)] {
-        rows.map { row in
+        var invalidCoordinates: [(sura: Int, ayah: Int)] = []
+        let results = rows.compactMap { row -> (verse: AyahNumber, text: String)? in
             let text: String = row["text"]
             let sura: Int = row["sura"]
             let ayah: Int = row["ayah"]
-            let verse = AyahNumber(quran: quran, sura: sura, ayah: ayah)!
+
+            guard let verse = AyahNumber(quran: quran, sura: sura, ayah: ayah) else {
+                invalidCoordinates.append((sura: sura, ayah: ayah))
+                return nil
+            }
             return (verse: verse, text: text)
         }
+
+        if let firstInvalidCoordinate = invalidCoordinates.first {
+            crasher.recordError(
+                InvalidVerseSearchRowsError(
+                    count: invalidCoordinates.count,
+                    firstSura: firstInvalidCoordinate.sura,
+                    firstAyah: firstInvalidCoordinate.ayah
+                ),
+                reason: "Skipped invalid verse search rows in \(textTable)"
+            )
+        }
+
+        return results
+    }
+}
+
+private struct InvalidVerseSearchRowsError: LocalizedError {
+    let count: Int
+    let firstSura: Int
+    let firstAyah: Int
+
+    var errorDescription: String? {
+        "Found \(count) search row(s) with invalid Quran coordinates; first=\(firstSura):\(firstAyah)"
     }
 }

--- a/Data/VerseTextPersistence/Tests/GRDBVerseTextPersistenceTests.swift
+++ b/Data/VerseTextPersistence/Tests/GRDBVerseTextPersistenceTests.swift
@@ -1,0 +1,30 @@
+import GRDB
+import QuranKit
+import XCTest
+@testable import VerseTextPersistence
+
+final class GRDBVerseTextPersistenceTests: XCTestCase {
+    func testSearchSkipsInvalidVerseCoordinatesAndKeepsValidRows() async throws {
+        let databaseURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("sqlite")
+        defer { try? FileManager.default.removeItem(at: databaseURL) }
+
+        let database = try DatabaseQueue(path: databaseURL.path)
+        try await database.write { db in
+            try db.execute(sql: """
+            CREATE VIRTUAL TABLE verses USING fts3(sura INTEGER, ayah INTEGER, text TEXT);
+            INSERT INTO verses(sura, ayah, text) VALUES
+                (1, 1, 'needle valid'),
+                (1, 999, 'needle invalid');
+            """)
+        }
+
+        let sut = GRDBTranslationVerseTextPersistence(fileURL: databaseURL)
+        let results = try await sut.search(for: "needle", quran: .hafsMadani1405)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.verse, Quran.hafsMadani1405.firstVerse)
+        XCTAssertEqual(results.first?.text, "needle valid")
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -313,11 +313,14 @@ private func dataTargets() -> [[Target]] {
             "QuranKit",
         ]),
 
-        target(type, name: "VerseTextPersistence", hasTests: false, dependencies: [
+        target(type, name: "VerseTextPersistence", dependencies: [
             "Crashing",
             "SQLitePersistence",
             "QuranKit",
             "QuranText",
+        ], testDependencies: [
+            .product(name: "GRDB", package: "GRDB.swift"),
+            "QuranKit",
         ]),
 
         target(type, name: "TranslationPersistence", hasTests: false, dependencies: [

--- a/QuranEngine-Package.xctestplan
+++ b/QuranEngine-Package.xctestplan
@@ -21,6 +21,13 @@
     {
       "target" : {
         "containerPath" : "container:",
+        "identifier" : "VerseTextPersistenceTests",
+        "name" : "VerseTextPersistenceTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
         "identifier" : "MoreMenuFeatureTests",
         "name" : "MoreMenuFeatureTests"
       }


### PR DESCRIPTION
## Root cause

Search treats downloaded Quran and translation SQLite files as trusted data and force-unwraps `AyahNumber(quran:sura:ayah:)` for every matching row. The Crashlytics event searched for `666`; at least one returned row contained coordinates that do not exist in the active Quran, so the persistence mapper trapped before Search could handle an error.

## Fix

- Validate each row against the active Quran at the persistence boundary.
- Keep valid results and skip malformed rows instead of failing the whole search.
- Record one grouped nonfatal integrity error containing only count/table/first coordinates—not the user query—so the bad resource can be identified.
- Add a real GRDB FTS regression fixture with one valid and one invalid row.

## Crashlytics

- [GRDB verse search — invalid `AyahNumber` force unwrap](https://console.firebase.google.com/u/1/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/35aa32fae084d6b58240a16870eb3ff8)

## Verification

- `make test-no-sync TARGET=VerseTextPersistenceTests`
- `make test-sync TARGET=VerseTextPersistenceTests`
- `make format-lint`