### PR TITLE
Fix SwiftUI audio state leaks

### DIFF
--- a/UI/NoorUI/Sources/Components/SegmentedChoicesPicker.swift
+++ b/UI/NoorUI/Sources/Components/SegmentedChoicesPicker.swift
@@ -25,9 +25,13 @@ public struct SegmentedChoicesPicker<Item: Hashable>: View {
     // MARK: Public
 
     public var body: some View {
+        // Capture only the label closure. Capturing self here also retains the
+        // selection binding through SwiftUI's tag projection cache.
+        let itemLabel = label
+
         Picker(title, selection: $selection) {
             ForEach(items, id: \.self) { item in
-                Text(label(item)).tag(item)
+                Text(itemLabel(item)).tag(item)
             }
         }
         .pickerStyle(.segmented)

--- a/UI/UIx/Sources/SwiftUI/Miscellaneous/View+ModalPresentation.swift
+++ b/UI/UIx/Sources/SwiftUI/Miscellaneous/View+ModalPresentation.swift
@@ -18,49 +18,68 @@ extension View {
 private struct SerializedModalPresentationModifier: ViewModifier {
     @Binding var request: ModalPresentationRequest?
     @StateObject private var coordinator = ModalPresentationCoordinator()
-    @State private var presentingViewController: UIViewController?
+    @StateObject private var presentingViewController = WeakViewControllerReference()
 
     func body(content: Content) -> some View {
         content
             .background(
                 ModalPresentationViewControllerReader(
-                    viewController: $presentingViewController
+                    viewController: presentingViewController
                 )
             )
             .onChange(of: request?.id) { _ in
                 handleRequestIfPossible()
             }
-            .onChange(of: presentingViewController == nil) { _ in
+            .onChange(of: presentingViewController.resolutionRevision) { _ in
                 handleRequestIfPossible()
             }
     }
 
     private func handleRequestIfPossible() {
-        guard let request, let presentingViewController else { return }
+        guard let request, let presentingViewController = presentingViewController.value else { return }
         self.request = nil
         coordinator.handle(request, from: presentingViewController)
     }
 }
 
+@MainActor
+final class WeakViewControllerReference: ObservableObject {
+    @Published private(set) var resolutionRevision: UInt = 0
+    weak var value: UIViewController?
+
+    func set(_ viewController: UIViewController?) {
+        value = viewController
+        if viewController != nil {
+            resolutionRevision &+= 1
+        }
+    }
+
+    func clear() {
+        value = nil
+    }
+}
+
 private struct ModalPresentationViewControllerReader: UIViewControllerRepresentable {
-    @Binding var viewController: UIViewController?
+    let viewController: WeakViewControllerReference
 
     func makeUIViewController(context: Context) -> ReaderViewController {
-        ReaderViewController(viewController: $viewController)
+        ReaderViewController(viewController: viewController)
     }
 
     func updateUIViewController(_ uiViewController: ReaderViewController, context: Context) {
-        uiViewController.viewController = $viewController
+        uiViewController.viewController = viewController
     }
 
     static func dismantleUIViewController(_ uiViewController: ReaderViewController, coordinator: ()) {
-        uiViewController.viewController.wrappedValue = nil
+        // SwiftUI is invalidating its graph here. Clearing the weak pointer must not
+        // publish another graph update while that invalidation is in progress.
+        uiViewController.viewController.clear()
     }
 
     final class ReaderViewController: UIViewController {
-        var viewController: Binding<UIViewController?>
+        var viewController: WeakViewControllerReference
 
-        init(viewController: Binding<UIViewController?>) {
+        init(viewController: WeakViewControllerReference) {
             self.viewController = viewController
             super.init(nibName: nil, bundle: nil)
         }
@@ -72,7 +91,7 @@ private struct ModalPresentationViewControllerReader: UIViewControllerRepresenta
 
         override func didMove(toParent parent: UIViewController?) {
             super.didMove(toParent: parent)
-            viewController.wrappedValue = parent
+            viewController.set(parent)
         }
     }
 }

--- a/UI/UIx/Tests/SerializedModalPresentationLifetimeTests.swift
+++ b/UI/UIx/Tests/SerializedModalPresentationLifetimeTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import UIx
+
+@MainActor
+final class SerializedModalPresentationLifetimeTests: XCTestCase {
+    func testPresenterReferenceDoesNotRetainViewController() {
+        let reference = WeakViewControllerReference()
+        weak var weakViewController: UIViewController?
+
+        autoreleasepool {
+            let viewController = UIViewController()
+            weakViewController = viewController
+            reference.set(viewController)
+            XCTAssertTrue(reference.value === viewController)
+            XCTAssertEqual(reference.resolutionRevision, 1)
+
+            reference.clear()
+            reference.set(viewController)
+            XCTAssertEqual(reference.resolutionRevision, 2)
+        }
+
+        XCTAssertNil(weakViewController)
+        XCTAssertNil(reference.value)
+    }
+}


### PR DESCRIPTION
## Summary

- keep the modal presenter as a weak reference so leaving a Quran page releases its hosting hierarchy and audio state
- publish a wrapping attachment revision so repeated presenter resolutions are handled, including reattachment to the same controller
- keep the native SwiftUI segmented picker while preventing its `ForEach` closure from capturing the selection binding
- add regression coverage for presenter lifetime and reattachment

## Root cause

The serialized modal reader stored its parent hosting controller in SwiftUI state, creating a cycle through the hosting hierarchy. Separately, the segmented picker’s content closure implicitly captured the full picker value, including its selection binding; SwiftUI’s tag projection cache then retained the advanced-audio view model.

## Impact

Leaving a Quran page now releases `AudioBannerViewModel` and its player instead of allowing playback to continue. Dismissing Advanced Audio Options also releases its view model without replacing the native SwiftUI picker.

## Validation

- iPhone 17 Pro Max simulator, iOS 26.5
- repeated Advanced Audio Options presentation/dismissal: 1,296 leaks / 102,496 bytes before; 0 leaks after
- `make format-lint`
- `make test-no-sync TARGET=UIxTests`
- `make test-sync TARGET=UIxTests`
- `make test-no-sync TARGET=NoorUITests`
- `make test-sync TARGET=NoorUITests`