### PR TITLE
Protect system bookmark collections

### DIFF
--- a/Data/MobileSyncTestSupport/Sources/MobileSyncTestSupport.swift
+++ b/Data/MobileSyncTestSupport/Sources/MobileSyncTestSupport.swift
@@ -1,4 +1,5 @@
 #if QURAN_SYNC
+import Foundation
 import MobileSync
 
 public final class MobileSyncTestDatabase: @unchecked Sendable {
@@ -19,6 +20,7 @@ public final class MobileSyncTestDatabase: @unchecked Sendable {
     }
 
     private init() {
+        Self.removeDatabaseFiles()
         AuthFlowFactoryProvider.shared.doInitialize()
         appGraph = SharedDependencyGraph.shared.doInit(
             driverFactory: DriverFactory(),
@@ -26,6 +28,22 @@ public final class MobileSyncTestDatabase: @unchecked Sendable {
             clientId: "",
             clientSecret: nil
         )
+    }
+
+    private static func removeDatabaseFiles() {
+        guard let applicationSupportDirectory = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return
+        }
+
+        let databaseURL = applicationSupportDirectory
+            .appendingPathComponent("databases", isDirectory: true)
+            .appendingPathComponent("quran.db")
+        for suffix in ["", "-shm", "-wal"] {
+            try? FileManager.default.removeItem(atPath: databaseURL.path + suffix)
+        }
     }
 }
 #endif

--- a/Domain/AnnotationsService/Sources/AyahBookmarkCollectionService.swift
+++ b/Domain/AnnotationsService/Sources/AyahBookmarkCollectionService.swift
@@ -21,6 +21,8 @@ public struct AyahBookmarkCollection: Identifiable {
     public let bookmarks: [AyahCollectionBookmark]
 
     public var id: String { collection.id }
+    public var canDelete: Bool { !collection.isSystem }
+    public var canRename: Bool { !collection.isSystem }
 }
 
 public struct AyahCollectionBookmark: Identifiable {
@@ -51,14 +53,6 @@ public enum AyahBookmarkCollectionKind: Equatable {
 
     public var isOldPageBookmarks: Bool {
         self == .oldPageBookmarks
-    }
-
-    public var canDelete: Bool {
-        self != .defaultBookmarks
-    }
-
-    public var canRename: Bool {
-        self != .defaultBookmarks
     }
 }
 
@@ -136,7 +130,7 @@ public struct AyahBookmarkCollectionService {
 
     static func collections(from collections: [CollectionWithAyahBookmarks], quran: Quran) -> [AyahBookmarkCollection] {
         collections.compactMap { collection in
-            guard !collection.collection.isSystemHighlight else {
+            guard collection.collection.isDefault || !collection.collection.isSystem else {
                 return nil
             }
             return AyahBookmarkCollection(

--- a/Features/BookmarksFeature/Sources/AyahSetDataSource.swift
+++ b/Features/BookmarksFeature/Sources/AyahSetDataSource.swift
@@ -69,8 +69,8 @@ struct BookmarkCollectionAyahSetDataSource: ManageableAyahSetDataSource {
             title: collection.displayName,
             ayahs: collection.bookmarks.map(\.ayah),
             highlightColor: nil,
-            canRename: collection.kind.canRename,
-            canDelete: collection.kind.canDelete
+            canRename: collection.canRename,
+            canDelete: collection.canDelete
         )
     }
 }

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
@@ -76,7 +76,7 @@ private struct BookmarkCollectionsContent: View {
 
                 NoorListRows(
                     viewModel.displayedCollections,
-                    canDelete: { $0.kind.canDelete },
+                    canDelete: { $0.canDelete },
                     onDelete: { collection in
                         { await viewModel.requestDeleteCollection(collection) }
                     }

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsViewModel.swift
@@ -85,7 +85,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     }
 
     static func deletableCollections(from collections: [AyahBookmarkCollection]) -> [AyahBookmarkCollection] {
-        let deletableCollections = collections.filter(\.kind.canDelete)
+        let deletableCollections = collections.filter(\.canDelete)
         let oldPageBookmarks = deletableCollections.filter(\.kind.isOldPageBookmarks)
         let remainingCollections = deletableCollections.filter { !$0.kind.isOldPageBookmarks }
         return oldPageBookmarks + remainingCollections
@@ -159,7 +159,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     }
 
     func requestDeleteCollection(_ collection: AyahBookmarkCollection) async {
-        guard collection.kind.canDelete else {
+        guard collection.canDelete else {
             return
         }
         guard !collection.bookmarks.isEmpty else {
@@ -170,7 +170,7 @@ final class BookmarkCollectionsViewModel: ObservableObject {
     }
 
     func deleteCollection(_ collection: AyahBookmarkCollection) async {
-        guard collection.kind.canDelete else {
+        guard collection.canDelete else {
             return
         }
         do {

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -99,7 +99,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         XCTAssertEqual(collection(name: "Personal").kind, .user)
     }
 
-    func test_collectionCapabilities_protectDefaultCollection() {
+    func test_collectionCapabilities_protectSystemCollections() {
         let defaultBookmarks = collection(
             name: "Default",
             id: "__default__",
@@ -109,12 +109,16 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         let oldPageBookmarks = collection(name: oldPageBookmarksCollectionName)
         let user = collection(name: "Personal")
 
-        XCTAssertFalse(defaultBookmarks.kind.canRename)
-        XCTAssertFalse(defaultBookmarks.kind.canDelete)
-        XCTAssertTrue(oldPageBookmarks.kind.canRename)
-        XCTAssertTrue(oldPageBookmarks.kind.canDelete)
-        XCTAssertTrue(user.kind.canRename)
-        XCTAssertTrue(user.kind.canDelete)
+        let system = collection(name: "Managed", isSystem: true)
+
+        XCTAssertFalse(defaultBookmarks.canRename)
+        XCTAssertFalse(defaultBookmarks.canDelete)
+        XCTAssertFalse(system.canRename)
+        XCTAssertFalse(system.canDelete)
+        XCTAssertTrue(oldPageBookmarks.canRename)
+        XCTAssertTrue(oldPageBookmarks.canDelete)
+        XCTAssertTrue(user.canRename)
+        XCTAssertTrue(user.canDelete)
     }
 
     func test_defaultCollectionPresentation_usesLocalizedFavoritesNameAndFilledStarIcon() {


### PR DESCRIPTION
## Summary

- derive collection rename and delete capabilities from persisted `isSystem` metadata
- keep the default Favorites collection visible while hiding other system collections
- remove the iOS `__default__` identifier assumption in favor of `isDefault`
- reset MobileSync test database files before initialization

## Compatibility

- rebased onto latest `main`, including `mobile-sync-spm` 0.1.19 from #988

## Testing

- `make test-no-sync` — 386 passed
- `make test-sync` — 512 passed
- `make format-lint`
- verified on the iOS Simulator against the prelive backend: the default Favorites collection is available and its collection membership is received through sync
