### PR TITLE
fix(build): use available iOS simulators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@ BUILD_TOOLS_DIR=./BuildTools
 
 PACKAGE_SCHEME ?= QuranEngine-Package
 PACKAGE_SDK ?= iphonesimulator
-PACKAGE_DESTINATION ?= name=iPhone 17,OS=26.2
+PACKAGE_DESTINATION ?= name=iPhone 17e,OS=26.5
 EXAMPLE_PROJECT ?= Example/QuranEngineApp.xcodeproj
 EXAMPLE_SCHEME ?= QuranEngineApp
 EXAMPLE_SDK ?= iphonesimulator
 EXAMPLE_DESTINATION ?= generic/platform=iOS
 EXAMPLE_BUNDLE_IDENTIFIER ?= com.quran.QuranEngineApp
-EXAMPLE_NO_SYNC_SIMULATOR ?= iPhone 17,26.2
-EXAMPLE_SYNC_SIMULATOR ?= iPhone 17 Pro,26.1
+EXAMPLE_NO_SYNC_SIMULATOR ?= iPhone 17e,26.5
+EXAMPLE_SYNC_SIMULATOR ?= iPhone 17 Pro Max,26.5
 DERIVED_DATA_DIR ?= .build/DerivedData
 GIT_COMMON_DIR := $(shell git rev-parse --path-format=absolute --git-common-dir)
 QURAN_WORKSPACE_DIR := $(abspath $(GIT_COMMON_DIR)/../..)


### PR DESCRIPTION
## Summary

- update package test/build destinations to the installed iPhone 17e simulator on iOS 26.5
- update no-sync example runs to iPhone 17e on iOS 26.5
- update sync example runs to iPhone 17 Pro Max on iOS 26.5

## Root cause

The Makefile referenced simulator device/runtime combinations that are not installed, so build, test, and run targets could not resolve their destinations.

## Validation

- confirmed both selected simulators are installed
- dry-ran no-sync, sync, and local-sync test and example targets
- previously built, tested, launched, and inspected these destinations locally