### PR TITLE
fix: prevent streaming audio duration crash

### DIFF
--- a/Core/QueuePlayer/Sources/AudioPlayer.swift
+++ b/Core/QueuePlayer/Sources/AudioPlayer.swift
@@ -18,9 +18,7 @@ class AudioPlayer {
         playbackRate = rate
         audioPlaying = AudioPlaying(request: request, fileIndex: 0, frameIndex: 0)
         player = Player(url: request.files[0].url)
-        player.onRateChanged = { [weak self] in
-            self?.rateChanged(to: $0)
-        }
+        configurePlayerCallbacks()
         interruptionMonitor.onAudioInterruption = { [weak self] in
             self?.onAudioInterruption(type: $0)
         }
@@ -107,9 +105,7 @@ class AudioPlayer {
 
     private var player: Player {
         didSet {
-            player.onRateChanged = { [weak self] in
-                self?.rateChanged(to: $0)
-            }
+            configurePlayerCallbacks()
         }
     }
 
@@ -154,14 +150,18 @@ class AudioPlayer {
         actions?.audioFrameChanged(fileIndex, frameIndex, player.playerItem)
     }
 
-    private func onFrameEnded() {
-        let time = getDurationToFrameEnd()
-        // make sure we reached the end of the frame
-        // don't use `abs` since we could be notified a little bit after
-        guard time < 0.2 else {
-            // audio is 200 ms behind, reschedule the timer
-            waitUntilFrameEnds()
-            return
+    private func onFrameEnded(reachedNaturalEnd: Bool = false) {
+        if !reachedNaturalEnd {
+            guard let time = getDurationToFrameEnd() else {
+                return
+            }
+            // make sure we reached the end of the frame
+            // don't use `abs` since we could be notified a little bit after
+            guard time < 0.2 else {
+                // audio is 200 ms behind, reschedule the timer
+                waitUntilFrameEnds()
+                return
+            }
         }
 
         // 1. Done playing the frame?
@@ -221,7 +221,7 @@ class AudioPlayer {
             return 0
         }
         let frameStart = audioPlaying.frame.startTime
-        let frameEnd = audioPlaying.frameEndTime ?? player.duration
+        let frameEnd = audioPlaying.frameEndTime ?? player.currentTime
         let recitedMediaDuration = max(0, frameEnd - frameStart)
         // Convert media duration to wall-clock recited time before scaling.
         return recitedMediaDuration / Double(playbackRate) * multiplier
@@ -256,10 +256,16 @@ class AudioPlayer {
             return
         }
 
-        // max with 100ms since sometimes the returned value could be negative
-        let mediaDelta = max(0, getDurationToFrameEnd(currentTime: currentTime))
-        // Convert media time to wall-clock time
-        let interval = max(0.05, mediaDelta / Double(playbackRate)) // small floor for stability
+        guard let interval = playbackTimerInterval(
+            frameEndTime: audioPlaying.frameEndTime,
+            currentTime: currentTime ?? player.currentTime,
+            playbackRate: playbackRate
+        ) else {
+            // Whole-file audio has no timing metadata. AVPlayer's natural-end
+            // notification advances it without synchronously loading duration.
+            timer = nil
+            return
+        }
         timer = Timer(interval: interval, queue: .main) { [weak self] in
             self?.timer = nil
             self?.onFrameEnded()
@@ -276,15 +282,43 @@ class AudioPlayer {
         actions?.playbackRateChanged(rate)
     }
 
+    private func configurePlayerCallbacks() {
+        player.onRateChanged = { [weak self] in
+            self?.rateChanged(to: $0)
+        }
+        player.onPlaybackEnded = { [weak self] in
+            self?.onFrameEnded(reachedNaturalEnd: true)
+        }
+    }
+
     private func seek(to frame: AudioFrame) {
         player.seek(to: frame.startTime, rate: playbackRate)
     }
 
     // MARK: - Utilities
 
-    private func getDurationToFrameEnd(currentTime: TimeInterval? = nil) -> TimeInterval {
+    private func getDurationToFrameEnd(currentTime: TimeInterval? = nil) -> TimeInterval? {
+        guard let frameEndTime = audioPlaying.frameEndTime else {
+            return nil
+        }
         let currentTimeInSeconds = currentTime ?? player.currentTime
-        let frameEndTime = audioPlaying.frameEndTime ?? player.duration
         return frameEndTime - currentTimeInSeconds
     }
+}
+
+func playbackTimerInterval(
+    frameEndTime: TimeInterval?,
+    currentTime: TimeInterval,
+    playbackRate: Float
+) -> TimeInterval? {
+    guard let frameEndTime,
+          frameEndTime.isFinite,
+          currentTime.isFinite,
+          playbackRate.isFinite,
+          playbackRate > 0
+    else {
+        return nil
+    }
+    let mediaDelta = max(0, frameEndTime - currentTime)
+    return max(0.05, mediaDelta / Double(playbackRate))
 }

--- a/Core/QueuePlayer/Sources/NowPlayingUpdater.swift
+++ b/Core/QueuePlayer/Sources/NowPlayingUpdater.swift
@@ -23,10 +23,16 @@ public class NowPlayingUpdater {
     }
 
     public func update(duration: TimeInterval) {
+        guard duration.isFinite, duration >= 0 else {
+            return
+        }
         update([MPMediaItemPropertyPlaybackDuration: duration])
     }
 
     public func update(elapsedTime: TimeInterval) {
+        guard elapsedTime.isFinite, elapsedTime >= 0 else {
+            return
+        }
         update([MPNowPlayingInfoPropertyElapsedPlaybackTime: elapsedTime])
     }
 

--- a/Core/QueuePlayer/Sources/Player.swift
+++ b/Core/QueuePlayer/Sources/Player.swift
@@ -14,14 +14,28 @@ final class Player {
 
     deinit {
         rateObservation?.invalidate()
+        if let playbackEndedObserver {
+            NotificationCenter.default.removeObserver(playbackEndedObserver)
+        }
     }
 
     init(url: URL) {
-        asset = AVURLAsset(url: url, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
+        asset = AVURLAsset(url: url, options: [AVURLAssetPreferPreciseDurationAndTimingKey: url.isFileURL])
         playerItem = AVPlayerItem(asset: asset)
         playerItem.audioTimePitchAlgorithm = .spectral
         player = AVPlayer(playerItem: playerItem)
-        player.automaticallyWaitsToMinimizeStalling = false
+        player.automaticallyWaitsToMinimizeStalling = !url.isFileURL
+
+        playbackEndedObserver = NotificationCenter.default.addObserver(
+            forName: AVPlayerItem.didPlayToEndTimeNotification,
+            object: playerItem,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task {
+                await self.onPlaybackEnded?()
+            }
+        }
 
         rateObservation = player.observe(\AVPlayer.rate, options: [.new]) { [weak self] _, change in
             if let rate = change.newValue {
@@ -36,15 +50,12 @@ final class Player {
     // MARK: Internal
 
     var onRateChanged: (@Sendable @MainActor (Float) -> Void)?
+    var onPlaybackEnded: (@Sendable @MainActor () -> Void)?
 
     let playerItem: AVPlayerItem
 
     var currentTime: TimeInterval {
         player.currentTime().seconds
-    }
-
-    var duration: TimeInterval {
-        asset.duration.seconds
     }
 
     // MARK: Internal helpers (read-only)
@@ -54,7 +65,11 @@ final class Player {
     }
 
     func play(rate: Float) {
-        player.playImmediately(atRate: rate)
+        if asset.url.isFileURL {
+            player.playImmediately(atRate: rate)
+        } else {
+            player.rate = rate
+        }
     }
 
     func pause() {
@@ -79,6 +94,7 @@ final class Player {
 
     private let asset: AVURLAsset
     private let player: AVPlayer
+    private var playbackEndedObserver: NSObjectProtocol?
 
     private var rateObservation: NSKeyValueObservation? {
         didSet { oldValue?.invalidate() }

--- a/Core/QueuePlayer/Tests/AudioPlayerTests.swift
+++ b/Core/QueuePlayer/Tests/AudioPlayerTests.swift
@@ -1,0 +1,28 @@
+import AVFoundation
+import XCTest
+@testable import QueuePlayer
+
+final class AudioPlayerTests: XCTestCase {
+    func testPlaybackTimerIntervalRequiresKnownFiniteFrameEnd() {
+        XCTAssertNil(playbackTimerInterval(frameEndTime: nil, currentTime: 0, playbackRate: 1))
+        XCTAssertNil(playbackTimerInterval(frameEndTime: .nan, currentTime: 0, playbackRate: 1))
+        XCTAssertNil(playbackTimerInterval(frameEndTime: 1, currentTime: .nan, playbackRate: 1))
+        XCTAssertEqual(playbackTimerInterval(frameEndTime: 3, currentTime: 1, playbackRate: 2), 1)
+    }
+
+    @MainActor
+    func testPlayerNotifiesWhenWholeFileReachesNaturalEnd() async {
+        let player = Player(url: URL(fileURLWithPath: "/tmp/QueuePlayerTests.mp3"))
+        let playbackEnded = expectation(description: "Playback ended")
+        player.onPlaybackEnded = {
+            playbackEnded.fulfill()
+        }
+
+        NotificationCenter.default.post(
+            name: AVPlayerItem.didPlayToEndTimeNotification,
+            object: player.playerItem
+        )
+
+        await fulfillment(of: [playbackEnded], timeout: 1)
+    }
+}

--- a/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioPlayer.swift
+++ b/Domain/QuranAudioKit/Sources/AudioPlayer/QuranAudioPlayer.swift
@@ -157,7 +157,7 @@ public class QuranAudioPlayer {
         let info = audioRequest.getPlayerInfo(for: fileIndex)
         nowPlaying.update(info: info)
         nowPlaying.update(playingIndex: fileIndex)
-        nowPlaying.update(duration: playerItem.asset.duration.seconds)
+        nowPlaying.update(duration: playerItem.duration.seconds)
         nowPlaying.update(elapsedTime: playerItem.currentTime().seconds)
 
         let ayah = audioRequest.getAyahNumberFrom(fileIndex: fileIndex, frameIndex: frameIndex)

--- a/Domain/QuranAudioKit/Tests/QuranAudioPlayerTests.swift
+++ b/Domain/QuranAudioKit/Tests/QuranAudioPlayerTests.swift
@@ -150,6 +150,29 @@ class QuranAudioPlayerTests: XCTestCase {
     }
 
     @MainActor
+    func testStreamingGappedReciterFullAlBaqaraUsesRemoteFiles() async throws {
+        let alBaqara = suras[1]
+
+        try await player.play(
+            reciter: gappedReciter,
+            rate: 1,
+            from: alBaqara.firstVerse,
+            to: alBaqara.lastVerse,
+            verseRuns: .finite(1),
+            listRuns: .finite(1),
+            streaming: true
+        )
+
+        guard case .playing(let request) = queuePlayer.state else {
+            return XCTFail("Expected a playing request")
+        }
+        XCTAssertEqual(request.files.count, alBaqara.verses.count + 1)
+        XCTAssertEqual(request.files.first?.url, gappedReciter.remoteURL(ayah: quran.firstVerse))
+        XCTAssertEqual(request.files.last?.url, gappedReciter.remoteURL(ayah: alBaqara.lastVerse))
+        XCTAssertTrue(request.files.allSatisfy { !$0.url.isFileURL })
+    }
+
+    @MainActor
     func testAudioPlaybackControls() async throws {
         for i in 0 ..< 2 {
             // play

--- a/Package.swift
+++ b/Package.swift
@@ -138,7 +138,7 @@ private func coreTargets() -> [[Target]] {
 
         target(type, name: "Localization", dependencies: []),
 
-        target(type, name: "QueuePlayer", hasTests: false, dependencies: [
+        target(type, name: "QueuePlayer", dependencies: [
             "Timing",
         ]),
 

--- a/QuranEngine-Package.xctestplan
+++ b/QuranEngine-Package.xctestplan
@@ -63,6 +63,13 @@
     {
       "target" : {
         "containerPath" : "container:",
+        "identifier" : "QueuePlayerTests",
+        "name" : "QueuePlayerTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
         "identifier" : "QuranKitTests",
         "name" : "QuranKitTests"
       }


### PR DESCRIPTION
## Summary

- avoid precise synchronous duration loading for remote MP3 streams
- advance whole-file playback using AVPlayer end notifications
- reject unknown and non-finite playback timing values
- cover full Al-Baqarah streaming requests and natural-end playback

## Root cause

Remote MP3 duration is initially unavailable and resolves to NaN. The player synchronously queried that duration on the main actor, then converted the resulting timer interval to UInt64, causing a fatal trap after the UI stalled.

## Testing

- make format-lint
- make test-no-sync
- make test-sync