### PR TITLE
Delay Core Data startup until protected data is available

### DIFF
--- a/Features/AppStructureFeature/Sources/Launch/LaunchStartup.swift
+++ b/Features/AppStructureFeature/Sources/Launch/LaunchStartup.swift
@@ -32,6 +32,12 @@ public final class LaunchStartup {
         self.reviewService = reviewService
     }
 
+    deinit {
+        if let protectedDataObserver {
+            notificationCenter.removeObserver(protectedDataObserver)
+        }
+    }
+
     // MARK: Public
 
     public func launch(from window: UIWindow) {
@@ -43,7 +49,12 @@ public final class LaunchStartup {
         crashContext.setSyncState("disabled")
         #endif
         logger.info("Crash context: startup phase launching")
-        upgradeIfNeeded(window: window)
+        perform(
+            protectedDataStartupState.launch(
+                isProtectedDataAvailable: UIApplication.shared.isProtectedDataAvailable
+            ),
+            window: window
+        )
     }
 
     // MARK: Private
@@ -54,9 +65,56 @@ public final class LaunchStartup {
     private let audioUpdater: AudioUpdater
     private let reviewService: ReviewService
     private let crashApplicationObserver = CrashApplicationObserver()
+    private let notificationCenter = NotificationCenter.default
 
     private let appMigrator = AppMigrator()
     private var appViewController: UIViewController?
+    private var protectedDataObserver: NSObjectProtocol?
+    private var protectedDataStartupState = ProtectedDataStartupState()
+
+    private func perform(_ action: ProtectedDataStartupState.Action, window: UIWindow) {
+        switch action {
+        case .start:
+            stopObservingProtectedData()
+            crashContext.setProtectedDataAvailable(UIApplication.shared.isProtectedDataAvailable)
+            upgradeIfNeeded(window: window)
+        case .wait:
+            waitForProtectedData(window: window)
+        case .none:
+            break
+        }
+    }
+
+    private func waitForProtectedData(window: UIWindow) {
+        crashContext.setStartupPhase("waiting_for_protected_data")
+        logger.info("Crash context: startup waiting for protected data")
+
+        protectedDataObserver = notificationCenter.addObserver(
+            forName: UIApplication.protectedDataDidBecomeAvailableNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self, weak window] _ in
+            Task { @MainActor in
+                guard let self, let window else { return }
+                self.perform(
+                    self.protectedDataStartupState.protectedDataDidBecomeAvailable(),
+                    window: window
+                )
+            }
+        }
+
+        // Close the race where protected data becomes available between the
+        // initial check and observer registration.
+        if UIApplication.shared.isProtectedDataAvailable {
+            perform(protectedDataStartupState.protectedDataDidBecomeAvailable(), window: window)
+        }
+    }
+
+    private func stopObservingProtectedData() {
+        guard let protectedDataObserver else { return }
+        notificationCenter.removeObserver(protectedDataObserver)
+        self.protectedDataObserver = nil
+    }
 
     private func upgradeIfNeeded(window: UIWindow) {
         registerMigrators()
@@ -117,6 +175,38 @@ public final class LaunchStartup {
             }
         }
     }
+}
+
+struct ProtectedDataStartupState {
+    enum Action: Equatable {
+        case start
+        case wait
+        case none
+    }
+
+    mutating func launch(isProtectedDataAvailable: Bool) -> Action {
+        guard phase == .idle else { return .none }
+        if isProtectedDataAvailable {
+            phase = .started
+            return .start
+        }
+        phase = .waiting
+        return .wait
+    }
+
+    mutating func protectedDataDidBecomeAvailable() -> Action {
+        guard phase == .waiting else { return .none }
+        phase = .started
+        return .start
+    }
+
+    private enum Phase {
+        case idle
+        case waiting
+        case started
+    }
+
+    private var phase = Phase.idle
 }
 
 private extension UIViewController {

--- a/Features/AppStructureFeature/Tests/ProtectedDataStartupStateTests.swift
+++ b/Features/AppStructureFeature/Tests/ProtectedDataStartupStateTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import AppStructureFeature
+
+final class ProtectedDataStartupStateTests: XCTestCase {
+    func testLaunchStartsImmediatelyWhenProtectedDataIsAvailable() {
+        var sut = ProtectedDataStartupState()
+
+        XCTAssertEqual(sut.launch(isProtectedDataAvailable: true), .start)
+    }
+
+    func testLaunchWaitsUntilProtectedDataBecomesAvailable() {
+        var sut = ProtectedDataStartupState()
+
+        XCTAssertEqual(sut.launch(isProtectedDataAvailable: false), .wait)
+        XCTAssertEqual(sut.protectedDataDidBecomeAvailable(), .start)
+    }
+
+    func testDuplicateAvailabilityNotificationDoesNotStartTwice() {
+        var sut = ProtectedDataStartupState()
+        _ = sut.launch(isProtectedDataAvailable: false)
+        _ = sut.protectedDataDidBecomeAvailable()
+
+        XCTAssertEqual(sut.protectedDataDidBecomeAvailable(), .none)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -827,7 +827,7 @@ private func featuresTargets() -> [[Target]] {
             "TranslationsFeature",
         ] + mobileSyncTargetDependencies),
 
-        target(type, name: "AppStructureFeature", hasTests: false, dependencies: [
+        target(type, name: "AppStructureFeature", dependencies: [
             "Crashing",
             "HomeFeature",
             "BookmarksFeature",

--- a/QuranEngine-Package.xctestplan
+++ b/QuranEngine-Package.xctestplan
@@ -21,6 +21,13 @@
     {
       "target" : {
         "containerPath" : "container:",
+        "identifier" : "AppStructureFeatureTests",
+        "name" : "AppStructureFeatureTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
         "identifier" : "VerseTextPersistenceTests",
         "name" : "VerseTextPersistenceTests"
       }


### PR DESCRIPTION
## Root cause

Crashlytics groups two different SQLite failures under the same `CoreDataStack` fatal-error line.

This PR fixes only the proven SQLite 23 path. Both code-23 events:

- ran on iOS 26,
- occurred in the first second,
- had `ApplicationState=background`,
- had `isProtectedDataAvailable=false`, and
- repeated three seconds apart on the same launch path.

`LaunchStartup` built the app immediately during a protected background launch. `AppBuilder` requested `lastPagePersistence`, which opened `Quran.sqlite` before iOS made the protected file available, producing SQLite `SQLITE_AUTH` (23).

The SQLite 21 event happened on iOS 18 with protected data available and is intentionally handled by a separate stacked PR.

## Fix

- Gate migrations and UI/Core Data construction on protected-data availability.
- Resume startup once on `protectedDataDidBecomeAvailable`.
- Close the check-versus-observer-registration race.
- Keep the existing file protection and preserve the user’s store; no deletion or downgrade to unprotected storage.
- Record `waiting_for_protected_data` in crash context.
- Add state-machine regression coverage for immediate, delayed, and duplicate notifications.

## Crashlytics

- [CoreDataStack mixed group — SQLite 23 events](https://console.firebase.google.com/u/1/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/84eca622235568e19b6207ab4688afcf)

## Verification

- `make test-no-sync TARGET=AppStructureFeatureTests`
- `make test-sync TARGET=AppStructureFeatureTests`
- `make format-lint`