### PR TITLE
Replace trash icons with localized X delete actions

### DIFF
--- a/Features/AudioDownloadsFeature/Sources/AudioDownloadsView.swift
+++ b/Features/AudioDownloadsFeature/Sources/AudioDownloadsView.swift
@@ -95,10 +95,9 @@ private struct AudioDownloadsSection<ListItem: View>: View {
     let onDelete: ItemDeletionAction<AudioDownloadItem>?
 
     var body: some View {
-        NoorSection(title: title, items) { item in
+        NoorSection(title: title, items, onDelete: onDelete) { item in
             listItem(item)
         }
-        .onDelete(action: onDelete)
     }
 }
 

--- a/Features/BookmarksFeature/Sources/AyahSetView.swift
+++ b/Features/BookmarksFeature/Sources/AyahSetView.swift
@@ -48,6 +48,9 @@ private struct AyahSetContentView: View {
             Section {
                 ForEach(viewModel.content.ayahs, id: \.self) { ayah in
                     ayahRow(ayah)
+                        .noorDeleteSwipeAction {
+                            Task { await viewModel.removeAyah(ayah) }
+                        }
                 }
                 .onDelete { offsets in
                     let ayahs = offsets.map { viewModel.content.ayahs[$0] }

--- a/Features/BookmarksFeature/Sources/AyahSetView.swift
+++ b/Features/BookmarksFeature/Sources/AyahSetView.swift
@@ -46,19 +46,13 @@ private struct AyahSetContentView: View {
     private var ayahList: some View {
         NoorList {
             Section {
-                ForEach(viewModel.content.ayahs, id: \.self) { ayah in
-                    ayahRow(ayah)
-                        .noorDeleteSwipeAction {
-                            Task { await viewModel.removeAyah(ayah) }
-                        }
-                }
-                .onDelete { offsets in
-                    let ayahs = offsets.map { viewModel.content.ayahs[$0] }
-                    Task {
-                        for ayah in ayahs {
-                            await viewModel.removeAyah(ayah)
-                        }
+                NoorListRows(
+                    viewModel.content.ayahs.map(SelfIdentifiable.init),
+                    onDelete: { item in
+                        { await viewModel.removeAyah(item.value) }
                     }
+                ) { item in
+                    ayahRow(item.value)
                 }
             } footer: {
                 Text(l("bookmarks.collections.ayahs.delete-hint"))

--- a/Features/BookmarksFeature/Sources/AyahSetViewController.swift
+++ b/Features/BookmarksFeature/Sources/AyahSetViewController.swift
@@ -108,7 +108,7 @@ private final class AyahSetMenuController {
             actions.append(
                 UIAction(
                     title: l("button.delete"),
-                    image: nil,
+                    image: UIImage(systemName: "xmark"),
                     attributes: .destructive
                 ) { [weak self] _ in
                     guard let self else {

--- a/Features/BookmarksFeature/Sources/AyahSetViewController.swift
+++ b/Features/BookmarksFeature/Sources/AyahSetViewController.swift
@@ -108,7 +108,7 @@ private final class AyahSetMenuController {
             actions.append(
                 UIAction(
                     title: l("button.delete"),
-                    image: UIImage(systemName: "trash"),
+                    image: nil,
                     attributes: .destructive
                 ) { [weak self] _ in
                     guard let self else {

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
@@ -74,7 +74,13 @@ private struct BookmarkCollectionsContent: View {
                     )
                 }
 
-                ForEach(viewModel.displayedCollections) { collection in
+                NoorListRows(
+                    viewModel.displayedCollections,
+                    canDelete: { $0.kind.canDelete },
+                    onDelete: { collection in
+                        { await viewModel.requestDeleteCollection(collection) }
+                    }
+                ) { collection in
                     collectionRow(
                         title: collection.displayName,
                         image: collection.displayImage,
@@ -82,18 +88,6 @@ private struct BookmarkCollectionsContent: View {
                         count: collection.bookmarks.count,
                         action: { viewModel.showCollection(collection) }
                     )
-                    .noorDeleteSwipeAction(isEnabled: collection.kind.canDelete) {
-                        Task { await viewModel.requestDeleteCollection(collection) }
-                    }
-                    .deleteDisabled(!collection.kind.canDelete)
-                }
-                .onDelete { offsets in
-                    let collections = offsets.map { viewModel.displayedCollections[$0] }
-                    Task {
-                        for collection in collections {
-                            await viewModel.requestDeleteCollection(collection)
-                        }
-                    }
                 }
 
                 NoorListItem(

--- a/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarkCollectionsView.swift
@@ -82,6 +82,9 @@ private struct BookmarkCollectionsContent: View {
                         count: collection.bookmarks.count,
                         action: { viewModel.showCollection(collection) }
                     )
+                    .noorDeleteSwipeAction(isEnabled: collection.kind.canDelete) {
+                        Task { await viewModel.requestDeleteCollection(collection) }
+                    }
                     .deleteDisabled(!collection.kind.canDelete)
                 }
                 .onDelete { offsets in

--- a/Features/BookmarksFeature/Sources/BookmarksView.swift
+++ b/Features/BookmarksFeature/Sources/BookmarksView.swift
@@ -51,10 +51,9 @@ private struct BookmarksViewUI: View {
                 noData
             } else {
                 NoorList {
-                    NoorSection(bookmarks) { bookmark in
+                    NoorSection(bookmarks, onDelete: deleteAction) { bookmark in
                         listItem(bookmark)
                     }
-                    .onDelete(action: deleteAction)
                 }
             }
         }

--- a/Features/NotesFeature/Sources/AyahNotesView.swift
+++ b/Features/NotesFeature/Sources/AyahNotesView.swift
@@ -59,10 +59,9 @@ private struct AyahNotesContent: View {
     var body: some View {
         VStack {
             NoorList {
-                NoorSection(notes) { note in
+                NoorSection(notes, onDelete: deleteAction) { note in
                     NoteItemView(note: note, editAction: editAction)
                 }
-                .onDelete(action: deleteAction)
             }
 
             ProminentRoundedButton(label: l("notes.new"), image: .plus) {

--- a/Features/NotesFeature/Sources/NotesView.swift
+++ b/Features/NotesFeature/Sources/NotesView.swift
@@ -102,13 +102,12 @@ private struct NotesViewUI: View {
                 }
             } else {
                 NoorList {
-                    NoorSection(notes) { note in
+                    NoorSection(notes, onDelete: deleteAction) { note in
                         listItem(note)
                             .listRowInsets(.init(top: 6, leading: 0, bottom: 6, trailing: 0))
                             .listRowBackground(Color.clear)
                             .listRowSeparator(.hidden)
                     }
-                    .onDelete(action: deleteAction)
                 }
             }
         }

--- a/Features/TranslationsFeature/Sources/TranslationsListView.swift
+++ b/Features/TranslationsFeature/Sources/TranslationsListView.swift
@@ -187,11 +187,9 @@ private struct TranslationsListSection<ListItem: View>: View {
     let onMove: ((IndexSet, Int) -> Void)?
 
     var body: some View {
-        NoorSection(title: title, items) { item in
+        NoorSection(title: title, items, onDelete: onDelete, onMove: onMove) { item in
             listItem(item)
         }
-        .onDelete(action: onDelete)
-        .onMove(action: onMove)
     }
 }
 

--- a/UI/NoorUI/Sources/Components/List/NoorEditableCollapsibleSection.swift
+++ b/UI/NoorUI/Sources/Components/List/NoorEditableCollapsibleSection.swift
@@ -80,7 +80,7 @@ public struct NoorEditableCollapsibleSection<Item: Identifiable, ListItem: View>
                         await headerDeleteAction()
                     }
                 } label: {
-                    Text(l("button.delete"))
+                    Label(l("button.delete"), systemImage: "xmark")
                         .foregroundStyle(Color.red)
                 }
                 .buttonStyle(.borderless)
@@ -93,6 +93,9 @@ public struct NoorEditableCollapsibleSection<Item: Identifiable, ListItem: View>
     private var rows: some View {
         ForEach(items) { item in
             listItem(item)
+                .noorDeleteSwipeAction(isEnabled: onDelete != nil) {
+                    delete(item)
+                }
         }
         .onDelete(perform: onDelete.map { onDelete in
             { indexSet in
@@ -102,6 +105,13 @@ public struct NoorEditableCollapsibleSection<Item: Identifiable, ListItem: View>
                 }
             }
         })
+    }
+
+    private func delete(_ item: Item) {
+        guard let onDelete else {
+            return
+        }
+        delete(item, action: onDelete)
     }
 
     private func delete(_ item: Item, action: ItemDeletionAction<Item>) {

--- a/UI/NoorUI/Sources/Components/List/NoorEditableCollapsibleSection.swift
+++ b/UI/NoorUI/Sources/Components/List/NoorEditableCollapsibleSection.swift
@@ -18,16 +18,14 @@ public struct NoorEditableCollapsibleSection<Item: Identifiable, ListItem: View>
         _ items: [Item],
         showsHeaderDeleteAction: Bool = false,
         headerDeleteAction: AsyncAction? = nil,
-        @ViewBuilder listItem: @escaping (Item) -> ListItem,
-        onDelete: ItemDeletionAction<Item>? = nil
+        onDelete: ItemDeletionAction<Item>? = nil,
+        @ViewBuilder listItem: @escaping (Item) -> ListItem
     ) {
         self.title = title
         _isExpanded = isExpanded
-        self.items = items
         self.showsHeaderDeleteAction = showsHeaderDeleteAction
         self.headerDeleteAction = headerDeleteAction
-        self.listItem = listItem
-        self.onDelete = onDelete
+        rows = NoorListRows(items, onDelete: onDelete, row: listItem)
     }
 
     // MARK: Public
@@ -46,13 +44,9 @@ public struct NoorEditableCollapsibleSection<Item: Identifiable, ListItem: View>
 
     let title: String
     @Binding var isExpanded: Bool
-    let items: [Item]
     let showsHeaderDeleteAction: Bool
     let headerDeleteAction: AsyncAction?
-    let listItem: (Item) -> ListItem
-    var onDelete: ItemDeletionAction<Item>?
-
-    @State private var deletingItemIDs: Set<Item.ID> = []
+    let rows: NoorListRows<Item, ListItem>
 
     // MARK: Private
 
@@ -87,53 +81,5 @@ public struct NoorEditableCollapsibleSection<Item: Identifiable, ListItem: View>
             }
         }
         .accessibilityLabel(title)
-    }
-
-    @ViewBuilder
-    private var rows: some View {
-        ForEach(items) { item in
-            listItem(item)
-                .noorDeleteSwipeAction(isEnabled: onDelete != nil) {
-                    delete(item)
-                }
-        }
-        .onDelete(perform: onDelete.map { onDelete in
-            { indexSet in
-                let itemsToDelete = indexSet.map { items[$0] }
-                for itemToDelete in itemsToDelete {
-                    delete(itemToDelete, action: onDelete)
-                }
-            }
-        })
-    }
-
-    private func delete(_ item: Item) {
-        guard let onDelete else {
-            return
-        }
-        delete(item, action: onDelete)
-    }
-
-    private func delete(_ item: Item, action: ItemDeletionAction<Item>) {
-        guard deletingItemIDs.insert(item.id).inserted else {
-            return
-        }
-        guard let operation = action(item) else {
-            deletingItemIDs.remove(item.id)
-            return
-        }
-
-        Task { @MainActor in
-            await operation()
-            deletingItemIDs.remove(item.id)
-        }
-    }
-}
-
-extension NoorEditableCollapsibleSection {
-    public func onDelete(action: ItemDeletionAction<Item>?) -> Self {
-        var mutableSelf = self
-        mutableSelf.onDelete = action
-        return mutableSelf
     }
 }

--- a/UI/NoorUI/Sources/Components/List/NoorEditableCollapsibleSection.swift
+++ b/UI/NoorUI/Sources/Components/List/NoorEditableCollapsibleSection.swift
@@ -5,6 +5,7 @@
 //  Created by Ahmed Nabil on 2026-05-13.
 //
 
+import Localization
 import SwiftUI
 import UIx
 
@@ -79,7 +80,7 @@ public struct NoorEditableCollapsibleSection<Item: Identifiable, ListItem: View>
                         await headerDeleteAction()
                     }
                 } label: {
-                    Image(systemName: "trash")
+                    Text(l("button.delete"))
                         .foregroundStyle(Color.red)
                 }
                 .buttonStyle(.borderless)

--- a/UI/NoorUI/Sources/Components/List/NoorSection.swift
+++ b/UI/NoorUI/Sources/Components/List/NoorSection.swift
@@ -5,6 +5,7 @@
 //  Created by Mohamed Afifi on 2023-07-04.
 //
 
+import Localization
 import SwiftUI
 import UIx
 
@@ -154,6 +155,9 @@ public struct NoorSection<Item: Identifiable, ListItem: View>: View {
     private var rows: some View {
         ForEach(items) { item in
             listItem(item)
+                .noorDeleteSwipeAction(isEnabled: onDelete != nil) {
+                    delete(item)
+                }
         }
         .onDelete(perform: deleteAction)
         .onMove(perform: onMove)
@@ -182,6 +186,24 @@ public struct NoorSection<Item: Identifiable, ListItem: View>: View {
         Task { @MainActor in
             await operation()
             deletingItemIDs.remove(item.id)
+        }
+    }
+}
+
+public extension View {
+    @ViewBuilder
+    func noorDeleteSwipeAction(
+        isEnabled: Bool = true,
+        action: @escaping Action
+    ) -> some View {
+        if isEnabled {
+            swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                Button(role: .destructive, action: action) {
+                    Label(l("button.delete"), systemImage: "xmark")
+                }
+            }
+        } else {
+            self
         }
     }
 }

--- a/UI/NoorUI/Sources/Components/List/NoorSection.swift
+++ b/UI/NoorUI/Sources/Components/List/NoorSection.swift
@@ -109,59 +109,45 @@ public struct SelfIdentifiable<T: Hashable>: Identifiable {
     public var id: T { value }
 }
 
-public struct NoorSection<Item: Identifiable, ListItem: View>: View {
+public struct NoorListRows<Item: Identifiable, Row: View>: View {
     // MARK: Lifecycle
 
     public init(
-        title: String? = nil,
-        isExpanded: Binding<Bool>? = nil,
         _ items: [Item],
-        @ViewBuilder listItem: @escaping (Item) -> ListItem,
+        canDelete: @escaping @MainActor @Sendable (Item) -> Bool = { _ in true },
         onDelete: ItemDeletionAction<Item>? = nil,
-        onMove: ((IndexSet, Int) -> Void)? = nil
+        onMove: ((IndexSet, Int) -> Void)? = nil,
+        @ViewBuilder row: @escaping (Item) -> Row
     ) {
-        self.title = title
-        self.isExpanded = isExpanded
         self.items = items
-        self.listItem = listItem
         self.onDelete = onDelete
         self.onMove = onMove
+        rows = ForEach(items) { item in
+            NoorDeletableRow(
+                item: item,
+                content: row(item),
+                isDeleteEnabled: onDelete != nil && canDelete(item),
+                onDelete: onDelete
+            )
+        }
     }
 
     // MARK: Public
 
     public var body: some View {
-        if !items.isEmpty {
-            NoorBasicSection(title: title, isExpanded: isExpanded) {
-                rows
-            }
-        }
+        rows
+            .onDelete(perform: deleteAction)
+            .onMove(perform: onMove)
     }
-
-    // MARK: Internal
-
-    let title: String?
-    let isExpanded: Binding<Bool>?
-    let items: [Item]
-    let listItem: (Item) -> ListItem
-    var onDelete: ItemDeletionAction<Item>?
-    var onMove: ((IndexSet, Int) -> Void)?
-
-    @State private var deletingItemIDs: Set<Item.ID> = []
 
     // MARK: Private
 
-    @ViewBuilder
-    private var rows: some View {
-        ForEach(items) { item in
-            listItem(item)
-                .noorDeleteSwipeAction(isEnabled: onDelete != nil) {
-                    delete(item)
-                }
-        }
-        .onDelete(perform: deleteAction)
-        .onMove(perform: onMove)
-    }
+    private let items: [Item]
+    private let onDelete: ItemDeletionAction<Item>?
+    private let onMove: ((IndexSet, Int) -> Void)?
+    private let rows: ForEach<[Item], Item.ID, NoorDeletableRow<Item, Row>>
+
+    @State private var deletingItemIDs: Set<Item.ID> = []
 
     private var deleteAction: ((IndexSet) -> Void)? {
         onDelete.map { _ in
@@ -190,6 +176,46 @@ public struct NoorSection<Item: Identifiable, ListItem: View>: View {
     }
 }
 
+public struct NoorSection<Item: Identifiable, ListItem: View>: View {
+    // MARK: Lifecycle
+
+    public init(
+        title: String? = nil,
+        isExpanded: Binding<Bool>? = nil,
+        _ items: [Item],
+        onDelete: ItemDeletionAction<Item>? = nil,
+        onMove: ((IndexSet, Int) -> Void)? = nil,
+        @ViewBuilder listItem: @escaping (Item) -> ListItem
+    ) {
+        self.title = title
+        self.isExpanded = isExpanded
+        isEmpty = items.isEmpty
+        rows = NoorListRows(
+            items,
+            onDelete: onDelete,
+            onMove: onMove,
+            row: listItem
+        )
+    }
+
+    // MARK: Public
+
+    public var body: some View {
+        if !isEmpty {
+            NoorBasicSection(title: title, isExpanded: isExpanded) {
+                rows
+            }
+        }
+    }
+
+    // MARK: Internal
+
+    let title: String?
+    let isExpanded: Binding<Bool>?
+    let isEmpty: Bool
+    let rows: NoorListRows<Item, ListItem>
+}
+
 public extension View {
     @ViewBuilder
     func noorDeleteSwipeAction(
@@ -198,8 +224,9 @@ public extension View {
     ) -> some View {
         if isEnabled {
             modifier(NoorDeleteSwipeActionModifier(action: action))
+                .deleteDisabled(false)
         } else {
-            self
+            deleteDisabled(true)
         }
     }
 }
@@ -220,16 +247,30 @@ private struct NoorDeleteSwipeActionModifier: ViewModifier {
     }
 }
 
-extension NoorSection {
-    public func onDelete(action: ItemDeletionAction<Item>?) -> Self {
-        var mutableSelf = self
-        mutableSelf.onDelete = action
-        return mutableSelf
+private struct NoorDeletableRow<Item, Content: View>: View {
+    let item: Item
+    let content: Content
+    let isDeleteEnabled: Bool
+    let onDelete: ItemDeletionAction<Item>?
+
+    @State private var isDeleting = false
+
+    var body: some View {
+        content
+            .noorDeleteSwipeAction(isEnabled: isDeleteEnabled && !isDeleting) {
+                delete()
+            }
     }
 
-    public func onMove(action: ((IndexSet, Int) -> Void)?) -> Self {
-        var mutableSelf = self
-        mutableSelf.onMove = action
-        return mutableSelf
+    private func delete() {
+        guard !isDeleting, let operation = onDelete?(item) else {
+            return
+        }
+        isDeleting = true
+
+        Task { @MainActor in
+            await operation()
+            isDeleting = false
+        }
     }
 }

--- a/UI/NoorUI/Sources/Components/List/NoorSection.swift
+++ b/UI/NoorUI/Sources/Components/List/NoorSection.swift
@@ -197,14 +197,26 @@ public extension View {
         action: @escaping Action
     ) -> some View {
         if isEnabled {
-            swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            modifier(NoorDeleteSwipeActionModifier(action: action))
+        } else {
+            self
+        }
+    }
+}
+
+private struct NoorDeleteSwipeActionModifier: ViewModifier {
+    let action: Action
+
+    @ScaledMetric(relativeTo: .body) private var minimumContentHeight = 36
+
+    func body(content: Content) -> some View {
+        content
+            .frame(minHeight: minimumContentHeight)
+            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                 Button(role: .destructive, action: action) {
                     Label(l("button.delete"), systemImage: "xmark")
                 }
             }
-        } else {
-            self
-        }
     }
 }
 

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -192,9 +192,13 @@ private struct AyahMenuViewList: View {
                     Divider()
                         .padding(.leading)
 
-                    Row(title: noteDeleteText, action: dataObject.actions.deleteNote) {
-                        Image(systemName: "trash")
-                            .foregroundColor(Color.red)
+                    Row(
+                        title: noteDeleteText,
+                        isDestructive: true,
+                        showsSymbol: false,
+                        action: dataObject.actions.deleteNote
+                    ) {
+                        EmptyView()
                     }
                 }
                 #endif
@@ -310,6 +314,8 @@ private struct Row<Symbol: View, Accessory: View>: View {
         subtitle: MultipartText? = nil,
         subtitlePlacement: SubtitlePlacement = .inline,
         isEnabled: Bool = true,
+        isDestructive: Bool = false,
+        showsSymbol: Bool = true,
         action: @Sendable @escaping () async -> Void,
         @ViewBuilder symbol: () -> Symbol
     ) where Accessory == EmptyView {
@@ -319,6 +325,8 @@ private struct Row<Symbol: View, Accessory: View>: View {
         self.subtitle = subtitle
         self.subtitlePlacement = subtitlePlacement
         self.isEnabled = isEnabled
+        self.isDestructive = isDestructive
+        self.showsSymbol = showsSymbol
         self.action = action
         hasAccessory = false
     }
@@ -338,6 +346,8 @@ private struct Row<Symbol: View, Accessory: View>: View {
         self.subtitle = subtitle
         self.subtitlePlacement = subtitlePlacement
         self.isEnabled = isEnabled
+        isDestructive = false
+        showsSymbol = true
         self.action = action
         hasAccessory = true
     }
@@ -350,6 +360,8 @@ private struct Row<Symbol: View, Accessory: View>: View {
     let subtitle: MultipartText?
     let subtitlePlacement: SubtitlePlacement
     let isEnabled: Bool
+    let isDestructive: Bool
+    let showsSymbol: Bool
     let action: @Sendable () async -> Void
     let hasAccessory: Bool
     @ScaledMetric var verticalPadding = 12
@@ -357,11 +369,13 @@ private struct Row<Symbol: View, Accessory: View>: View {
     var body: some View {
         AsyncButton(action: action) {
             HStack {
-                ZStack {
-                    HighlightPaletteIcon()
-                        .hidden()
-                    symbol
-                        .foregroundColor(primaryColor)
+                if showsSymbol {
+                    ZStack {
+                        HighlightPaletteIcon()
+                            .hidden()
+                        symbol
+                            .foregroundColor(primaryColor)
+                    }
                 }
                 label
                 if hasAccessory {
@@ -381,7 +395,10 @@ private struct Row<Symbol: View, Accessory: View>: View {
     // MARK: Private
 
     private var primaryColor: Color {
-        isEnabled ? .label : .tertiaryLabel
+        if !isEnabled {
+            return .tertiaryLabel
+        }
+        return isDestructive ? .red : .label
     }
 
     private var secondaryColor: Color {

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -195,10 +195,9 @@ private struct AyahMenuViewList: View {
                     Row(
                         title: noteDeleteText,
                         isDestructive: true,
-                        showsSymbol: false,
                         action: dataObject.actions.deleteNote
                     ) {
-                        EmptyView()
+                        Image(systemName: "xmark")
                     }
                 }
                 #endif
@@ -315,7 +314,6 @@ private struct Row<Symbol: View, Accessory: View>: View {
         subtitlePlacement: SubtitlePlacement = .inline,
         isEnabled: Bool = true,
         isDestructive: Bool = false,
-        showsSymbol: Bool = true,
         action: @Sendable @escaping () async -> Void,
         @ViewBuilder symbol: () -> Symbol
     ) where Accessory == EmptyView {
@@ -326,7 +324,6 @@ private struct Row<Symbol: View, Accessory: View>: View {
         self.subtitlePlacement = subtitlePlacement
         self.isEnabled = isEnabled
         self.isDestructive = isDestructive
-        self.showsSymbol = showsSymbol
         self.action = action
         hasAccessory = false
     }
@@ -347,7 +344,6 @@ private struct Row<Symbol: View, Accessory: View>: View {
         self.subtitlePlacement = subtitlePlacement
         self.isEnabled = isEnabled
         isDestructive = false
-        showsSymbol = true
         self.action = action
         hasAccessory = true
     }
@@ -361,7 +357,6 @@ private struct Row<Symbol: View, Accessory: View>: View {
     let subtitlePlacement: SubtitlePlacement
     let isEnabled: Bool
     let isDestructive: Bool
-    let showsSymbol: Bool
     let action: @Sendable () async -> Void
     let hasAccessory: Bool
     @ScaledMetric var verticalPadding = 12
@@ -369,13 +364,11 @@ private struct Row<Symbol: View, Accessory: View>: View {
     var body: some View {
         AsyncButton(action: action) {
             HStack {
-                if showsSymbol {
-                    ZStack {
-                        HighlightPaletteIcon()
-                            .hidden()
-                        symbol
-                            .foregroundColor(primaryColor)
-                    }
+                ZStack {
+                    HighlightPaletteIcon()
+                        .hidden()
+                    symbol
+                        .foregroundColor(primaryColor)
                 }
                 label
                 if hasAccessory {


### PR DESCRIPTION
## Summary

- replace trash glyphs with the localized destructive action and the `xmark` symbol
- use the same X + localized Delete treatment across menus and swipe actions
- keep compact collection rows tall enough for the same stacked action style
- cover both sync and no-sync app configurations
- unify swipe and edit-mode deletion in `NoorListRows`; configure delete and move handlers in initializers

## Why

Trash imagery is not appropriate for Quran-related content. The X icon keeps destructive actions explicit without using a trash symbol.

## Screenshots

### No sync

| Ayah menu — Delete Highlight | Notes |
| --- | --- |
| <img width="300" alt="No-sync ayah menu showing X Delete Highlight action" src="https://github.com/user-attachments/assets/0322cf9f-cff1-4bcc-b580-6be041d06470" /> | <img width="300" alt="No-sync Notes showing X Delete swipe action" src="https://github.com/user-attachments/assets/54d45889-116b-4d80-bb00-09bb003d6f21" /> |
| Bookmarks | Audio Manager |
| <img width="300" alt="No-sync Bookmarks showing X Delete swipe action" src="https://github.com/user-attachments/assets/ff86c6d2-ce29-42d4-99d6-d76fb572aca5" /> | <img width="300" alt="No-sync Audio Manager showing X Delete swipe action" src="https://github.com/user-attachments/assets/fca0eb0a-4f96-46f2-9d08-911f3a6d2c37" /> |
| Translations | |
| <img width="300" alt="No-sync Translations showing X Delete swipe action" src="https://github.com/user-attachments/assets/dde9b637-c81a-4b2b-a3fd-fc105b00a596" /> | |

### Sync

| Ayah notes | Notes |
| --- | --- |
| <img width="300" alt="Sync Ayah Notes showing X Delete swipe action" src="https://github.com/user-attachments/assets/283359b0-59dd-4983-9e82-ba7c98af8326" /> | <img width="300" alt="Sync Notes showing X Delete swipe action" src="https://github.com/user-attachments/assets/416621af-8a34-44a6-85a9-ae5fa2d37b8b" /> |
| Collections | Collection ayah |
| <img width="300" alt="Sync Collections showing X Delete swipe action" src="https://github.com/user-attachments/assets/95c4b389-ed42-48ee-b047-ccefa236192b" /> | <img width="300" alt="Sync collection ayah showing X Delete swipe action" src="https://github.com/user-attachments/assets/126b7520-e052-43bf-8415-0b521a1aa9bb" /> |
| Collection menu | Audio Manager |
| <img width="300" alt="Sync collection menu showing X Delete action" src="https://github.com/user-attachments/assets/b443efd4-2b6f-4770-8813-3f106acafd62" /> | <img width="300" alt="Sync Audio Manager showing X Delete swipe action" src="https://github.com/user-attachments/assets/5dd64a6f-6e7c-4773-aaf3-81bda785532c" /> |
| Translations | |
| <img width="300" alt="Sync Translations showing X Delete swipe action" src="https://github.com/user-attachments/assets/8e855bf9-2930-45c4-9d64-bea6a9d45f7e" /> | |

> `NoorEditableCollapsibleSection` has no current live app call site; its X delete treatment is covered by build validation.

## Validation

- `make format-lint`
- `make build-no-sync`
- `make build-sync`
- `make test-no-sync` — full package test plan passed
- `make test-sync TARGET=NoorUI` — 34 tests passed
- `make run-example-no-sync`
- `make run-example-sync`
