### PR TITLE
chore(ci): add macOS workflow guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,20 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Package:
     runs-on: macos-26
+    timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setting up Xcode
       run: sudo xcode-select -s "/Applications/Xcode_26.2.app"
@@ -22,15 +30,16 @@ jobs:
     - name: Run tests
       run: make test-no-sync
 
-    - uses: codecov/codecov-action@v4
+    - uses: codecov/codecov-action@a99c28d3f0da835de33ff2feb2e15691c7b9641f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   PackageSync:
     runs-on: macos-26
+    timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Setting up Xcode
       run: sudo xcode-select -s "/Applications/Xcode_26.2.app"
@@ -43,9 +52,10 @@ jobs:
 
   ExampleApp:
     runs-on: macos-26
+    timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setting up Xcode
         run: sudo xcode-select -s "/Applications/Xcode_26.2.app"
@@ -58,9 +68,10 @@ jobs:
 
   ExampleAppSync:
     runs-on: macos-26
+    timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setting up Xcode
         run: sudo xcode-select -s "/Applications/Xcode_26.2.app"
@@ -73,9 +84,10 @@ jobs:
 
   SwiftFormat:
     runs-on: macos-26
+    timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setting up Xcode
         run: sudo xcode-select -s "/Applications/Xcode_26.2.app"


### PR DESCRIPTION
## Why

Recent iOS CI bursts queued for hours because every `main` push kept a separate macOS run alive. One package job also remained active for roughly six hours because no timeout was configured. This keeps iOS on GitHub-hosted `macos-26`; it does not move any job to QF self-hosted runners.

## Changes

- cancel superseded runs for the same branch or pull request
- add 15–45 minute job timeouts based on normal observed runtimes
- set default workflow permissions to `contents: read`
- upgrade and SHA-pin `actions/checkout` and Codecov to Node-24-compatible releases

## Validation

- `git diff --check`
- `nix run nixpkgs#actionlint -- -color=false .github/workflows/ci.yml`

This is intentionally PR-only for iOS team review.