### PR TITLE
Avoid retaining SwiftUI builders

### DIFF
--- a/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
+++ b/Features/AdvancedAudioOptionsFeature/Sources/AdvancedAudioOptionsView.swift
@@ -341,20 +341,33 @@ private struct EndAtRow: View {
 // MARK: - Pills
 
 private struct PillChoicesRow<Item: Hashable>: View {
-    let items: [Item]
     @Binding var selection: Item
-    let label: (Item) -> String
+    let choices: [Choice]
+
+    init(items: [Item], selection: Binding<Item>, label: (Item) -> String) {
+        _selection = selection
+        choices = items.map { Choice(item: $0, label: label($0)) }
+    }
 
     var body: some View {
+        let selection = $selection
+
         ScrollView(.horizontal, showsIndicators: false) {
             HStack {
-                ForEach(items, id: \.self) { item in
-                    ChoicePill(label: label(item), isSelected: item == selection) {
-                        selection = item
+                ForEach(choices) { choice in
+                    ChoicePill(label: choice.label, isSelected: choice.item == selection.wrappedValue) {
+                        selection.wrappedValue = choice.item
                     }
                 }
             }
         }
+    }
+
+    struct Choice: Identifiable {
+        let item: Item
+        let label: String
+
+        var id: Item { item }
     }
 }
 

--- a/Features/AudioDownloadsFeature/Sources/AudioDownloadsView.swift
+++ b/Features/AudioDownloadsFeature/Sources/AudioDownloadsView.swift
@@ -15,14 +15,25 @@ struct AudioDownloadsView: View {
     @StateObject var viewModel: AudioDownloadsViewModel
 
     var body: some View {
+        let viewModel = viewModel
+
         AudioDownloadsViewUI(
             editMode: $viewModel.editMode,
             error: $viewModel.error,
             items: viewModel.items.sorted(),
-            start: { await viewModel.start() },
-            downloadAction: { await viewModel.startDownloading($0.reciter) },
-            cancelAction: { await viewModel.cancelDownloading($0.reciter) },
-            deleteAction: { @Sendable item in viewModel.deleteReciterFiles(item.reciter) }
+            start: { [weak viewModel] in
+                guard let viewModel else { return }
+                await viewModel.start()
+            },
+            downloadAction: { [weak viewModel] item in
+                guard let viewModel else { return }
+                await viewModel.startDownloading(item.reciter)
+            },
+            cancelAction: { [weak viewModel] item in
+                guard let viewModel else { return }
+                await viewModel.cancelDownloading(item.reciter)
+            },
+            deleteAction: { @Sendable [weak viewModel] item in viewModel?.deleteReciterFiles(item.reciter) }
         )
     }
 }
@@ -37,6 +48,11 @@ private struct AudioDownloadsViewUI: View {
     let deleteAction: ItemDeletionAction<AudioDownloadItem>
 
     var body: some View {
+        let cancelAction = cancelAction
+        let deleteAction = deleteAction
+        let downloadAction = downloadAction
+        let editMode = editMode
+
         NoorList {
             AudioDownloadsSection(
                 title: l("reciters.downloaded"),
@@ -45,7 +61,12 @@ private struct AudioDownloadsViewUI: View {
                     NoorListItem(
                         title: .text(item.reciter.localizedName),
                         subtitle: .init(text: .text(item.size.formattedString()), location: .bottom),
-                        accessory: accessory(item)
+                        accessory: Self.accessory(
+                            item,
+                            editMode: editMode,
+                            downloadAction: downloadAction,
+                            cancelAction: cancelAction
+                        )
                     )
                 },
                 onDelete: { item in deleteAction(item) }
@@ -57,7 +78,12 @@ private struct AudioDownloadsViewUI: View {
                 listItem: { item in
                     NoorListItem(
                         title: .text(item.reciter.localizedName),
-                        accessory: accessory(item)
+                        accessory: Self.accessory(
+                            item,
+                            editMode: editMode,
+                            downloadAction: downloadAction,
+                            cancelAction: cancelAction
+                        )
                     )
                 },
                 onDelete: nil
@@ -68,7 +94,12 @@ private struct AudioDownloadsViewUI: View {
         .environment(\.editMode, $editMode)
     }
 
-    func accessory(_ item: AudioDownloadItem) -> NoorListItem.Accessory? {
+    static func accessory(
+        _ item: AudioDownloadItem,
+        editMode: EditMode,
+        downloadAction: @escaping AsyncItemAction<AudioDownloadItem>,
+        cancelAction: @escaping AsyncItemAction<AudioDownloadItem>
+    ) -> NoorListItem.Accessory? {
         if editMode == .active {
             return nil
         }
@@ -91,12 +122,26 @@ private struct AudioDownloadsViewUI: View {
 private struct AudioDownloadsSection<ListItem: View>: View {
     let title: String
     let items: [AudioDownloadItem]
-    let listItem: (AudioDownloadItem) -> ListItem
+    let listItemsByID: [AudioDownloadItem.ID: ListItem]
     let onDelete: ItemDeletionAction<AudioDownloadItem>?
 
+    init(
+        title: String,
+        items: [AudioDownloadItem],
+        listItem: (AudioDownloadItem) -> ListItem,
+        onDelete: ItemDeletionAction<AudioDownloadItem>?
+    ) {
+        self.title = title
+        self.items = items
+        listItemsByID = Dictionary(uniqueKeysWithValues: items.map { ($0.id, listItem($0)) })
+        self.onDelete = onDelete
+    }
+
     var body: some View {
+        let listItemsByID = listItemsByID
+
         NoorSection(title: title, items) { item in
-            listItem(item)
+            listItemsByID[item.id]
         }
         .onDelete(action: onDelete)
     }

--- a/Features/AudioDownloadsFeature/Sources/AudioDownloadsView.swift
+++ b/Features/AudioDownloadsFeature/Sources/AudioDownloadsView.swift
@@ -21,19 +21,10 @@ struct AudioDownloadsView: View {
             editMode: $viewModel.editMode,
             error: $viewModel.error,
             items: viewModel.items.sorted(),
-            start: { [weak viewModel] in
-                guard let viewModel else { return }
-                await viewModel.start()
-            },
-            downloadAction: { [weak viewModel] item in
-                guard let viewModel else { return }
-                await viewModel.startDownloading(item.reciter)
-            },
-            cancelAction: { [weak viewModel] item in
-                guard let viewModel else { return }
-                await viewModel.cancelDownloading(item.reciter)
-            },
-            deleteAction: { @Sendable [weak viewModel] item in viewModel?.deleteReciterFiles(item.reciter) }
+            start: { await viewModel.start() },
+            downloadAction: { await viewModel.startDownloading($0.reciter) },
+            cancelAction: { await viewModel.cancelDownloading($0.reciter) },
+            deleteAction: { @Sendable item in viewModel.deleteReciterFiles(item.reciter) }
         )
     }
 }

--- a/Features/HomeFeature/Sources/HomeView.swift
+++ b/Features/HomeFeature/Sources/HomeView.swift
@@ -157,9 +157,13 @@ private struct HomeViewUI: View {
     func sectionsView<Item: Identifiable>(
         items: [Item],
         groupBy: (Item) -> Juz,
-        @ViewBuilder listItem: @escaping (Item) -> some View
+        @ViewBuilder listItem: (Item) -> some View
     ) -> some View {
+        let isJuzExpanded = isJuzExpanded
         let itemsByJuz = Dictionary(grouping: items, by: groupBy)
+        let listItemsByID = Dictionary(uniqueKeysWithValues: items.map { ($0.id, listItem($0)) })
+        let setJuzExpanded = setJuzExpanded
+        let surahSortOrder = surahSortOrder
         let juzs = itemsByJuz.keys.sorted {
             surahSortOrder.rawValue * ($0.juzNumber - $1.juzNumber) < 0
         }
@@ -180,7 +184,7 @@ private struct HomeViewUI: View {
                 set: { setJuzExpanded(juz, $0) }
             )
             NoorSection(title: juz.localizedName, isExpanded: isExpanded, items) { item in
-                listItem(item)
+                listItemsByID[item.id]
             }
         }
     }

--- a/Features/QuranImageFeature/Sources/ContentLineView.swift
+++ b/Features/QuranImageFeature/Sources/ContentLineView.swift
@@ -23,21 +23,21 @@ struct ContentLineView: View {
 
         ContentLineViewBody(
             page: viewModel.page,
-            layoutForSize: { [weak viewModel] in viewModel?.layout(for: $0, showHeaderFooter: false) },
+            layoutForSize: { viewModel.layout(for: $0, showHeaderFooter: false) },
             scrollToVerse: viewModel.scrollToVerse,
             wordFrames: viewModel.wordFrames,
             highlightColorsByVerse: viewModel.highlightColorsByVerse,
             chromeStyle: viewModel.chromeStyle,
             imageRenderingMode: viewModel.imageRenderingMode,
-            imageForLine: { [weak viewModel] in viewModel?.lineImage(for: $0) },
-            imageForSideline: { [weak viewModel] in viewModel?.sidelineImage(for: $0) },
-            onGlobalFrameChange: { [weak viewModel] in viewModel?.updateContentFrame($0) }
+            imageForLine: { viewModel.lineImage(for: $0) },
+            imageForSideline: { viewModel.sidelineImage(for: $0) },
+            onGlobalFrameChange: { viewModel.updateContentFrame($0) }
         )
         .geometryActions(
             PageGeometryActions(
                 id: ObjectIdentifier(viewModel),
                 word: { _ in nil },
-                verse: { [weak viewModel] point in viewModel?.verseAtGlobalPoint(point) }
+                verse: { point in viewModel.verseAtGlobalPoint(point) }
             )
         )
         .task {

--- a/Features/QuranImageFeature/Sources/ContentLineView.swift
+++ b/Features/QuranImageFeature/Sources/ContentLineView.swift
@@ -19,23 +19,25 @@ struct ContentLineView: View {
     @StateObject var viewModel: ContentLineViewModel
 
     var body: some View {
+        let viewModel = viewModel
+
         ContentLineViewBody(
             page: viewModel.page,
-            layoutForSize: { viewModel.layout(for: $0, showHeaderFooter: false) },
+            layoutForSize: { [weak viewModel] in viewModel?.layout(for: $0, showHeaderFooter: false) },
             scrollToVerse: viewModel.scrollToVerse,
             wordFrames: viewModel.wordFrames,
             highlightColorsByVerse: viewModel.highlightColorsByVerse,
             chromeStyle: viewModel.chromeStyle,
             imageRenderingMode: viewModel.imageRenderingMode,
-            imageForLine: viewModel.lineImage(for:),
-            imageForSideline: viewModel.sidelineImage(for:),
-            onGlobalFrameChange: viewModel.updateContentFrame
+            imageForLine: { [weak viewModel] in viewModel?.lineImage(for: $0) },
+            imageForSideline: { [weak viewModel] in viewModel?.sidelineImage(for: $0) },
+            onGlobalFrameChange: { [weak viewModel] in viewModel?.updateContentFrame($0) }
         )
         .geometryActions(
             PageGeometryActions(
                 id: ObjectIdentifier(viewModel),
                 word: { _ in nil },
-                verse: { point in viewModel.verseAtGlobalPoint(point) }
+                verse: { [weak viewModel] point in viewModel?.verseAtGlobalPoint(point) }
             )
         )
         .task {

--- a/Features/QuranPagesFeature/Sources/QuranPaginationView.swift
+++ b/Features/QuranPagesFeature/Sources/QuranPaginationView.swift
@@ -17,11 +17,11 @@ public enum PagingStrategy {
 public struct QuranPaginationView<Content: View>: View {
     // MARK: Lifecycle
 
-    public init(pagingStrategy: PagingStrategy, selection: Binding<[Page]>, pages: [Page], content: @escaping (Page) -> Content) {
+    public init(pagingStrategy: PagingStrategy, selection: Binding<[Page]>, pages: [Page], content: (Page) -> Content) {
         self.pagingStrategy = pagingStrategy
         _selection = selection
         self.pages = pages
-        self.content = content
+        contentByPage = Dictionary(uniqueKeysWithValues: pages.map { ($0, content($0)) })
     }
 
     // MARK: Public
@@ -33,13 +33,13 @@ public struct QuranPaginationView<Content: View>: View {
                 QuranSinglePaginationView(
                     selection: singlePageSelection,
                     pages: pages,
-                    content: contentView
+                    contentByPage: contentByPage
                 )
             case .doublePage:
                 QuranDoublePaginationView(
                     selection: $selection,
                     pages: pages,
-                    content: contentView
+                    contentByPage: contentByPage
                 )
             }
         }
@@ -54,14 +54,11 @@ public struct QuranPaginationView<Content: View>: View {
 
     // MARK: Private
 
-    @Environment(\.layoutDirection) private var layoutDirection
-
     private let pagingStrategy: PagingStrategy
 
     @Binding private var selection: [Page]
     private let pages: [Page]
-
-    @ViewBuilder private let content: (Page) -> Content
+    private let contentByPage: [Page: Content]
 
     private var singlePageSelection: Binding<Page> {
         Binding(
@@ -72,12 +69,6 @@ public struct QuranPaginationView<Content: View>: View {
                 selection = newSelection
             }
         )
-    }
-
-    @ViewBuilder
-    private func contentView(for page: Page) -> some View {
-        content(page)
-            .environment(\.layoutDirection, layoutDirection)
     }
 }
 
@@ -93,9 +84,12 @@ private struct QuranDoublePaginationView<Content: View>: View {
 
     @Binding var selection: [Page]
     let pages: [Page]
-    @ViewBuilder let content: (Page) -> Content
+    let contentByPage: [Page: Content]
 
     var body: some View {
+        let contentByPage = contentByPage
+        let layoutDirection = layoutDirection
+
         PageViewController(
             transitionStyle: .scroll,
             navigationOrientation: .horizontal,
@@ -106,9 +100,11 @@ private struct QuranDoublePaginationView<Content: View>: View {
             ForEach(doublePages) { doublePage in
                 HStack(spacing: 0) {
                     QuranSeparators.PageSideSeparator(leading: true)
-                    content(doublePage.first)
+                    contentByPage[doublePage.first]
+                        .environment(\.layoutDirection, layoutDirection)
                     QuranSeparators.PageMiddleSeparator()
-                    content(doublePage.second)
+                    contentByPage[doublePage.second]
+                        .environment(\.layoutDirection, layoutDirection)
                     QuranSeparators.PageSideSeparator(leading: false)
                 }
             }
@@ -116,6 +112,8 @@ private struct QuranDoublePaginationView<Content: View>: View {
     }
 
     // MARK: Private
+
+    @Environment(\.layoutDirection) private var layoutDirection
 
     private var doublePageSelection: Binding<DoublePage> {
         Binding(
@@ -143,9 +141,12 @@ private struct QuranSinglePaginationView<Content: View>: View {
 
     @Binding var selection: Page
     let pages: [Page]
-    @ViewBuilder let content: (Page) -> Content
+    let contentByPage: [Page: Content]
 
     var body: some View {
+        let contentByPage = contentByPage
+        let layoutDirection = layoutDirection
+
         PageViewController(
             transitionStyle: .scroll,
             navigationOrientation: .horizontal,
@@ -158,14 +159,16 @@ private struct QuranSinglePaginationView<Content: View>: View {
                     if isRightSide(page) {
                         HStack(spacing: 0) {
                             QuranSeparators.PageSideSeparator(leading: true)
-                            content(page)
+                            contentByPage[page]
+                                .environment(\.layoutDirection, layoutDirection)
                             QuranSeparators.PageMiddleSeparator()
                                 .offset(x: middleOffset)
                                 .padding(.leading, -middleOffset)
                         }
                     } else {
                         HStack(spacing: 0) {
-                            content(page)
+                            contentByPage[page]
+                                .environment(\.layoutDirection, layoutDirection)
                             QuranSeparators.PageSideSeparator(leading: false)
                         }
                     }
@@ -175,6 +178,8 @@ private struct QuranSinglePaginationView<Content: View>: View {
     }
 
     // MARK: Private
+
+    @Environment(\.layoutDirection) private var layoutDirection
 
     private var middleOffset: CGFloat {
         QuranSeparators.middleWidth

--- a/Features/ReadingSelectorFeature/Sources/View/ReadingItem.swift
+++ b/Features/ReadingSelectorFeature/Sources/View/ReadingItem.swift
@@ -21,6 +21,10 @@ struct ReadingItem<Value: Hashable, ImageView: View>: View {
     @ScaledMetric var cornerRadius = Dimensions.cornerRadius
 
     var body: some View {
+        let imageView = imageView
+        let progress = progress
+        let reading = reading
+
         Button(action: action) {
             ZStack(alignment: .topTrailing) {
                 SingleAxisGeometryReader { width in
@@ -30,10 +34,18 @@ struct ReadingItem<Value: Hashable, ImageView: View>: View {
                                 ProgressView(value: progress, total: 1)
                             }
                             if !reading.tags.isEmpty {
-                                tagsView
+                                VStack(alignment: .leading, spacing: 4) {
+                                    ForEach(reading.tags, id: \.self) { tag in
+                                        NoorTagView(tag)
+                                    }
+                                }
+                                .padding(.bottom, 4)
                             }
-                            titleView
-                            descriptionView
+                            Text(reading.title)
+                                .font(.headline)
+                                .padding(.bottom)
+                            Text(reading.description)
+                                .font(.footnote)
                         }
                         .frame(width: width * 0.65)
 
@@ -52,26 +64,6 @@ struct ReadingItem<Value: Hashable, ImageView: View>: View {
     }
 
     // MARK: Private
-
-    private var titleView: some View {
-        Text(reading.title)
-            .font(.headline)
-            .padding(.bottom)
-    }
-
-    private var descriptionView: some View {
-        Text(reading.description)
-            .font(.footnote)
-    }
-
-    private var tagsView: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            ForEach(reading.tags, id: \.self) { tag in
-                NoorTagView(tag)
-            }
-        }
-        .padding(.bottom, 4)
-    }
 
     private var backgroundRectangle: some InsettableShape {
         RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)

--- a/Features/ReadingSelectorFeature/Sources/View/ReadingSelector.swift
+++ b/Features/ReadingSelectorFeature/Sources/View/ReadingSelector.swift
@@ -25,11 +25,8 @@ struct ReadingSelector: View {
             selectedValue: viewModel.selectedReading,
             groups: viewModel.readingGroups,
             imageView: imageView,
-            selectItem: { [weak viewModel] in viewModel?.showReading($0) },
-            start: { [weak viewModel] in
-                guard let viewModel else { return }
-                await viewModel.start()
-            },
+            selectItem: { viewModel.showReading($0) },
+            start: { await viewModel.start() },
             retry: { }
         )
         .populateThemeStyle()

--- a/Features/ReadingSelectorFeature/Sources/View/ReadingSelector.swift
+++ b/Features/ReadingSelectorFeature/Sources/View/ReadingSelector.swift
@@ -17,14 +17,19 @@ struct ReadingSelector: View {
     @StateObject var viewModel: ReadingSelectorViewModel
 
     var body: some View {
+        let viewModel = viewModel
+
         ReadingSelectorUI(
             error: $viewModel.error,
             progress: viewModel.progress,
             selectedValue: viewModel.selectedReading,
             groups: viewModel.readingGroups,
             imageView: imageView,
-            selectItem: { viewModel.showReading($0) },
-            start: { await viewModel.start() },
+            selectItem: { [weak viewModel] in viewModel?.showReading($0) },
+            start: { [weak viewModel] in
+                guard let viewModel else { return }
+                await viewModel.start()
+            },
             retry: { }
         )
         .populateThemeStyle()
@@ -54,12 +59,23 @@ private struct ReadingSelectorUI<Value: Hashable, ImageView: View>: View {
     let progress: Double?
     let selectedValue: Value?
     let groups: [ReadingGroup<Value>]
-    let imageView: (ReadingInfo<Value>) -> ImageView
+    let imageViews: [Value: ImageView]
     let selectItem: (Value) -> Void
     let start: AsyncAction
     let retry: AsyncAction
 
     var body: some View {
+        let error = $error
+        let imageViews = imageViews
+        let readingInfoDetails = $readingInfoDetails
+        let retry = retry
+        let selectItem = selectItem
+        let selectedGroupID = $selectedGroupID
+        let selectedReadings = selectedReadings
+        let selectedValue = selectedValue
+        let start = start
+        let groups = groups
+
         ScrollViewReader { proxy in
             ScrollView {
                 VStack {
@@ -70,38 +86,42 @@ private struct ReadingSelectorUI<Value: Hashable, ImageView: View>: View {
                     SegmentedChoicesPicker(
                         title: l("reading.selector.title"),
                         items: groups.map(\.id),
-                        selection: $selectedGroupID,
+                        selection: selectedGroupID,
                         label: groupTitle
                     )
                     .padding()
 
                     ForEach(selectedReadings) { reading in
                         let selected = selectedValue == reading.value
-                        ReadingItem(
-                            reading: reading,
-                            imageView: imageView(reading),
-                            selected: selected,
-                            progress: selected ? progress : nil
-                        ) {
-                            readingInfoDetails = reading
+                        if let imageView = imageViews[reading.value] {
+                            ReadingItem(
+                                reading: reading,
+                                imageView: imageView,
+                                selected: selected,
+                                progress: selected ? progress : nil
+                            ) {
+                                readingInfoDetails.wrappedValue = reading
+                            }
                         }
                     }
                 }
             }
-            .onChange(of: selectedGroupID) { _ in
+            .onChange(of: selectedGroupID.wrappedValue) { _ in
                 proxy.scrollTo(ReadingSelectorScrollPosition.top, anchor: .top)
             }
         }
-        .sheet(item: $readingInfoDetails) { reading in
-            ReadingDetails(
-                reading: reading,
-                imageView: imageView(reading),
-                useAction: {
-                    readingInfoDetails = nil
-                    selectItem(reading.value)
-                },
-                closeAction: { readingInfoDetails = nil }
-            )
+        .sheet(item: readingInfoDetails) { reading in
+            if let imageView = imageViews[reading.value] {
+                ReadingDetails(
+                    reading: reading,
+                    imageView: imageView,
+                    useAction: {
+                        readingInfoDetails.wrappedValue = nil
+                        selectItem(reading.value)
+                    },
+                    closeAction: { readingInfoDetails.wrappedValue = nil }
+                )
+            }
         }
         .background(
             Color.systemGroupedBackground
@@ -115,9 +135,9 @@ private struct ReadingSelectorUI<Value: Hashable, ImageView: View>: View {
                     group.readings.contains(where: { $0.value == selectedValue })
                 })
             else { return }
-            selectedGroupID = group.id
+            selectedGroupID.wrappedValue = group.id
         }
-        .errorAlert(error: $error, retry: retry)
+        .errorAlert(error: error, retry: retry)
     }
 
     // MARK: Private
@@ -134,7 +154,7 @@ private struct ReadingSelectorUI<Value: Hashable, ImageView: View>: View {
         progress: Double?,
         selectedValue: Value?,
         groups: [ReadingGroup<Value>],
-        imageView: @escaping (ReadingInfo<Value>) -> ImageView,
+        imageView: (ReadingInfo<Value>) -> ImageView,
         selectItem: @escaping (Value) -> Void,
         start: @escaping AsyncAction,
         retry: @escaping AsyncAction
@@ -143,7 +163,11 @@ private struct ReadingSelectorUI<Value: Hashable, ImageView: View>: View {
         self.progress = progress
         self.selectedValue = selectedValue
         self.groups = groups
-        self.imageView = imageView
+        var imageViews: [Value: ImageView] = [:]
+        for reading in groups.flatMap(\.readings) {
+            imageViews[reading.value] = imageView(reading)
+        }
+        self.imageViews = imageViews
         self.selectItem = selectItem
         self.start = start
         self.retry = retry

--- a/Features/TranslationsFeature/Sources/TranslationsListView.swift
+++ b/Features/TranslationsFeature/Sources/TranslationsListView.swift
@@ -25,14 +25,14 @@ struct TranslationsListView: View {
             selectedTranslations: viewModel.selectedTranslations,
             downloadedTranslations: viewModel.downloadedTranslations,
             availableTranslations: viewModel.availableTranslations,
-            selectAction: { [weak viewModel] item in await viewModel?.selectTranslation(item) },
-            deselectAction: { [weak viewModel] item in await viewModel?.deselectTranslation(item) },
-            downloadAction: { [weak viewModel] item in await viewModel?.startDownloading(item) },
-            cancelAction: { [weak viewModel] item in await viewModel?.cancelDownloading(item) },
-            deleteAction: { [weak viewModel] item in viewModel?.deleteTranslation(item) },
-            moveSelectedItemsAction: { [weak viewModel] in viewModel?.moveSelectedTranslations(at: $0, to: $1) },
-            start: { [weak viewModel] in await viewModel?.start() },
-            refresh: { [weak viewModel] in await viewModel?.refresh() }
+            selectAction: { await viewModel.selectTranslation($0) },
+            deselectAction: { await viewModel.deselectTranslation($0) },
+            downloadAction: { await viewModel.startDownloading($0) },
+            cancelAction: { await viewModel.cancelDownloading($0) },
+            deleteAction: { viewModel.deleteTranslation($0) },
+            moveSelectedItemsAction: { viewModel.moveSelectedTranslations(at: $0, to: $1) },
+            start: { await viewModel.start() },
+            refresh: { await viewModel.refresh() }
         )
     }
 }

--- a/Features/TranslationsFeature/Sources/TranslationsListView.swift
+++ b/Features/TranslationsFeature/Sources/TranslationsListView.swift
@@ -16,6 +16,8 @@ struct TranslationsListView: View {
     @StateObject var viewModel: TranslationsListViewModel
 
     var body: some View {
+        let viewModel = viewModel
+
         TranslationsListViewUI(
             editMode: $viewModel.editMode,
             error: $viewModel.error,
@@ -23,14 +25,14 @@ struct TranslationsListView: View {
             selectedTranslations: viewModel.selectedTranslations,
             downloadedTranslations: viewModel.downloadedTranslations,
             availableTranslations: viewModel.availableTranslations,
-            selectAction: { await viewModel.selectTranslation($0) },
-            deselectAction: { await viewModel.deselectTranslation($0) },
-            downloadAction: { await viewModel.startDownloading($0) },
-            cancelAction: { await viewModel.cancelDownloading($0) },
-            deleteAction: { viewModel.deleteTranslation($0) },
-            moveSelectedItemsAction: viewModel.moveSelectedTranslations,
-            start: { await viewModel.start() },
-            refresh: { await viewModel.refresh() }
+            selectAction: { [weak viewModel] item in await viewModel?.selectTranslation(item) },
+            deselectAction: { [weak viewModel] item in await viewModel?.deselectTranslation(item) },
+            downloadAction: { [weak viewModel] item in await viewModel?.startDownloading(item) },
+            cancelAction: { [weak viewModel] item in await viewModel?.cancelDownloading(item) },
+            deleteAction: { [weak viewModel] item in viewModel?.deleteTranslation(item) },
+            moveSelectedItemsAction: { [weak viewModel] in viewModel?.moveSelectedTranslations(at: $0, to: $1) },
+            start: { [weak viewModel] in await viewModel?.start() },
+            refresh: { [weak viewModel] in await viewModel?.refresh() }
         )
     }
 }
@@ -182,13 +184,29 @@ private struct TranslationsListViewUI: View {
 private struct TranslationsListSection<ListItem: View>: View {
     let title: String?
     let items: [TranslationItem]
-    let listItem: (TranslationItem) -> ListItem
+    let listItemsByID: [TranslationItem.ID: ListItem]
     let onDelete: ItemDeletionAction<TranslationItem>?
     let onMove: ((IndexSet, Int) -> Void)?
 
+    init(
+        title: String?,
+        items: [TranslationItem],
+        listItem: (TranslationItem) -> ListItem,
+        onDelete: ItemDeletionAction<TranslationItem>?,
+        onMove: ((IndexSet, Int) -> Void)?
+    ) {
+        self.title = title
+        self.items = items
+        listItemsByID = Dictionary(uniqueKeysWithValues: items.map { ($0.id, listItem($0)) })
+        self.onDelete = onDelete
+        self.onMove = onMove
+    }
+
     var body: some View {
+        let listItemsByID = listItemsByID
+
         NoorSection(title: title, items) { item in
-            listItem(item)
+            listItemsByID[item.id]
         }
         .onDelete(action: onDelete)
         .onMove(action: onMove)

--- a/UI/NoorUI/Sources/Components/DropdownButton.swift
+++ b/UI/NoorUI/Sources/Components/DropdownButton.swift
@@ -8,33 +8,38 @@
 import SwiftUI
 
 public struct DropdownButton<Item: Hashable, Content: View>: View {
-    private let items: [Item]
+    private let choices: [Choice]
     @Binding private var selectedItem: Item
-    private let content: (Item) -> Content
 
     @ScaledMetric private var horizontalPadding = 12.0
     @ScaledMetric private var verticalPadding = 6.0
     @ScaledMetric private var cornerRadius = Dimensions.cornerRadius
 
-    public init(items: [Item], selectedItem: Binding<Item>, @ViewBuilder content: @escaping (Item) -> Content) {
-        self.items = items
+    public init(items: [Item], selectedItem: Binding<Item>, @ViewBuilder content: (Item) -> Content) {
+        choices = items.map { Choice(item: $0, content: content($0)) }
         _selectedItem = selectedItem
-        self.content = content
     }
 
     public var body: some View {
+        let choices = choices
+        let selectedItem = $selectedItem
+        let selectedContent = choices.first { $0.item == selectedItem.wrappedValue }?.content
+        let horizontalPadding = horizontalPadding
+        let verticalPadding = verticalPadding
+        let cornerRadius = cornerRadius
+
         Menu {
-            ForEach(items, id: \.self) { item in
+            ForEach(choices) { choice in
                 Button {
-                    selectedItem = item
+                    selectedItem.wrappedValue = choice.item
                 } label: {
-                    content(item)
+                    choice.content
                 }
             }
         } label: {
             VStack {
                 HStack {
-                    content(selectedItem)
+                    selectedContent
                     Image(systemName: "chevron.down")
                         .font(.caption)
                 }
@@ -47,5 +52,12 @@ public struct DropdownButton<Item: Hashable, Content: View>: View {
             )
             .foregroundStyle(Color.label)
         }
+    }
+
+    private struct Choice: Identifiable {
+        let item: Item
+        let content: Content
+
+        var id: Item { item }
     }
 }

--- a/UI/NoorUI/Sources/Components/List/NoorEditableCollapsibleSection.swift
+++ b/UI/NoorUI/Sources/Components/List/NoorEditableCollapsibleSection.swift
@@ -17,15 +17,14 @@ public struct NoorEditableCollapsibleSection<Item: Identifiable, ListItem: View>
         _ items: [Item],
         showsHeaderDeleteAction: Bool = false,
         headerDeleteAction: AsyncAction? = nil,
-        @ViewBuilder listItem: @escaping (Item) -> ListItem,
+        @ViewBuilder listItem: (Item) -> ListItem,
         onDelete: ItemDeletionAction<Item>? = nil
     ) {
         self.title = title
         _isExpanded = isExpanded
-        self.items = items
+        entries = items.map { Entry(item: $0, content: listItem($0)) }
         self.showsHeaderDeleteAction = showsHeaderDeleteAction
         self.headerDeleteAction = headerDeleteAction
-        self.listItem = listItem
         self.onDelete = onDelete
     }
 
@@ -45,10 +44,9 @@ public struct NoorEditableCollapsibleSection<Item: Identifiable, ListItem: View>
 
     let title: String
     @Binding var isExpanded: Bool
-    let items: [Item]
+    let entries: [Entry]
     let showsHeaderDeleteAction: Bool
     let headerDeleteAction: AsyncAction?
-    let listItem: (Item) -> ListItem
     var onDelete: ItemDeletionAction<Item>?
 
     @State private var deletingItemIDs: Set<Item.ID> = []
@@ -90,12 +88,12 @@ public struct NoorEditableCollapsibleSection<Item: Identifiable, ListItem: View>
 
     @ViewBuilder
     private var rows: some View {
-        ForEach(items) { item in
-            listItem(item)
+        ForEach(entries) { entry in
+            entry.content
         }
         .onDelete(perform: onDelete.map { onDelete in
             { indexSet in
-                let itemsToDelete = indexSet.map { items[$0] }
+                let itemsToDelete = indexSet.map { entries[$0].item }
                 for itemToDelete in itemsToDelete {
                     delete(itemToDelete, action: onDelete)
                 }
@@ -116,6 +114,13 @@ public struct NoorEditableCollapsibleSection<Item: Identifiable, ListItem: View>
             await operation()
             deletingItemIDs.remove(item.id)
         }
+    }
+
+    struct Entry: Identifiable {
+        let item: Item
+        let content: ListItem
+
+        var id: Item.ID { item.id }
     }
 }
 

--- a/UI/NoorUI/Sources/Components/List/NoorSection.swift
+++ b/UI/NoorUI/Sources/Components/List/NoorSection.swift
@@ -115,14 +115,13 @@ public struct NoorSection<Item: Identifiable, ListItem: View>: View {
         title: String? = nil,
         isExpanded: Binding<Bool>? = nil,
         _ items: [Item],
-        @ViewBuilder listItem: @escaping (Item) -> ListItem,
+        @ViewBuilder listItem: (Item) -> ListItem,
         onDelete: ItemDeletionAction<Item>? = nil,
         onMove: ((IndexSet, Int) -> Void)? = nil
     ) {
         self.title = title
         self.isExpanded = isExpanded
-        self.items = items
-        self.listItem = listItem
+        entries = items.map { Entry(item: $0, content: listItem($0)) }
         self.onDelete = onDelete
         self.onMove = onMove
     }
@@ -130,7 +129,7 @@ public struct NoorSection<Item: Identifiable, ListItem: View>: View {
     // MARK: Public
 
     public var body: some View {
-        if !items.isEmpty {
+        if !entries.isEmpty {
             NoorBasicSection(title: title, isExpanded: isExpanded) {
                 rows
             }
@@ -141,8 +140,7 @@ public struct NoorSection<Item: Identifiable, ListItem: View>: View {
 
     let title: String?
     let isExpanded: Binding<Bool>?
-    let items: [Item]
-    let listItem: (Item) -> ListItem
+    let entries: [Entry]
     var onDelete: ItemDeletionAction<Item>?
     var onMove: ((IndexSet, Int) -> Void)?
 
@@ -152,8 +150,8 @@ public struct NoorSection<Item: Identifiable, ListItem: View>: View {
 
     @ViewBuilder
     private var rows: some View {
-        ForEach(items) { item in
-            listItem(item)
+        ForEach(entries) { entry in
+            entry.content
         }
         .onDelete(perform: deleteAction)
         .onMove(perform: onMove)
@@ -162,7 +160,7 @@ public struct NoorSection<Item: Identifiable, ListItem: View>: View {
     private var deleteAction: ((IndexSet) -> Void)? {
         onDelete.map { _ in
             { indexSet in
-                let itemsToDelete = indexSet.map { items[$0] }
+                let itemsToDelete = indexSet.map { entries[$0].item }
                 for itemToDelete in itemsToDelete {
                     delete(itemToDelete)
                 }
@@ -183,6 +181,13 @@ public struct NoorSection<Item: Identifiable, ListItem: View>: View {
             await operation()
             deletingItemIDs.remove(item.id)
         }
+    }
+
+    struct Entry: Identifiable {
+        let item: Item
+        let content: ListItem
+
+        var id: Item.ID { item.id }
     }
 }
 

--- a/UI/NoorUI/Sources/Components/SegmentedChoicesPicker.swift
+++ b/UI/NoorUI/Sources/Components/SegmentedChoicesPicker.swift
@@ -14,24 +14,19 @@ public struct SegmentedChoicesPicker<Item: Hashable>: View {
         title: String,
         items: [Item],
         selection: Binding<Item>,
-        label: @escaping (Item) -> String
+        label: (Item) -> String
     ) {
         self.title = title
-        self.items = items
+        choices = items.map { Choice(item: $0, title: label($0)) }
         _selection = selection
-        self.label = label
     }
 
     // MARK: Public
 
     public var body: some View {
-        // Capture only the label closure. Capturing self here also retains the
-        // selection binding through SwiftUI's tag projection cache.
-        let itemLabel = label
-
         Picker(title, selection: $selection) {
-            ForEach(items, id: \.self) { item in
-                Text(itemLabel(item)).tag(item)
+            ForEach(choices) { choice in
+                Text(choice.title).tag(choice.item)
             }
         }
         .pickerStyle(.segmented)
@@ -40,7 +35,13 @@ public struct SegmentedChoicesPicker<Item: Hashable>: View {
     // MARK: Private
 
     private let title: String
-    private let items: [Item]
+    private let choices: [Choice]
     @Binding private var selection: Item
-    private let label: (Item) -> String
+
+    private struct Choice: Identifiable {
+        let item: Item
+        let title: String
+
+        var id: Item { item }
+    }
 }

--- a/UI/NoorUI/Sources/Features/Quran/AdaptiveImageScrollView.swift
+++ b/UI/NoorUI/Sources/Features/Quran/AdaptiveImageScrollView.swift
@@ -35,6 +35,14 @@ public struct AdaptiveImageScrollView<Header: View, Footer: View>: View {
     // MARK: Public
 
     public var body: some View {
+        let decorations = decorations
+        let footer = footer
+        let header = header
+        let image = image
+        let onGlobalFrameChange = onGlobalFrameChange
+        let onScaleChange = onScaleChange
+        let renderingMode = renderingMode
+
         AdaptiveQuranScrollView {
             header
         } footer: {
@@ -55,7 +63,7 @@ public struct AdaptiveImageScrollView<Header: View, Footer: View>: View {
                     Color.clear
                 }
             }
-            .frame(height: imageHeight(for: availableContentSize))
+            .frame(height: Self.imageHeight(image: image, availableContentSize: availableContentSize))
         }
     }
 
@@ -69,7 +77,7 @@ public struct AdaptiveImageScrollView<Header: View, Footer: View>: View {
     private let onScaleChange: (WordFrameScale) -> Void
     private let onGlobalFrameChange: (CGRect) -> Void
 
-    private func imageHeight(for availableContentSize: CGSize) -> CGFloat {
+    private static func imageHeight(image: UIImage?, availableContentSize: CGSize) -> CGFloat {
         if let imageSize = image?.size, availableContentSize.width > availableContentSize.height {
             return availableContentSize.width * (imageSize.height / imageSize.width)
         } else {

--- a/UI/NoorUI/Sources/Features/Quran/AdaptiveQuranScrollView.swift
+++ b/UI/NoorUI/Sources/Features/Quran/AdaptiveQuranScrollView.swift
@@ -25,21 +25,35 @@ public struct AdaptiveQuranScrollView<Header: View, Footer: View, Content: View>
     // MARK: Public
 
     public var body: some View {
+        let content = content
+        let footer = footer
+        let footerSize = $footerSize
+        let header = header
+        let headerSize = $headerSize
+        let readableInsets = $readableInsets
+
         GeometryReader { geometry in
-            scrollView {
+            let availableContentSize = Self.availableContentSize(
+                from: geometry,
+                readableInsets: readableInsets.wrappedValue,
+                headerSize: headerSize.wrappedValue,
+                footerSize: footerSize.wrappedValue
+            )
+
+            Self.scrollView {
                 VStack(spacing: 0) {
                     header
-                        .onSizeChange { headerSize = $0 }
+                        .onSizeChange { headerSize.wrappedValue = $0 }
 
-                    content(availableContentSize(from: geometry))
+                    content(availableContentSize)
                         .readableInsetsPadding(.horizontal)
 
                     footer
-                        .onSizeChange { footerSize = $0 }
+                        .onSizeChange { footerSize.wrappedValue = $0 }
                 }
             }
         }
-        .onReadableInsetsChange { readableInsets = $0 }
+        .onReadableInsetsChange { readableInsets.wrappedValue = $0 }
     }
 
     // MARK: Private
@@ -53,7 +67,7 @@ public struct AdaptiveQuranScrollView<Header: View, Footer: View, Content: View>
     private let content: (CGSize) -> Content
 
     @ViewBuilder
-    private func scrollView(@ViewBuilder content: () -> some View) -> some View {
+    private static func scrollView(@ViewBuilder content: () -> some View) -> some View {
         if #available(iOS 16.4, *) {
             ScrollView(content: content)
                 .scrollBounceBehavior(.basedOnSize)
@@ -62,7 +76,12 @@ public struct AdaptiveQuranScrollView<Header: View, Footer: View, Content: View>
         }
     }
 
-    private func availableContentSize(from geometry: GeometryProxy) -> CGSize {
+    private static func availableContentSize(
+        from geometry: GeometryProxy,
+        readableInsets: EdgeInsets,
+        headerSize: CGSize,
+        footerSize: CGSize
+    ) -> CGSize {
         CGSize(
             width: max(0, geometry.size.width - readableInsets.leading - readableInsets.trailing),
             height: max(0, geometry.size.height - headerSize.height - footerSize.height)

--- a/UI/NoorUI/Tests/BuilderClosureLifetimeTests.swift
+++ b/UI/NoorUI/Tests/BuilderClosureLifetimeTests.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import XCTest
+@testable import NoorUI
+
+@MainActor
+final class BuilderClosureLifetimeTests: XCTestCase {
+    func testSegmentedChoicesPickerDoesNotStoreLabelBuilder() {
+        assertBuilderReleased { token in
+            SegmentedChoicesPicker(
+                title: "Title",
+                items: [1],
+                selection: .constant(1),
+                label: { _ in token.text }
+            )
+        }
+    }
+
+    func testDropdownButtonDoesNotStoreContentBuilder() {
+        assertBuilderReleased { token in
+            DropdownButton(items: [1], selectedItem: .constant(1)) { _ in
+                Text(token.text)
+            }
+        }
+    }
+
+    func testNoorSectionDoesNotStoreListItemBuilder() {
+        assertBuilderReleased { token in
+            NoorSection([Item(id: 1)]) { _ in
+                Text(token.text)
+            }
+        }
+    }
+
+    func testNoorEditableCollapsibleSectionDoesNotStoreListItemBuilder() {
+        assertBuilderReleased { token in
+            NoorEditableCollapsibleSection(
+                title: "Title",
+                isExpanded: .constant(true),
+                [Item(id: 1)]
+            ) { _ in
+                Text(token.text)
+            }
+        }
+    }
+
+    private func assertBuilderReleased(
+        _ makeView: (Token) -> Any,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        weak var weakToken: Token?
+        var retainedView: Any?
+
+        autoreleasepool {
+            let token = Token()
+            weakToken = token
+            retainedView = makeView(token)
+        }
+
+        XCTAssertNil(weakToken, file: file, line: line)
+        withExtendedLifetime(retainedView) { }
+    }
+}
+
+private final class Token {
+    let text = "Text"
+}
+
+private struct Item: Identifiable {
+    let id: Int
+}

--- a/UI/UIx/Sources/SwiftUI/CollectionView/CollectionView.swift
+++ b/UI/UIx/Sources/SwiftUI/CollectionView/CollectionView.swift
@@ -21,11 +21,13 @@ public struct CollectionView<
     public init(
         layout: UICollectionViewLayout,
         sections: [ListSection<SectionId, Item>],
-        @ViewBuilder content: @escaping (SectionId, Item) -> ItemContent
+        @ViewBuilder content: (SectionId, Item) -> ItemContent
     ) {
         self.layout = layout
         self.sections = sections
-        self.content = content
+        contentByItem = Dictionary(uniqueKeysWithValues: sections.flatMap { section in
+            section.items.map { item in (item, content(section.id, item)) }
+        })
     }
 
     // MARK: Public
@@ -35,7 +37,7 @@ public struct CollectionView<
             layout: layout,
             sections: sections,
             configure: configure,
-            content: content,
+            contentByItem: contentByItem,
             isPagingEnabled: isPagingEnabled,
             usesCollectionViewSafeAreaForCellLayoutMargins: usesCollectionViewSafeAreaForCellLayoutMargins,
             scrollAnchorId: scrollAnchorId,
@@ -75,7 +77,7 @@ public struct CollectionView<
 
     private let layout: UICollectionViewLayout
     private let sections: [ListSection<SectionId, Item>]
-    private let content: (SectionId, Item) -> ItemContent
+    private let contentByItem: [Item: ItemContent]
     private var configure: ((UICollectionView) -> Void)?
 
     private var isPagingEnabled: Bool = false
@@ -97,7 +99,7 @@ private struct CollectionViewBody<
     let layout: UICollectionViewLayout
     let sections: [ListSection<SectionId, Item>]
     let configure: ((UICollectionView) -> Void)?
-    let content: (SectionId, Item) -> ItemContent
+    let contentByItem: [Item: ItemContent]
 
     let isPagingEnabled: Bool
     let usesCollectionViewSafeAreaForCellLayoutMargins: Bool
@@ -106,7 +108,7 @@ private struct CollectionViewBody<
     let scrollAnchor: ScrollAnchor
 
     func makeUIViewController(context: Context) -> UIViewControllerType {
-        let viewController = UIViewControllerType(collectionViewLayout: layout, content: content)
+        let viewController = UIViewControllerType(collectionViewLayout: layout, contentByItem: contentByItem)
         configure?(viewController.collectionView)
 
         context.coordinator.viewController = viewController
@@ -130,6 +132,7 @@ private struct CollectionViewBody<
             viewController.collectionView.collectionViewLayout = layout
         }
 
+        viewController.contentByItem = contentByItem
         viewController.dataSource?.sections = sections
 
         viewController.usesCollectionViewSafeAreaForCellLayoutMargins = usesCollectionViewSafeAreaForCellLayoutMargins

--- a/UI/UIx/Sources/SwiftUI/CollectionView/CollectionViewController.swift
+++ b/UI/UIx/Sources/SwiftUI/CollectionView/CollectionViewController.swift
@@ -18,15 +18,16 @@ final class CollectionViewController<
 
     init(
         collectionViewLayout: UICollectionViewLayout,
-        content: @escaping (SectionId, Item) -> ItemContent
+        contentByItem: [Item: ItemContent]
     ) {
+        self.contentByItem = contentByItem
         collectionView = .init(frame: .zero, collectionViewLayout: collectionViewLayout)
         collectionView.backgroundColor = .clear
 
         super.init(nibName: nil, bundle: nil)
         collectionView.delegate = self
 
-        setUpDataSource(content: content)
+        setUpDataSource()
     }
 
     @available(*, unavailable)
@@ -52,6 +53,8 @@ final class CollectionViewController<
             scroller.dataSource = dataSource
         }
     }
+
+    var contentByItem: [Item: ItemContent]
 
     override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
@@ -134,7 +137,7 @@ final class CollectionViewController<
 
     // MARK: Private
 
-    private func setUpDataSource(content: @escaping (SectionId, Item) -> ItemContent) {
+    private func setUpDataSource() {
         collectionView.register(CellType.self, forCellWithReuseIdentifier: CellType.reuseId)
 
         dataSource = CollectionViewDataSource(collectionView: collectionView) {
@@ -143,7 +146,7 @@ final class CollectionViewController<
                 return nil
             }
 
-            guard let section = dataSource.section(from: indexPath), let item = dataSource.item(at: indexPath) else {
+            guard let item = dataSource.item(at: indexPath), let content = contentByItem[item] else {
                 return nil
             }
 
@@ -151,7 +154,7 @@ final class CollectionViewController<
 
             // Get & configure the cell.
             let cell = collectionView.dequeueReusableCell(CellType.self, for: indexPath)
-            cell.configure(content: content(section.id, item), dataId: itemId)
+            cell.configure(content: content, dataId: itemId)
 
             cell.updateLayoutMargins(
                 usesCollectionViewSafeAreaForCellLayoutMargins: usesCollectionViewSafeAreaForCellLayoutMargins,

--- a/UI/UIx/Sources/SwiftUI/CollectionView/CollectionViewReader.swift
+++ b/UI/UIx/Sources/SwiftUI/CollectionView/CollectionViewReader.swift
@@ -28,8 +28,12 @@ public struct CollectionViewReader<Content: View>: View {
     // MARK: Public
 
     public var body: some View {
-        content(_environmentCollectionView?.wrappedValue ?? _collectionView)
-            .environment(\._collectionView, $_collectionView)
+        let collectionView = $_collectionView
+        let content = content
+        let environmentCollectionView = _environmentCollectionView
+
+        content(environmentCollectionView?.wrappedValue ?? collectionView.wrappedValue)
+            .environment(\._collectionView, collectionView)
     }
 
     // MARK: Internal

--- a/UI/UIx/Sources/SwiftUI/SingleChoice/SingleChoiceSelector.swift
+++ b/UI/UIx/Sources/SwiftUI/SingleChoice/SingleChoiceSelector.swift
@@ -31,12 +31,15 @@ public class SingleChoiceSelector<Item: Equatable, Content: View>: UITableViewCo
         style: UITableView.Style,
         sections: [SingleChoiceSection<Item>],
         selected: Item?,
-        configure: @escaping (Item, Item?) -> Content,
+        configure: (Item, Item?) -> Content,
         onSelection: @escaping (Item) -> Void
     ) {
-        self.sections = sections
-        self.selected = selected
-        self.configure = configure
+        self.sections = sections.map { section in
+            Section(
+                header: section.header,
+                rows: section.items.map { Row(item: $0, content: configure($0, selected)) }
+            )
+        }
         self.onSelection = onSelection
         super.init(style: style)
     }
@@ -63,20 +66,20 @@ public class SingleChoiceSelector<Item: Equatable, Content: View>: UITableViewCo
     }
 
     override public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        sections[section].items.count
+        sections[section].rows.count
     }
 
     override public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: cellReuseId, for: indexPath) as? Cell else {
             fatalError("Cell not of type \(Cell.self)")
         }
-        let view = configure(sections[indexPath.section].items[indexPath.item], selected)
+        let view = sections[indexPath.section].rows[indexPath.item].content
         cell.set(rootView: view, parentController: self)
         return cell
     }
 
     override public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let item = sections[indexPath.section].items[indexPath.item]
+        let item = sections[indexPath.section].rows[indexPath.item].item
         onSelection(item)
     }
 
@@ -86,10 +89,18 @@ public class SingleChoiceSelector<Item: Equatable, Content: View>: UITableViewCo
 
     // MARK: Private
 
-    private let sections: [SingleChoiceSection<Item>]
-    private let selected: Item?
+    private let sections: [Section]
     private let onSelection: (Item) -> Void
-    private let configure: (Item, Item?) -> Content
+
+    private struct Section {
+        let header: String?
+        let rows: [Row]
+    }
+
+    private struct Row {
+        let item: Item
+        let content: Content
+    }
 
     private var cellReuseId: String {
         String(describing: Cell.self)
@@ -101,7 +112,7 @@ public func singleChoiceSelector<Item: Hashable>(
     style: UITableView.Style = .insetGrouped,
     sections: [SingleChoiceSection<Item>],
     selected: Item?,
-    itemText: @escaping (Item) -> String,
+    itemText: (Item) -> String,
     onSelection: @escaping (Item) -> Void
 ) -> SingleChoiceSelector<Item, SingleChoiceRow> {
     SingleChoiceSelector(
@@ -118,24 +129,31 @@ public func singleChoiceSelector<Item: Hashable>(
 public struct SingleChoiceSelectorView<Item: Hashable>: View {
     // MARK: Lifecycle
 
-    public init(sections: [SingleChoiceSection<Item>], selected: Binding<Item?>, itemText: @escaping (Item) -> String) {
-        self.sections = sections
+    public init(sections: [SingleChoiceSection<Item>], selected: Binding<Item?>, itemText: (Item) -> String) {
+        self.sections = sections.enumerated().map { index, section in
+            ChoiceSection(
+                id: index,
+                header: section.header,
+                choices: section.items.map { Choice(item: $0, text: itemText($0)) }
+            )
+        }
         _selected = selected
-        self.itemText = itemText
     }
 
     // MARK: Public
 
     public var body: some View {
+        let selected = $selected
+
         PreferredContentSizeMatchesScrollView {
             List {
-                ForEach(sections, id: \.header) { section in
+                ForEach(sections) { section in
                     if let header = section.header {
                         Section(header: Text(header)) {
-                            itemsView(section.items)
+                            itemsView(section.choices, selected: selected)
                         }
                     } else {
-                        itemsView(section.items)
+                        itemsView(section.choices, selected: selected)
                     }
                 }
             }
@@ -145,17 +163,29 @@ public struct SingleChoiceSelectorView<Item: Hashable>: View {
 
     // MARK: Private
 
-    private let sections: [SingleChoiceSection<Item>]
+    private let sections: [ChoiceSection]
     @Binding private var selected: Item?
-    private let itemText: (Item) -> String
 
-    private func itemsView(_ items: [Item]) -> some View {
-        ForEach(items, id: \.self) { item in
+    private func itemsView(_ choices: [Choice], selected: Binding<Item?>) -> some View {
+        ForEach(choices) { choice in
             Button {
-                selected = item
+                selected.wrappedValue = choice.item
             } label: {
-                SingleChoiceRow(text: itemText(item), selected: item == selected)
+                SingleChoiceRow(text: choice.text, selected: choice.item == selected.wrappedValue)
             }
         }
+    }
+
+    private struct ChoiceSection: Identifiable {
+        let id: Int
+        let header: String?
+        let choices: [Choice]
+    }
+
+    private struct Choice: Identifiable {
+        let item: Item
+        let text: String
+
+        var id: Item { item }
     }
 }

--- a/UI/UIx/Sources/SwiftUI/Views/SingleAxisGeometryReader.swift
+++ b/UI/UIx/Sources/SwiftUI/Views/SingleAxisGeometryReader.swift
@@ -33,7 +33,12 @@ public struct SingleAxisGeometryReader<Content: View>: View {
     // MARK: Public
 
     public var body: some View {
-        content(size)
+        let alignment = alignment
+        let axis = axis
+        let content = content
+        let size = $size
+
+        content(size.wrappedValue)
             .frame(
                 maxWidth: axis == .horizontal ? .infinity : nil,
                 maxHeight: axis == .vertical ? .infinity : nil,
@@ -42,7 +47,7 @@ public struct SingleAxisGeometryReader<Content: View>: View {
             .background(GeometryReader { proxy in
                 Color.clear.preference(key: SizeKey.self, value: axis == .horizontal ? proxy.size.width : proxy.size.height)
             })
-            .onPreferenceChange(SizeKey.self) { size = $0 }
+            .onPreferenceChange(SizeKey.self) { size.wrappedValue = $0 }
     }
 
     // MARK: Private

--- a/UI/UIx/Tests/BuilderClosureLifetimeTests.swift
+++ b/UI/UIx/Tests/BuilderClosureLifetimeTests.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+import UIKit
+import XCTest
+@testable import UIx
+
+@MainActor
+final class BuilderClosureLifetimeTests: XCTestCase {
+    func testSingleChoiceSelectorViewDoesNotStoreTextBuilder() {
+        assertBuilderReleased { token in
+            SingleChoiceSelectorView(
+                sections: [SingleChoiceSection(items: [1])],
+                selected: .constant(1),
+                itemText: { _ in token.text }
+            )
+        }
+    }
+
+    func testSingleChoiceSelectorDoesNotStoreConfigurationBuilder() {
+        assertBuilderReleased { token in
+            SingleChoiceSelector(
+                style: .insetGrouped,
+                sections: [SingleChoiceSection(items: [1])],
+                selected: 1,
+                configure: { _, _ in Text(token.text) },
+                onSelection: { _ in }
+            )
+        }
+    }
+
+    func testCollectionViewDoesNotStoreContentBuilder() {
+        assertBuilderReleased { token in
+            CollectionView(
+                layout: UICollectionViewFlowLayout(),
+                sections: [ListSection(sectionId: 0, items: [Item(id: 1)])]
+            ) { _, _ in
+                Text(token.text)
+            }
+        }
+    }
+
+    private func assertBuilderReleased(
+        _ makeView: (Token) -> Any,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        weak var weakToken: Token?
+        var retainedView: Any?
+
+        autoreleasepool {
+            let token = Token()
+            weakToken = token
+            retainedView = makeView(token)
+        }
+
+        XCTAssertNil(weakToken, file: file, line: line)
+        withExtendedLifetime(retainedView) { }
+    }
+}
+
+private final class Token {
+    let text = "Text"
+}
+
+private struct Item: Identifiable, Hashable {
+    let id: Int
+}


### PR DESCRIPTION
## Summary

- eagerly materialize formatter, list-row, pagination, single-choice, and collection-view content instead of storing escaping builders in SwiftUI values
- narrow captures for runtime-dependent geometry and action closures
- add NoorUI and UIx regression tests covering builder lifetimes

## Root cause

Escaping builders stored inside SwiftUI view values could retain the surrounding view graph, including bindings and observed objects, after presentation or navigation dismissal. Native segmented pickers exposed this as retained audio-option state.

## Impact

Dismissed SwiftUI screens and their view models can deallocate normally, preventing overlapping audio state and related memory retention.

## Validation

- SwiftFormat passed
- iOS 26.5 memgraph on iPhone 17 Pro Max: 0 leaks / 0 bytes after repeated Advanced Audio, Reading Selector, Audio Manager, Translations, and theme-picker flows
- targeted NoorUI and UIx no-sync tests passed before additional testing was stopped