### PR TITLE
Improve audio banner responsive layout

### DIFF
--- a/Features/QuranViewFeature/Sources/QuranView.swift
+++ b/Features/QuranViewFeature/Sources/QuranView.swift
@@ -50,6 +50,7 @@ class QuranView: UIView, UIGestureRecognizerDelegate, UINavigationBarDelegate {
     override func layoutSubviews() {
         navigationItem.titleView?.setNeedsLayout()
         super.layoutSubviews()
+        configureAudioBarScrollEdgeEffectIfNeeded()
     }
 
     func position(for bar: UIBarPositioning) -> UIBarPosition {
@@ -99,6 +100,34 @@ class QuranView: UIView, UIGestureRecognizerDelegate, UINavigationBarDelegate {
 
     private let tapGesture = UITapGestureRecognizer()
     private var audioView: UIView?
+    private var audioBarScrollEdgeInteraction: (any UIInteraction)?
+
+    private func configureAudioBarScrollEdgeEffectIfNeeded() {
+        guard #available(iOS 26.0, *) else { return }
+        if let interaction = audioBarScrollEdgeInteraction as? UIScrollEdgeElementContainerInteraction,
+           interaction.scrollView != nil
+        {
+            return
+        }
+
+        guard let audioView,
+              let scrollView = contentView?.findSubview(ofType: UIScrollView.self)
+        else {
+            return
+        }
+
+        let interaction: UIScrollEdgeElementContainerInteraction
+        if let existingInteraction = audioBarScrollEdgeInteraction as? UIScrollEdgeElementContainerInteraction {
+            guard existingInteraction.scrollView == nil else { return }
+            interaction = existingInteraction
+        } else {
+            interaction = UIScrollEdgeElementContainerInteraction()
+            interaction.edge = .bottom
+            audioBarScrollEdgeInteraction = interaction
+            audioView.addInteraction(interaction)
+        }
+        interaction.scrollView = scrollView
+    }
 
     private func setUp() {
         clipsToBounds = true

--- a/UI/NoorUI/Sources/Features/AudioBanner/AudioBannerViewUI.swift
+++ b/UI/NoorUI/Sources/Features/AudioBanner/AudioBannerViewUI.swift
@@ -55,6 +55,8 @@ public struct AudioBannerActions {
 public struct AudioBannerViewUI: View {
     private let state: AudioBannerState
     private let actions: AudioBannerActions
+    @ScaledMetric private var maxWidth = 500
+
     public init(state: AudioBannerState, actions: AudioBannerActions) {
         self.state = state
         self.actions = actions
@@ -72,72 +74,209 @@ public struct AudioBannerViewUI: View {
             }
         }
         .font(.title2)
-        .background(
-            BannerBackground(color: .clear)
-                .shadow(color: .label.opacity(0.33), radius: 2)
-        )
+        .frame(maxWidth: maxWidth)
+        .audioBannerBackground()
     }
 }
 
 private struct AudioPlaying: View {
+    private enum Control {
+        case stop
+        case rate
+        case backward
+        case playPause
+        case forward
+        case more
+    }
+
+    private struct Layout {
+        let showsRate: Bool
+        let positions: [Control: CGPoint]
+
+        func position(for control: Control) -> CGPoint {
+            positions[control, default: .zero]
+        }
+    }
+
     let paused: Bool
     let currentRate: Float
     let actions: AudioBannerActions
 
+    @Environment(\.layoutDirection) private var layoutDirection
+    @ScaledMetric private var minimumMiddleSpacing = 4.0
+    @ScaledMetric private var maximumMiddleSpacing = 16.0
+    @State private var controlSizes: [Control: CGSize] = [:]
+
+    private let minimumTapLength = 44.0
+
+    private var stopButton: some View {
+        Button(action: actions.stop) {
+            NoorSystemImage.stop.image
+                .frame(minWidth: minimumTapLength, minHeight: minimumTapLength)
+                .contentShape(Rectangle())
+        }
+    }
+
+    private var rateMenu: some View {
+        Menu {
+            ForEach(PlaybackSpeed.supportedRates, id: \.self) { value in
+                Button(PlaybackSpeed.formatted(value)) { actions.setPlaybackRate(value) }
+            }
+        } label: {
+            Text(PlaybackSpeed.formatted(currentRate))
+                .font(.footnote)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .background(Color(.systemGray5))
+                .clipShape(Capsule())
+                .frame(minWidth: minimumTapLength, minHeight: minimumTapLength)
+                .contentShape(Rectangle())
+        }
+    }
+
+    private var backwardButton: some View {
+        Button(action: actions.backward) {
+            NoorSystemImage.backward.image
+                .frame(minWidth: minimumTapLength, minHeight: minimumTapLength)
+                .contentShape(Rectangle())
+        }
+    }
+
+    private var playPauseButton: some View {
+        Button(action: paused ? actions.resume : actions.pause) {
+            (paused ? NoorSystemImage.play.image : NoorSystemImage.pause.image)
+                .frame(minWidth: minimumTapLength, minHeight: minimumTapLength)
+                .contentShape(Rectangle())
+        }
+    }
+
+    private var forwardButton: some View {
+        Button(action: actions.forward) {
+            NoorSystemImage.forward.image
+                .frame(minWidth: minimumTapLength, minHeight: minimumTapLength)
+                .contentShape(Rectangle())
+        }
+    }
+
+    private var moreButton: some View {
+        Button(action: actions.more) {
+            NoorSystemImage.more.image
+                .frame(minWidth: minimumTapLength, minHeight: minimumTapLength)
+                .contentShape(Rectangle())
+        }
+    }
+
     var body: some View {
-        HStack {
-            Button(action: actions.stop) {
-                NoorSystemImage.stop.image
-                    .padding()
-            }
+        GeometryReader { geometry in
+            let layout = makeLayout(availableWidth: geometry.size.width)
 
-            Menu {
-                ForEach(PlaybackSpeed.supportedRates, id: \.self) { value in
-                    Button(PlaybackSpeed.formatted(value)) { actions.setPlaybackRate(value) }
+            ZStack {
+                stopButton
+                    .onSizeChange { updateSize($0, for: .stop) }
+                    .position(layout.position(for: .stop))
+
+                if layout.showsRate {
+                    rateMenu
+                        .position(layout.position(for: .rate))
                 }
-            } label: {
-                Text(PlaybackSpeed.formatted(currentRate))
-                    .font(.footnote)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 6)
-                    .background(Color(.systemGray5))
-                    .clipShape(Capsule())
-            }
-            .padding(.leading, 4)
 
-            Button(action: actions.backward) {
-                NoorSystemImage.backward.image
-                    .padding()
-            }
-            Group {
-                if paused {
-                    Button(action: actions.resume) {
-                        NoorSystemImage.play.image
-                    }
-                } else {
-                    Button(action: actions.pause) {
-                        NoorSystemImage.pause.image
-                    }
-                }
-            }
-            .padding()
-            Button(action: actions.forward) {
-                NoorSystemImage.forward.image
-                    .padding()
-            }
+                backwardButton
+                    .onSizeChange { updateSize($0, for: .backward) }
+                    .position(layout.position(for: .backward))
 
-            Spacer()
-            Button(action: actions.more) {
-                NoorSystemImage.more.image
-                    .padding()
+                playPauseButton
+                    .onSizeChange { updateSize($0, for: .playPause) }
+                    .position(layout.position(for: .playPause))
+
+                forwardButton
+                    .onSizeChange { updateSize($0, for: .forward) }
+                    .position(layout.position(for: .forward))
+
+                moreButton
+                    .onSizeChange { updateSize($0, for: .more) }
+                    .position(layout.position(for: .more))
+
+                rateMenu
+                    .fixedSize()
+                    .onSizeChange { updateSize($0, for: .rate) }
+                    .hidden()
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
             }
         }
+        .frame(height: measuredHeight)
+        .padding()
+    }
+
+    private var measuredHeight: CGFloat {
+        max(minimumTapLength, controlSizes.values.map(\.height).max() ?? 0)
+    }
+
+    private func makeLayout(availableWidth: CGFloat) -> Layout {
+        let stopSize = size(for: .stop)
+        let rateSize = size(for: .rate)
+        let backwardSize = size(for: .backward)
+        let playPauseSize = size(for: .playPause)
+        let forwardSize = size(for: .forward)
+        let moreSize = size(for: .more)
+
+        let middleButtonsWidth = backwardSize.width + playPauseSize.width + forwardSize.width
+        let edgeOnlySideWidth = max(stopSize.width, moreSize.width)
+        let rateSideWidth = max(
+            stopSize.width + rateSize.width + minimumMiddleSpacing * 2,
+            moreSize.width
+        )
+        let minimumWidthWithRate = middleButtonsWidth
+            + minimumMiddleSpacing * 2
+            + rateSideWidth * 2
+        let showsRate = controlSizes[.rate] != nil && availableWidth >= minimumWidthWithRate
+        let reservedSideWidth = showsRate ? rateSideWidth : edgeOnlySideWidth
+        let availableMiddleSpacing = (
+            availableWidth - reservedSideWidth * 2 - middleButtonsWidth
+        ) / 2
+        let middleSpacing = min(maximumMiddleSpacing, max(0, availableMiddleSpacing))
+        let middleWidth = middleButtonsWidth + middleSpacing * 2
+        let middleLeading = (availableWidth - middleWidth) / 2
+        let centerY = measuredHeight / 2
+
+        var logicalXPositions: [Control: CGFloat] = [
+            .stop: stopSize.width / 2,
+            .backward: middleLeading + backwardSize.width / 2,
+            .playPause: middleLeading + backwardSize.width + middleSpacing + playPauseSize.width / 2,
+            .forward: middleLeading
+                + backwardSize.width
+                + middleSpacing
+                + playPauseSize.width
+                + middleSpacing
+                + forwardSize.width / 2,
+            .more: availableWidth - moreSize.width / 2,
+        ]
+        if showsRate {
+            logicalXPositions[.rate] = (stopSize.width + middleLeading) / 2
+        }
+
+        let positions = logicalXPositions.mapValues { logicalX in
+            let x = layoutDirection == .leftToRight ? logicalX : availableWidth - logicalX
+            return CGPoint(x: x, y: centerY)
+        }
+        return Layout(showsRate: showsRate, positions: positions)
+    }
+
+    private func size(for control: Control) -> CGSize {
+        controlSizes[control] ?? CGSize(width: minimumTapLength, height: minimumTapLength)
+    }
+
+    private func updateSize(_ size: CGSize, for control: Control) {
+        guard controlSizes[control] != size else { return }
+        controlSizes[control] = size
     }
 }
 
 private struct ReadyToPlay: View {
     let reciter: String
     let actions: AudioBannerActions
+    @ScaledMetric private var cornerRadius = Dimensions.cornerRadius
+
     var body: some View {
         ZStack {
             HStack {
@@ -163,9 +302,7 @@ private struct ReadyToPlay: View {
                 }
                 .buttonStyle(CustomButtonStyle { config in
                     config.label
-                        .background(
-                            BannerBackground(color: config.isPressed ? .systemFill : Color.clear)
-                        )
+                        .readyToPlayBackground(isPressed: config.isPressed)
                 })
             }
         }
@@ -212,7 +349,54 @@ private struct BannerBackground: View {
             .background(.thinMaterial)
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
             .ignoresSafeArea(edges: [.bottom, .leading, .trailing])
+            .shadow(color: .label.opacity(0.33), radius: 2)
     }
+}
+
+private extension View {
+    @ViewBuilder
+    func readyToPlayBackground(isPressed: Bool) -> some View {
+        if #available(iOS 26.0, *) {
+            background {
+                Color.systemFill
+                    .opacity(isPressed ? 1 : 0)
+                    .clipShape(Capsule())
+            }
+        } else {
+            background(BannerBackground(color: isPressed ? .systemFill : Color.clear))
+        }
+    }
+
+    @ViewBuilder
+    func audioBannerBackground() -> some View {
+        if #available(iOS 26.0, *) {
+            glassEffect(in: .capsule)
+                .padding(.horizontal)
+        } else {
+            background(BannerBackground(color: .clear))
+        }
+    }
+}
+
+#Preview("Compact Playing") {
+    let actions = AudioBannerActions(
+        play: {},
+        pause: {},
+        resume: {},
+        stop: {},
+        backward: {},
+        forward: {},
+        cancelDownloading: {},
+        reciters: {},
+        more: {},
+        setPlaybackRate: { _ in }
+    )
+    AudioBannerViewUI(
+        state: .playing(paused: false, rate: 1),
+        actions: actions
+    )
+    .frame(width: 300)
+    .background(Color.systemGroupedBackground)
 }
 
 #Preview {
@@ -241,7 +425,7 @@ private struct BannerBackground: View {
             }
         }
 
-        @State var counter: Int = 0
+        @State var counter: Int = 1
 
         var body: some View {
             VStack {
@@ -256,6 +440,7 @@ private struct BannerBackground: View {
                     AudioBannerViewUI(state: state, actions: actions)
                 }
             }
+            .background(Color.systemGroupedBackground)
         }
     }
 


### PR DESCRIPTION
## Summary

- adapt AudioBanner controls to the available width while keeping the edge actions pinned
- keep the middle playback controls centered, add adaptive spacing, and hide playback rate when space is constrained
- preserve 44 pt interaction targets and right-to-left layout behavior
- use Liquid Glass on iOS 26 while retaining the existing material presentation on older systems
- connect the audio banner to the Quran scroll edge on iOS 26

## Validation

- `make format-lint`
- `make build-no-sync TARGET=NoorUI`
- Quran Debug app build
- visual verification on iPhone and iPad, portrait and landscape, across iOS 26 and iOS 15

## Screenshots

<table>
  <tr>
    <th>Device / runtime</th>
    <th>Portrait</th>
    <th>Landscape</th>
  </tr>
  <tr>
    <td><strong>iPhone 17 Pro</strong><br>iOS 26.1</td>
    <td><img width="300" alt="iPhone 17 Pro on iOS 26.1 in portrait" src="https://github.com/user-attachments/assets/96ce9e7e-c4a8-4403-b136-8d3163f0ea76"></td>
    <td><img width="300" alt="iPhone 17 Pro on iOS 26.1 in landscape" src="https://github.com/user-attachments/assets/d849f9f6-bf4c-4e8d-ba30-7309f3e9540f"></td>
  </tr>
  <tr>
    <td><strong>iPad Pro 13-inch</strong><br>iOS 26.2</td>
    <td><img width="300" alt="iPad Pro 13-inch on iOS 26.2 in portrait" src="https://github.com/user-attachments/assets/0e83b4cb-5710-4000-8f31-9d1bfffc8bd3"></td>
    <td><img width="300" alt="iPad Pro 13-inch on iOS 26.2 in landscape" src="https://github.com/user-attachments/assets/cdc134e9-4e66-4355-b1bb-f20c0cdd5dcc"></td>
  </tr>
  <tr>
    <td><strong>iPhone 11 Pro</strong><br>iOS 15.5</td>
    <td><img width="300" alt="iPhone 11 Pro on iOS 15.5 in portrait" src="https://github.com/user-attachments/assets/aec190c5-b98a-4cc0-9470-7ac61547a045"></td>
    <td><img width="300" alt="iPhone 11 Pro on iOS 15.5 in landscape" src="https://github.com/user-attachments/assets/77865c90-da6b-40c8-92c4-d603ea6c9906"></td>
  </tr>
  <tr>
    <td><strong>iPad Pro 12.9-inch</strong><br>iOS 15.5</td>
    <td><img width="300" alt="iPad Pro 12.9-inch on iOS 15.5 in portrait" src="https://github.com/user-attachments/assets/9d89a599-511e-4eb5-8a68-a74625addb2c"></td>
    <td><img width="300" alt="iPad Pro 12.9-inch on iOS 15.5 in landscape" src="https://github.com/user-attachments/assets/b2d633ce-435c-4a2d-b585-985cf5f0ab4d"></td>
  </tr>
</table>
