### PR TITLE
Recover Core Data from SQLite misuse at launch

### DIFF
--- a/Data/CoreDataPersistence/Sources/CoreDataStack.swift
+++ b/Data/CoreDataPersistence/Sources/CoreDataStack.swift
@@ -119,7 +119,7 @@ public class CoreDataStack {
         var attempt = 1
         while true {
             let container = newPersistenceContainer()
-            configurePersistentStore(in: container)
+            configurePersistentStores(in: container)
 
             guard let error = persistentStoreLoader(container) else {
                 return container
@@ -136,20 +136,34 @@ public class CoreDataStack {
         }
     }
 
-    private func configurePersistentStore(in container: NSPersistentContainer) {
-        guard let description = container.persistentStoreDescriptions.first else {
+    func configurePersistentStores(in container: NSPersistentContainer) {
+        let descriptions = container.persistentStoreDescriptions
+        guard !descriptions.isEmpty else {
             crashContext.setPersistence(store: name, operation: "load_store", phase: "missing_description")
             fatalError("###\(#function): Failed to retrieve a persistent store description.")
         }
-        description.shouldAddStoreAsynchronously = false
-        description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
-        description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+        for description in descriptions {
+            description.shouldAddStoreAsynchronously = false
+            description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+            description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+        }
     }
 
     private static func loadPersistentStores(in container: NSPersistentContainer) -> NSError? {
+        // The completion is escaping because Core Data also supports asynchronous
+        // descriptions. Capturing its result here is valid only while every store
+        // is explicitly configured to finish loading before this method returns.
+        precondition(
+            !container.persistentStoreDescriptions.isEmpty &&
+                container.persistentStoreDescriptions.allSatisfy { !$0.shouldAddStoreAsynchronously },
+            "Persistent stores must be configured for synchronous loading."
+        )
+
         var loadError: NSError?
         container.loadPersistentStores { _, error in
-            loadError = error as NSError?
+            if loadError == nil {
+                loadError = error as NSError?
+            }
         }
         return loadError
     }

--- a/Data/CoreDataPersistence/Sources/CoreDataStack.swift
+++ b/Data/CoreDataPersistence/Sources/CoreDataStack.swift
@@ -16,10 +16,25 @@ import VLogging
 public class CoreDataStack {
     // MARK: Lifecycle
 
-    public init(name: String, modelUrl: URL, lazyUniquifiers: @escaping () -> [CoreDataEntityUniquifier]) {
+    public convenience init(name: String, modelUrl: URL, lazyUniquifiers: @escaping () -> [CoreDataEntityUniquifier]) {
+        self.init(
+            name: name,
+            modelUrl: modelUrl,
+            lazyUniquifiers: lazyUniquifiers,
+            persistentStoreLoader: Self.loadPersistentStores
+        )
+    }
+
+    init(
+        name: String,
+        modelUrl: URL,
+        lazyUniquifiers: @escaping () -> [CoreDataEntityUniquifier],
+        persistentStoreLoader: @escaping (NSPersistentContainer) -> NSError?
+    ) {
         self.name = name
         self.modelUrl = modelUrl
         self.lazyUniquifiers = lazyUniquifiers
+        self.persistentStoreLoader = persistentStoreLoader
     }
 
     // MARK: Public
@@ -46,24 +61,9 @@ public class CoreDataStack {
     lazy var persistentContainer: NSPersistentContainer = {
         crashContext.setPersistence(store: name, operation: "load_store", phase: "starting")
         logger.info("Core Data store load starting: \(name)")
-        let container = newPersistenceContainer()
-
-        // Enable history tracking and remote notifications
-        guard let description = container.persistentStoreDescriptions.first else {
-            crashContext.setPersistence(store: name, operation: "load_store", phase: "missing_description")
-            fatalError("###\(#function): Failed to retrieve a persistent store description.")
-        }
-        description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
-        description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
-
-        container.loadPersistentStores(completionHandler: { _, error in
-            if let error = error as NSError? {
-                crashContext.setPersistence(store: self.name, operation: "load_store", phase: "failed")
-                fatalError("###\(#function): Failed to load persistent store: \(error)")
-            }
-            crashContext.setPersistence(store: self.name, operation: "load_store", phase: "ready")
-            logger.info("Core Data store loaded: \(self.name)")
-        })
+        let container = loadPersistentContainer()
+        crashContext.setPersistence(store: name, operation: "load_store", phase: "ready")
+        logger.info("Core Data store loaded: \(name)")
 
         container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
         container.viewContext.transactionAuthor = appTransactionAuthorName
@@ -92,6 +92,7 @@ public class CoreDataStack {
 
     private let name: String
     private let modelUrl: URL
+    private let persistentStoreLoader: (NSPersistentContainer) -> NSError?
 
     private let lazyUniquifiers: () -> [CoreDataEntityUniquifier]
     private lazy var uniquifiers: [CoreDataEntityUniquifier] = lazyUniquifiers()
@@ -114,6 +115,45 @@ public class CoreDataStack {
         return NSPersistentCloudKitContainer(name: name, managedObjectModel: model)
     }
 
+    private func loadPersistentContainer() -> NSPersistentContainer {
+        var attempt = 1
+        while true {
+            let container = newPersistenceContainer()
+            configurePersistentStore(in: container)
+
+            guard let error = persistentStoreLoader(container) else {
+                return container
+            }
+            guard PersistentStoreLoadRecovery.shouldRetry(error, attempt: attempt) else {
+                crashContext.setPersistence(store: name, operation: "load_store", phase: "failed")
+                fatalError("###\(#function): Failed to load persistent store: \(error)")
+            }
+
+            crashContext.setPersistence(store: name, operation: "load_store", phase: "retrying_sqlite_misuse")
+            crasher.recordError(error, reason: "Retrying Core Data store after SQLite misuse during initialization")
+            logger.error("Core Data store returned SQLite misuse during initialization; retrying with a fresh container.")
+            attempt += 1
+        }
+    }
+
+    private func configurePersistentStore(in container: NSPersistentContainer) {
+        guard let description = container.persistentStoreDescriptions.first else {
+            crashContext.setPersistence(store: name, operation: "load_store", phase: "missing_description")
+            fatalError("###\(#function): Failed to retrieve a persistent store description.")
+        }
+        description.shouldAddStoreAsynchronously = false
+        description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+        description.setOption(true as NSNumber, forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey)
+    }
+
+    private static func loadPersistentStores(in container: NSPersistentContainer) -> NSError? {
+        var loadError: NSError?
+        container.loadPersistentStores { _, error in
+            loadError = error as NSError?
+        }
+        return loadError
+    }
+
     /// Handle remote store change notifications (.NSPersistentStoreRemoteChange).
     @objc
     private func storeRemoteChange(_ notification: Notification) {
@@ -129,5 +169,11 @@ public class CoreDataStack {
                 crashContext.setPersistence(store: self.name, operation: "merge_remote_change", phase: "ready")
             }
         }
+    }
+}
+
+enum PersistentStoreLoadRecovery {
+    static func shouldRetry(_ error: NSError, attempt: Int) -> Bool {
+        attempt == 1 && error.domain == "NSSQLiteErrorDomain" && error.code == 21
     }
 }

--- a/Data/CoreDataPersistence/Tests/CoreDataStackTests.swift
+++ b/Data/CoreDataPersistence/Tests/CoreDataStackTests.swift
@@ -33,11 +33,33 @@ class CoreDataStackTests: XCTestCase {
         let context = stack.newBackgroundContext()
         XCTAssertEqual(context.transactionAuthor, "app")
 
-        let description = stack.persistentContainer.persistentStoreDescriptions.first
-        XCTAssertNotNil(description)
-        XCTAssertEqual(description?.options[NSPersistentHistoryTrackingKey] as? NSNumber, NSNumber(value: true))
-        XCTAssertEqual(description?.options[NSPersistentStoreRemoteChangeNotificationPostOptionKey] as? NSNumber, NSNumber(value: true))
-        XCTAssertEqual(description?.shouldAddStoreAsynchronously, false)
+        let descriptions = stack.persistentContainer.persistentStoreDescriptions
+        XCTAssertFalse(descriptions.isEmpty)
+        for description in descriptions {
+            XCTAssertEqual(description.options[NSPersistentHistoryTrackingKey] as? NSNumber, NSNumber(value: true))
+            XCTAssertEqual(description.options[NSPersistentStoreRemoteChangeNotificationPostOptionKey] as? NSNumber, NSNumber(value: true))
+            XCTAssertFalse(description.shouldAddStoreAsynchronously)
+        }
+    }
+
+    func test_configurePersistentStoresConfiguresEveryDescriptionSynchronously() throws {
+        let container = NSPersistentContainer(
+            name: "ConfigurationTests",
+            managedObjectModel: try XCTUnwrap(NSManagedObjectModel(contentsOf: CoreDataModelResources.quranModel))
+        )
+        container.persistentStoreDescriptions = [
+            NSPersistentStoreDescription(),
+            NSPersistentStoreDescription(),
+        ]
+        container.persistentStoreDescriptions.forEach { $0.shouldAddStoreAsynchronously = true }
+
+        stack.configurePersistentStores(in: container)
+
+        XCTAssertTrue(container.persistentStoreDescriptions.allSatisfy { description in
+            !description.shouldAddStoreAsynchronously &&
+                description.options[NSPersistentHistoryTrackingKey] as? NSNumber == NSNumber(value: true) &&
+                description.options[NSPersistentStoreRemoteChangeNotificationPostOptionKey] as? NSNumber == NSNumber(value: true)
+        })
     }
 
     func test_sqliteMisuseReloadsStoreWithFreshContainer() {

--- a/Data/CoreDataPersistence/Tests/CoreDataStackTests.swift
+++ b/Data/CoreDataPersistence/Tests/CoreDataStackTests.swift
@@ -6,6 +6,7 @@
 //
 
 import CoreData
+import CoreDataModel
 import XCTest
 @testable import CoreDataPersistence
 
@@ -36,5 +37,50 @@ class CoreDataStackTests: XCTestCase {
         XCTAssertNotNil(description)
         XCTAssertEqual(description?.options[NSPersistentHistoryTrackingKey] as? NSNumber, NSNumber(value: true))
         XCTAssertEqual(description?.options[NSPersistentStoreRemoteChangeNotificationPostOptionKey] as? NSNumber, NSNumber(value: true))
+        XCTAssertEqual(description?.shouldAddStoreAsynchronously, false)
+    }
+
+    func test_sqliteMisuseReloadsStoreWithFreshContainer() {
+        var attempts = 0
+        var containers: [NSPersistentContainer] = []
+        stack = CoreDataStack(
+            name: "CoreDataStackRetryTests-\(UUID().uuidString)",
+            modelUrl: CoreDataModelResources.quranModel,
+            lazyUniquifiers: { [] },
+            persistentStoreLoader: { container in
+                attempts += 1
+                containers.append(container)
+                guard attempts > 1 else {
+                    return NSError(domain: "NSSQLiteErrorDomain", code: 21)
+                }
+
+                container.persistentStoreDescriptions.first?.type = NSInMemoryStoreType
+                var loadError: NSError?
+                container.loadPersistentStores { _, error in
+                    loadError = error as NSError?
+                }
+                return loadError
+            }
+        )
+
+        XCTAssertNotNil(stack.persistentContainer)
+        XCTAssertEqual(attempts, 2)
+        XCTAssertEqual(containers.count, 2)
+        XCTAssertFalse(containers[0] === containers[1])
+    }
+
+    func test_storeLoadRecoveryOnlyRetriesFirstSQLiteMisuse() {
+        XCTAssertTrue(PersistentStoreLoadRecovery.shouldRetry(
+            NSError(domain: "NSSQLiteErrorDomain", code: 21),
+            attempt: 1
+        ))
+        XCTAssertFalse(PersistentStoreLoadRecovery.shouldRetry(
+            NSError(domain: "NSSQLiteErrorDomain", code: 21),
+            attempt: 2
+        ))
+        XCTAssertFalse(PersistentStoreLoadRecovery.shouldRetry(
+            NSError(domain: NSCocoaErrorDomain, code: 256),
+            attempt: 1
+        ))
     }
 }


### PR DESCRIPTION
## Root cause

Crashlytics grouped this event with protected-data failures because both terminate at the same `CoreDataStack` fatal-error line. This is a distinct signature:

- `NSSQLiteErrorDomain Code=21` (`SQLITE_MISUSE`),
- iOS 18.5,
- protected data available,
- app inactive,
- first synchronous store-open attempt,
- no concurrent Core Data access on any captured thread.

SQLite 21 means the SQLite handle/API state is invalid. The app treated that one-time coordinator state as permanently fatal. Retrying the same handle would be incorrect; deleting the store would risk user data.

The persistent-store completion is escaping because Core Data also supports asynchronous loading. Reading its captured error immediately is valid only when every store description is explicitly configured for synchronous loading.

## Fix

- Configure and validate every persistent-store description for synchronous loading before capturing the completion result; document the invariant with a precondition.
- Preserve the first error if a container has multiple persistent-store completion calls.
- For only the first `NSSQLiteErrorDomain/21` failure, discard the failed container and load the same on-disk store through a fresh container/coordinator.
- Preserve the SQLite store and sidecars; no deletion, replacement, or in-memory fallback.
- Record the first failure as a nonfatal and expose `retrying_sqlite_misuse` through crash context.
- Keep a second SQLite-21 failure and every other store error fatal so persistent failures remain visible.
- Add regression tests proving all store descriptions are configured, the synchronous contract holds, one fresh-container retry occurs, and the retry policy remains narrow.

## Crashlytics

- [CoreDataStack mixed group — SQLite 21 event](https://console.firebase.google.com/u/1/project/quran-9f6b3/crashlytics/app/ios:com.quran.ios/issues/84eca622235568e19b6207ab4688afcf)

## Verification

- `make test-no-sync TARGET=CoreDataPersistenceTests`
- `make test-sync TARGET=CoreDataPersistenceTests`
- `make format-lint`
