### PR TITLE
fix: project publisher-backed state safely

### DIFF
--- a/Core/Utilities/Sources/Features/PublishedBinding.swift
+++ b/Core/Utilities/Sources/Features/PublishedBinding.swift
@@ -1,0 +1,88 @@
+//
+//  PublishedBinding.swift
+//
+//
+//  Created by QuranEngine on 2026-08-12.
+//
+
+import Combine
+
+/// An observable projection of a publisher-backed source of truth.
+///
+/// Writes are forwarded to the source. The projected value changes only after
+/// `updates` emits the source's accepted value.
+@MainActor
+@propertyWrapper
+public final class PublishedBinding<Value: Equatable> {
+    // MARK: Lifecycle
+
+    public init<Updates: Publisher>(
+        wrappedValue: Value,
+        updates: Updates,
+        set: @escaping (Value) -> Void
+    ) where Updates.Output == Value, Updates.Failure == Never {
+        value = wrappedValue
+        subject = CurrentValueSubject(wrappedValue)
+        setValue = set
+        cancellable = updates.sink { [weak self] value in
+            self?.receive(value)
+        }
+    }
+
+    // MARK: Public
+
+    public var wrappedValue: Value {
+        get { value }
+        set { updateSource(to: newValue) }
+    }
+
+    public var projectedValue: AnyPublisher<Value, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    public static subscript<EnclosingSelf: ObservableObject>(
+        _enclosingInstance enclosingInstance: EnclosingSelf,
+        wrapped _: ReferenceWritableKeyPath<EnclosingSelf, Value>,
+        storage storageKeyPath: ReferenceWritableKeyPath<EnclosingSelf, PublishedBinding<Value>>
+    ) -> Value where EnclosingSelf.ObjectWillChangePublisher == ObservableObjectPublisher {
+        get {
+            let binding = enclosingInstance[keyPath: storageKeyPath]
+            binding.connect(to: enclosingInstance)
+            return binding.value
+        }
+        set {
+            let binding = enclosingInstance[keyPath: storageKeyPath]
+            binding.connect(to: enclosingInstance)
+            binding.updateSource(to: newValue)
+        }
+    }
+
+    // MARK: Private
+
+    private var value: Value
+    private let subject: CurrentValueSubject<Value, Never>
+    private let setValue: (Value) -> Void
+    private var cancellable: AnyCancellable?
+    private var notifyObjectWillChange: (() -> Void)?
+
+    private func connect<EnclosingSelf: ObservableObject>(to enclosingInstance: EnclosingSelf)
+        where EnclosingSelf.ObjectWillChangePublisher == ObservableObjectPublisher
+    {
+        guard notifyObjectWillChange == nil else { return }
+        notifyObjectWillChange = { [weak enclosingInstance] in
+            enclosingInstance?.objectWillChange.send()
+        }
+    }
+
+    private func updateSource(to newValue: Value) {
+        guard newValue != value else { return }
+        setValue(newValue)
+    }
+
+    private func receive(_ newValue: Value) {
+        guard newValue != value else { return }
+        notifyObjectWillChange?()
+        value = newValue
+        subject.send(newValue)
+    }
+}

--- a/Core/Utilities/Tests/PublishedBindingTests.swift
+++ b/Core/Utilities/Tests/PublishedBindingTests.swift
@@ -1,0 +1,146 @@
+import Combine
+import Utilities
+import XCTest
+
+@MainActor
+final class PublishedBindingTests: XCTestCase {
+    func testInitialValueDoesNotPublishAChange() {
+        let source = Source(value: 1)
+        let sut = Model(source: source)
+        var changes = 0
+        let cancellable = sut.objectWillChange.sink { changes += 1 }
+
+        XCTAssertEqual(sut.value, 1)
+        XCTAssertEqual(changes, 0)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    func testSourceUpdatePublishesChangedValue() {
+        let source = Source(value: 1)
+        let sut = Model(source: source)
+        var changes = 0
+        let cancellable = sut.objectWillChange.sink { changes += 1 }
+        _ = sut.value
+
+        source.value = 2
+
+        XCTAssertEqual(sut.value, 2)
+        XCTAssertEqual(changes, 1)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    func testEqualSourceUpdateDoesNotPublishAChange() {
+        let source = Source(value: 1)
+        let sut = Model(source: source)
+        var changes = 0
+        let cancellable = sut.objectWillChange.sink { changes += 1 }
+        _ = sut.value
+
+        source.value = 1
+
+        XCTAssertEqual(sut.value, 1)
+        XCTAssertEqual(changes, 0)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    func testSettingValueWritesToSourceAndPublishesSourceUpdateOnce() {
+        let source = Source(value: 1)
+        let sut = Model(source: source)
+        var changes = 0
+        let cancellable = sut.objectWillChange.sink { changes += 1 }
+        _ = sut.value
+
+        sut.value = 2
+
+        XCTAssertEqual(source.value, 2)
+        XCTAssertEqual(sut.value, 2)
+        XCTAssertEqual(changes, 1)
+        withExtendedLifetime(cancellable) {}
+    }
+
+    func testSettingEqualValueDoesNotWriteToSource() {
+        let source = Source(value: 1)
+        let sut = Model(source: source)
+        _ = sut.value
+
+        sut.value = 1
+
+        XCTAssertEqual(source.numberOfWrites, 0)
+    }
+
+    func testProjectionWaitsForSourceUpdate() {
+        let updates = PassthroughSubject<Int, Never>()
+        var writtenValues: [Int] = []
+        let sut = Model(
+            initialValue: 1,
+            updates: updates.eraseToAnyPublisher(),
+            set: { writtenValues.append($0) }
+        )
+        _ = sut.value
+
+        sut.value = 2
+
+        XCTAssertEqual(writtenValues, [2])
+        XCTAssertEqual(sut.value, 1)
+
+        updates.send(3)
+
+        XCTAssertEqual(sut.value, 3)
+    }
+
+    func testProjectedPublisherEmitsInitialAndChangedSourceValues() {
+        let source = Source(value: 1)
+        let sut = Model(source: source)
+        var values: [Int] = []
+        let cancellable = sut.$value.sink { values.append($0) }
+
+        source.value = 1
+        source.value = 2
+
+        XCTAssertEqual(values, [1, 2])
+        withExtendedLifetime(cancellable) {}
+    }
+}
+
+@MainActor
+private final class Model: ObservableObject {
+    @PublishedBinding var value: Int
+
+    init(source: Source) {
+        _value = PublishedBinding(
+            wrappedValue: source.value,
+            updates: source.updates,
+            set: { source.value = $0 }
+        )
+    }
+
+    init(initialValue: Int, updates: AnyPublisher<Int, Never>, set: @escaping (Int) -> Void) {
+        _value = PublishedBinding(
+            wrappedValue: initialValue,
+            updates: updates,
+            set: set
+        )
+    }
+}
+
+@MainActor
+private final class Source {
+    var value: Int {
+        didSet {
+            numberOfWrites += 1
+            subject.send(value)
+        }
+    }
+
+    var updates: AnyPublisher<Int, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    private(set) var numberOfWrites = 0
+
+    private let subject = PassthroughSubject<Int, Never>()
+
+    init(value: Int) {
+        self.value = value
+    }
+}

--- a/Features/QuranContentFeature/Sources/ContentViewModel.swift
+++ b/Features/QuranContentFeature/Sources/ContentViewModel.swift
@@ -19,6 +19,7 @@ import QuranTextKit
 import QuranTranslationFeature
 import TranslationService
 import UIKit
+import Utilities
 import VLogging
 
 @MainActor
@@ -60,18 +61,36 @@ public final class ContentViewModel: ObservableObject {
 
         visiblePages = [input.initialPage]
 
-        highlights = deps.highlightsService.highlights
-        twoPagesEnabled = deps.quranContentStatePreferences.twoPagesEnabled
-        quranMode = deps.quranContentStatePreferences.quranMode
+        let highlightsService = deps.highlightsService
+        _highlights = PublishedBinding(
+            wrappedValue: highlightsService.highlights,
+            updates: highlightsService.$highlights,
+            set: { highlightsService.highlights = $0 }
+        )
 
-        deps.highlightsService.$highlights
-            .sink { [weak self] in self?.highlights = $0 }
+        let contentStatePreferences = deps.quranContentStatePreferences
+        _twoPagesEnabled = PublishedBinding(
+            wrappedValue: contentStatePreferences.twoPagesEnabled,
+            updates: contentStatePreferences.$twoPagesEnabled,
+            set: { contentStatePreferences.twoPagesEnabled = $0 }
+        )
+        _quranMode = PublishedBinding(
+            wrappedValue: contentStatePreferences.quranMode,
+            updates: contentStatePreferences.$quranMode,
+            set: { contentStatePreferences.quranMode = $0 }
+        )
+
+        $highlights
+            .zip($highlights.dropFirst())
+            .sink { [weak self] oldValue, newValue in
+                if let ayah = newValue.verseToScrollTo(comparingTo: oldValue) {
+                    self?.visiblePages = [ayah.page]
+                }
+            }
             .store(in: &cancellables)
-        deps.quranContentStatePreferences.$twoPagesEnabled
-            .sink { [weak self] in self?.twoPagesEnabled = $0 }
-            .store(in: &cancellables)
-        deps.quranContentStatePreferences.$quranMode
-            .sink { [weak self] in self?.quranMode = $0 }
+        $quranMode
+            .dropFirst()
+            .sink { [weak self] _ in self?.updateQuranModeCrashContext() }
             .store(in: &cancellables)
 
         updateQuranModeCrashContext()
@@ -112,26 +131,12 @@ public final class ContentViewModel: ObservableObject {
     let deps: Deps
     weak var listener: ContentListener?
 
-    @Published var quranMode: QuranMode {
-        didSet {
-            updateQuranModeCrashContext()
-        }
-    }
+    @PublishedBinding var quranMode: QuranMode
 
-    @Published var twoPagesEnabled: Bool
+    @PublishedBinding var twoPagesEnabled: Bool
     @Published var geometryActions: [PageGeometryActions] = []
 
-    @Published var highlights: QuranHighlights {
-        didSet {
-            if oldValue != highlights {
-                deps.highlightsService.highlights = highlights
-
-                if let ayah = highlights.verseToScrollTo(comparingTo: oldValue) {
-                    visiblePages = [ayah.page]
-                }
-            }
-        }
-    }
+    @PublishedBinding var highlights: QuranHighlights
 
     var pagingStrategy: PagingStrategy {
         twoPagesEnabled ? .doublePage : .singlePage

--- a/Features/QuranPagesFeature/Sources/QuranPaginationView.swift
+++ b/Features/QuranPagesFeature/Sources/QuranPaginationView.swift
@@ -66,7 +66,11 @@ public struct QuranPaginationView<Content: View>: View {
     private var singlePageSelection: Binding<Page> {
         Binding(
             get: { selection[0] },
-            set: { selection = [$0] }
+            set: {
+                let newSelection = [$0]
+                guard newSelection != selection else { return }
+                selection = newSelection
+            }
         )
     }
 
@@ -119,7 +123,11 @@ private struct QuranDoublePaginationView<Content: View>: View {
                 let pageIndex = selection.first.flatMap { pages.firstIndex(of: $0) } ?? 0
                 return doublePages[pageIndex / 2]
             },
-            set: { selection = [$0.first, $0.second] }
+            set: {
+                let newSelection = [$0.first, $0.second]
+                guard newSelection != selection else { return }
+                selection = newSelection
+            }
         )
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -724,6 +724,7 @@ private func featuresTargets() -> [[Target]] {
         target(type, name: "QuranContentFeature", hasTests: false, dependencies: [
             "QuranImageFeature",
             "QuranTranslationFeature",
+            "Utilities",
         ]),
 
         target(type, name: "TranslationsFeature", hasTests: false, dependencies: [

--- a/UI/NoorUI/Sources/Pager/PageViewController.swift
+++ b/UI/NoorUI/Sources/Pager/PageViewController.swift
@@ -363,7 +363,7 @@ extension _PageViewController {
         }
 
         private func reconcileSelection(visibleElement: Element?, pendingSelection: Element?) {
-            if let visibleElement {
+            if let visibleElement, visibleElement != parent.selection {
                 parent.selection = visibleElement
             }
 


### PR DESCRIPTION
## Summary

- add a reusable `@PublishedBinding` projection for publisher-backed sources of truth
- migrate Quran content mode, layout preference, and highlights to the source-authoritative projection
- suppress redundant pager selection writes during SwiftUI reconciliation

## Root cause

`ContentViewModel` maintained two-way synchronization between local `@Published` properties and authoritative services/preferences. Equal values could feed back into `ObservableObject` publication while SwiftUI was updating the view hierarchy. The pager also wrote unchanged selections back through nested bindings during controller reconciliation.

## Impact

Services and preferences remain the source of truth while `ContentViewModel` stays observable. Source updates publish once, equal updates are ignored, and pager bindings avoid no-op writes that trigger the SwiftUI runtime warning.

## Validation

- `make format-lint`
- `make test-no-sync TARGET=Utilities` — 40 tests passed
- `make test-no-sync TARGET=NoorUI` — 34 tests passed
- no-sync package build passed as part of the targeted test run
- `make build-sync TARGET=QuranContentFeature`