### PR TITLE
Fix bookmarks action sheet on iPad

### DIFF
--- a/Features/BookmarksFeature/Sources/BookmarksViewController.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksViewController.swift
@@ -64,7 +64,7 @@ final class BookmarksViewController: UIHostingController<BookmarksView> {
                 title: l("bookmarks.delete-all"),
                 style: .plain,
                 target: self,
-                action: #selector(confirmDeleteAll)
+                action: #selector(confirmDeleteAll(_:))
             )
             navigationItem.leftBarButtonItem?.tintColor = .systemRed
         } else {
@@ -73,9 +73,9 @@ final class BookmarksViewController: UIHostingController<BookmarksView> {
     }
 
     @objc
-    private func confirmDeleteAll() {
+    private func confirmDeleteAll(_ sourceBarButtonItem: UIBarButtonItem) {
         let alert = Self.makeDeleteAllConfirmation(
-            sourceBarButtonItem: navigationItem.leftBarButtonItem
+            sourceBarButtonItem: sourceBarButtonItem
         ) { [weak self] in
             Task { await self?.viewModel.deleteAll() }
         }
@@ -83,7 +83,7 @@ final class BookmarksViewController: UIHostingController<BookmarksView> {
     }
 
     static func makeDeleteAllConfirmation(
-        sourceBarButtonItem: UIBarButtonItem?,
+        sourceBarButtonItem: UIBarButtonItem,
         deleteAll: @escaping () -> Void
     ) -> UIAlertController {
         let alert = UIAlertController(

--- a/Features/BookmarksFeature/Sources/BookmarksViewController.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksViewController.swift
@@ -74,16 +74,29 @@ final class BookmarksViewController: UIHostingController<BookmarksView> {
 
     @objc
     private func confirmDeleteAll() {
+        let alert = Self.makeDeleteAllConfirmation(
+            sourceBarButtonItem: navigationItem.leftBarButtonItem
+        ) { [weak self] in
+            Task { await self?.viewModel.deleteAll() }
+        }
+        present(alert, animated: true)
+    }
+
+    static func makeDeleteAllConfirmation(
+        sourceBarButtonItem: UIBarButtonItem?,
+        deleteAll: @escaping () -> Void
+    ) -> UIAlertController {
         let alert = UIAlertController(
             title: l("bookmarks.delete-all"),
             message: l("bookmarks.delete-all.confirmation"),
             preferredStyle: .actionSheet
         )
-        alert.addAction(UIAlertAction(title: l("bookmarks.delete-all"), style: .destructive) { [weak self] _ in
-            Task { await self?.viewModel.deleteAll() }
+        alert.addAction(UIAlertAction(title: l("bookmarks.delete-all"), style: .destructive) { _ in
+            deleteAll()
         })
         alert.addAction(UIAlertAction(title: lAndroid("cancel"), style: .cancel))
-        present(alert, animated: true)
+        alert.popoverPresentationController?.barButtonItem = sourceBarButtonItem
+        return alert
     }
 }
 #endif

--- a/Features/BookmarksFeature/Tests/BookmarksViewControllerTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarksViewControllerTests.swift
@@ -1,0 +1,19 @@
+#if !QURAN_SYNC
+import UIKit
+import XCTest
+@testable import BookmarksFeature
+
+@MainActor
+final class BookmarksViewControllerTests: XCTestCase {
+    func testDeleteAllConfirmationAnchorsActionSheetToSourceButton() throws {
+        let source = UIBarButtonItem(systemItem: .trash)
+
+        let alert = BookmarksViewController.makeDeleteAllConfirmation(
+            sourceBarButtonItem: source,
+            deleteAll: {}
+        )
+
+        XCTAssertTrue(try XCTUnwrap(alert.popoverPresentationController?.barButtonItem) === source)
+    }
+}
+#endif


### PR DESCRIPTION
## Root cause

The legacy bookmarks delete-all confirmation uses `UIAlertController.Style.actionSheet`. On iPad, UIKit presents that style as a popover and requires either `barButtonItem` or `sourceView`/`sourceRect`. The controller supplied neither, so presentation raised `NSGenericException` before any app code could recover.

## Fix

- Anchor the action sheet to the delete-all navigation item that invoked it.
- Keep phone presentation unchanged.
- Add a controller regression test that asserts the exact source item is installed on the popover presentation controller.

## Crashlytics

- [UIPopoverPresentationController — unanchored action sheet](https://console.firebase.google.com/u/1/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/973f38d2cfbde9f64d6f0f62ddfb3a7e)

## Verification

- `make test-no-sync TARGET=BookmarksFeatureTests`
- `make test-sync TARGET=BookmarksFeatureTests`
- `make format-lint`