### PR TITLE
chore: upgrade mobile-sync-spm to 0.1.19

### DIFF
--- a/Core/Utilities/Tests/AsyncPublisherTests.swift
+++ b/Core/Utilities/Tests/AsyncPublisherTests.swift
@@ -22,12 +22,10 @@ class AsyncPublisherTests: XCTestCase {
 
     let numbers = [1, 2, 3]
     var subject: PassthroughSubject<Int, Never>!
-    var channel: AsyncChannel<Void>!
     var values: Values!
 
     override func setUp() {
         subject = PassthroughSubject()
-        channel = AsyncChannel()
         values = Values()
     }
 
@@ -35,7 +33,7 @@ class AsyncPublisherTests: XCTestCase {
         let prefix = 2
         let asyncPublisher = subject.values(bufferingPolicy: .unbounded)
 
-        Task { [iterator = asyncPublisher.makeAsyncIterator()] in
+        let task = Task { [iterator = asyncPublisher.makeAsyncIterator()] in
             var iterator = iterator
             while let number = await iterator.next() {
                 await values.append(number)
@@ -43,15 +41,13 @@ class AsyncPublisherTests: XCTestCase {
                     break
                 }
             }
-            await channel.send(())
         }
 
         for number in numbers {
             subject.send(number)
         }
 
-        // Wait until the break
-        await channel.next()
+        await task.value
 
         await AsyncAssertEqual(await values.results, Array(numbers.prefix(2)))
     }
@@ -67,7 +63,6 @@ class AsyncPublisherTests: XCTestCase {
                 await received.send(number)
             }
             await values.append(1945)
-            await channel.send(())
         }
 
         for number in numbers {
@@ -76,7 +71,7 @@ class AsyncPublisherTests: XCTestCase {
         }
 
         task.cancel()
-        await channel.next()
+        await task.value
 
         await AsyncAssertEqual(await values.results, numbers + [1945])
     }
@@ -97,25 +92,23 @@ class AsyncPublisherTests: XCTestCase {
         let numbersPublisher = numbers.publisher
         let asyncPublisher = numbersPublisher.values(bufferingPolicy: .bufferingNewest(2))
 
-        var results = [Int]()
-        for await number in asyncPublisher {
-            results.append(number)
-        }
+        var iterator = asyncPublisher.makeAsyncIterator()
+        let first = await iterator.next()
+        let second = await iterator.next()
 
         // Only the last 2 values should be preserved
-        XCTAssertEqual(results, [2, 3])
+        XCTAssertEqual([first, second].compactMap { $0 }, [2, 3])
     }
 
     func test_bufferingOldest() async {
         let numbersPublisher = numbers.publisher
         let asyncPublisher = numbersPublisher.values(bufferingPolicy: .bufferingOldest(2))
 
-        var results = [Int]()
-        for await number in asyncPublisher {
-            results.append(number)
-        }
+        var iterator = asyncPublisher.makeAsyncIterator()
+        let first = await iterator.next()
+        let second = await iterator.next()
 
         // Only the first 2 values should be preserved
-        XCTAssertEqual(results, [1, 2])
+        XCTAssertEqual([first, second].compactMap { $0 }, [1, 2])
     }
 }

--- a/Core/Utilities/Tests/AsyncThrowingPublisherTests.swift
+++ b/Core/Utilities/Tests/AsyncThrowingPublisherTests.swift
@@ -32,19 +32,17 @@ class AsyncThrowingPublisherTests: XCTestCase {
     let numbers = [1, 2, 3]
     let numbersPublisher = [1, 2, 3].publisher.setFailureType(to: PublishingError.self)
     var subject: PassthroughSubject<Int, PublishingError>!
-    var channel: AsyncChannel<Void>!
     var values: Values!
 
     override func setUp() {
         subject = PassthroughSubject()
-        channel = AsyncChannel()
         values = Values()
     }
 
     func test_passThroughSubject_failure() async {
         let asyncPublisher = subject.values()
 
-        Task { [iterator = asyncPublisher.makeAsyncIterator()] in
+        let task = Task { [iterator = asyncPublisher.makeAsyncIterator()] in
             var iterator = iterator
             do {
                 while let number = try await iterator.next() {
@@ -53,14 +51,12 @@ class AsyncThrowingPublisherTests: XCTestCase {
             } catch {
                 await values.setError(error)
             }
-            await channel.send(())
         }
 
         // Send failure
         subject.send(completion: .failure(.invalid))
 
-        // Wait until the task completes.
-        await channel.next()
+        await task.value
 
         await AsyncAssertEqual(await values.error as? PublishingError, PublishingError.invalid)
     }
@@ -69,7 +65,7 @@ class AsyncThrowingPublisherTests: XCTestCase {
         let prefix = 2
         let asyncPublisher = subject.values(bufferingPolicy: .unbounded)
 
-        Task { [iterator = asyncPublisher.makeAsyncIterator()] in
+        let task = Task { [iterator = asyncPublisher.makeAsyncIterator()] in
             var iterator = iterator
             do {
                 while let number = try await iterator.next() {
@@ -81,15 +77,13 @@ class AsyncThrowingPublisherTests: XCTestCase {
             } catch {
                 XCTFail("Unexpected error: \(error)")
             }
-            await channel.send(())
         }
 
         for number in numbers {
             subject.send(number)
         }
 
-        // Wait until the break
-        await channel.next()
+        await task.value
 
         await AsyncAssertEqual(await values.results, Array(numbers.prefix(2)))
     }
@@ -109,7 +103,6 @@ class AsyncThrowingPublisherTests: XCTestCase {
                 XCTFail("Unexpected error: \(error)")
             }
             await values.append(1945)
-            await channel.send(())
         }
 
         for number in numbers {
@@ -118,7 +111,7 @@ class AsyncThrowingPublisherTests: XCTestCase {
         }
 
         task.cancel()
-        await channel.next()
+        await task.value
 
         await AsyncAssertEqual(await values.results, numbers + [1945])
     }
@@ -137,24 +130,22 @@ class AsyncThrowingPublisherTests: XCTestCase {
     func test_bufferingNewest() async throws {
         let asyncPublisher = numbersPublisher.values(bufferingPolicy: .bufferingNewest(2))
 
-        var results = [Int]()
-        for try await number in asyncPublisher {
-            results.append(number)
-        }
+        var iterator = asyncPublisher.makeAsyncIterator()
+        let first = try await iterator.next()
+        let second = try await iterator.next()
 
         // Only the last 2 values should be preserved
-        XCTAssertEqual(results, [2, 3])
+        XCTAssertEqual([first, second].compactMap { $0 }, [2, 3])
     }
 
     func test_bufferingOldest() async throws {
         let asyncPublisher = numbersPublisher.values(bufferingPolicy: .bufferingOldest(2))
 
-        var results = [Int]()
-        for try await number in asyncPublisher {
-            results.append(number)
-        }
+        var iterator = asyncPublisher.makeAsyncIterator()
+        let first = try await iterator.next()
+        let second = try await iterator.next()
 
         // Only the first 2 values should be preserved
-        XCTAssertEqual(results, [1, 2])
+        XCTAssertEqual([first, second].compactMap { $0 }, [1, 2])
     }
 }

--- a/Domain/AnnotationsService/Tests/AyahBookmarkCollectionServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/AyahBookmarkCollectionServiceTests.swift
@@ -22,36 +22,38 @@ final class AyahBookmarkCollectionServiceTests: XCTestCase {
     }
 
     func test_createCollection_persistsCollection() async throws {
-        try await service.createCollection(named: "Favorites")
+        try await service.createCollection(named: "Personal")
 
         let collections = try await storedCollections { collections in
-            collections.contains { $0.collection.name == "Favorites" }
+            collections.contains { $0.collection.name == "Personal" }
         }
-        XCTAssertEqual(collections.map(\.collection.name), ["Default", "Favorites"])
+        XCTAssertEqual(collections.count, 2)
+        XCTAssertTrue(collections.contains { $0.collection.isDefault })
+        XCTAssertTrue(collections.contains { $0.collection.name == "Personal" })
     }
 
     func test_removeCollection_deletesPersistedCollection() async throws {
-        try await service.createCollection(named: "Favorites")
-        let collection = try await storedCollection(named: "Favorites")
+        try await service.createCollection(named: "Personal")
+        let collection = try await storedCollection(named: "Personal")
 
         try await service.removeCollection(id: collection.collection.id)
 
         let collections = try await storedCollections {
             $0.count == 1 && $0.first?.collection.isDefault == true
         }
-        XCTAssertEqual(collections.map(\.collection.name), ["Default"])
+        XCTAssertTrue(collections[0].collection.isDefault)
     }
 
     func test_addAndRemoveAyahBookmark_persistsCollectionMembership() async throws {
-        try await service.createCollection(named: "Favorites")
-        let collection = try await storedCollection(named: "Favorites")
+        try await service.createCollection(named: "Personal")
+        let collection = try await storedCollection(named: "Personal")
 
         try await service.addAyahBookmarkToCollection(
             collectionId: collection.collection.id,
             ayah: ayah(1)
         )
 
-        let stored = try await storedCollection(named: "Favorites") { $0.bookmarks.count == 1 }
+        let stored = try await storedCollection(named: "Personal") { $0.bookmarks.count == 1 }
         XCTAssertEqual(stored.bookmarks.first?.sura, 1)
         XCTAssertEqual(stored.bookmarks.first?.ayah, 1)
 
@@ -61,38 +63,38 @@ final class AyahBookmarkCollectionServiceTests: XCTestCase {
         )
         try await service.removeBookmarkFromCollection(bookmark)
 
-        let emptied = try await storedCollection(named: "Favorites") { $0.bookmarks.isEmpty }
+        let emptied = try await storedCollection(named: "Personal") { $0.bookmarks.isEmpty }
         XCTAssertTrue(emptied.bookmarks.isEmpty)
     }
 
     func test_addAyahs_persistsOnlyMissingUniqueAyahs() async throws {
-        try await service.createCollection(named: "Favorites")
-        let stored = try await storedCollection(named: "Favorites")
+        try await service.createCollection(named: "Personal")
+        let stored = try await storedCollection(named: "Personal")
 
         try await service.addAyahs(
             [ayah(1), ayah(1), ayah(2)],
             toCollectionWithID: stored.collection.id
         )
 
-        let updated = try await storedCollection(named: "Favorites") { $0.bookmarks.count == 2 }
+        let updated = try await storedCollection(named: "Personal") { $0.bookmarks.count == 2 }
         XCTAssertEqual(Set(updated.bookmarks.map { "\($0.sura):\($0.ayah)" }), ["1:1", "1:2"])
     }
 
     func test_removeAyahs_removesOnlyRequestedCollectionMemberships() async throws {
-        try await service.createCollection(named: "Favorites")
+        try await service.createCollection(named: "Personal")
         try await service.createCollection(named: "Study")
-        let favorites = try await storedCollection(named: "Favorites")
+        let personal = try await storedCollection(named: "Personal")
         let study = try await storedCollection(named: "Study")
         for number in [1, 2] {
-            try await service.addAyahBookmarkToCollection(collectionId: favorites.collection.id, ayah: ayah(number))
+            try await service.addAyahBookmarkToCollection(collectionId: personal.collection.id, ayah: ayah(number))
             try await service.addAyahBookmarkToCollection(collectionId: study.collection.id, ayah: ayah(number))
         }
 
-        try await service.removeAyahs([ayah(1)], fromCollectionWithID: favorites.collection.id)
+        try await service.removeAyahs([ayah(1)], fromCollectionWithID: personal.collection.id)
 
-        let updatedFavorites = try await storedCollection(named: "Favorites") { $0.bookmarks.count == 1 }
+        let updatedPersonal = try await storedCollection(named: "Personal") { $0.bookmarks.count == 1 }
         let updatedStudy = try await storedCollection(named: "Study") { $0.bookmarks.count == 2 }
-        XCTAssertEqual(updatedFavorites.bookmarks.map(\.ayah), [2])
+        XCTAssertEqual(updatedPersonal.bookmarks.map(\.ayah), [2])
         XCTAssertEqual(Set(updatedStudy.bookmarks.map(\.ayah)), [1, 2])
     }
 
@@ -103,7 +105,8 @@ final class AyahBookmarkCollectionServiceTests: XCTestCase {
 
         let collections = try await iterator.next() ?? []
 
-        XCTAssertEqual(collections.map(\.collection.name), ["Default"])
+        XCTAssertEqual(collections.count, 1)
+        XCTAssertTrue(collections[0].collection.isDefault)
     }
 
     private func storedCollection(

--- a/Features/BookmarksFeature/Tests/AyahSetViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/AyahSetViewModelTests.swift
@@ -27,7 +27,7 @@ final class AyahSetViewModelTests: XCTestCase {
 
     func test_start_observesCollectionsFromMobileSyncDatabase() async throws {
         let service = makeService()
-        try await service.createCollection(named: "Favorites")
+        try await service.createCollection(named: "Personal")
         let stored = try await storedCollections {
             $0.contains { !$0.collection.isDefault }
         }
@@ -38,7 +38,7 @@ final class AyahSetViewModelTests: XCTestCase {
         let sut = makeSUT(collection: collection, service: service)
         let observed = expectation(description: "Observes persisted collection")
         let observation = sut.$content
-            .filter { $0.title == "Favorites" }
+            .filter { $0.title == "Personal" }
             .prefix(1)
             .sink { _ in observed.fulfill() }
 
@@ -52,7 +52,7 @@ final class AyahSetViewModelTests: XCTestCase {
 
     func test_start_loadsArabicTextForCollectionBookmarks() async throws {
         let service = makeService()
-        try await service.createCollection(named: "Favorites")
+        try await service.createCollection(named: "Personal")
         let storedCollection = try await firstCollection()
         let ayah = try XCTUnwrap(AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1))
         try await service.addAyahBookmarkToCollection(
@@ -112,7 +112,7 @@ final class AyahSetViewModelTests: XCTestCase {
 
     func test_renamePendingCollection_updatesRealMobileSyncDatabase() async throws {
         let service = makeService()
-        try await service.createCollection(named: "Favorites")
+        try await service.createCollection(named: "Personal")
         let collection = try await firstCollection()
         let sut = makeSUT(collection: collection, service: service)
         sut.pendingName = " Duas "
@@ -126,7 +126,7 @@ final class AyahSetViewModelTests: XCTestCase {
 
     func test_requestDeleteCollection_deletesEmptyCollectionAndNotifiesListener() async throws {
         let service = makeService()
-        try await service.createCollection(named: "Favorites")
+        try await service.createCollection(named: "Personal")
         let collection = try await firstCollection()
         var didDeleteCollection = false
         let sut = makeSUT(
@@ -140,7 +140,6 @@ final class AyahSetViewModelTests: XCTestCase {
         let stored = try await storedCollections {
             $0.count == 1 && $0[0].collection.isDefault
         }
-        XCTAssertEqual(stored.map(\.collection.name), ["Default"])
         XCTAssertTrue(stored[0].collection.isDefault)
         XCTAssertTrue(didDeleteCollection)
         XCTAssertFalse(sut.isPresentingDeleteConfirmation)
@@ -149,18 +148,18 @@ final class AyahSetViewModelTests: XCTestCase {
 
     func test_requestDeleteCollection_requiresConfirmationForNonEmptyCollection() async throws {
         let service = makeService()
-        try await service.createCollection(named: "Favorites")
+        try await service.createCollection(named: "Personal")
         let storedCollection = try await firstCollection()
         try await service.addAyahBookmarkToCollection(
             collectionId: storedCollection.collection.id,
             ayah: AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
         )
         let stored = try await storedCollections {
-            $0.first { $0.collection.name == "Favorites" }?.bookmarks.count == 1
+            $0.first { $0.collection.name == "Personal" }?.bookmarks.count == 1
         }
         let collection = try XCTUnwrap(
             AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405)
-                .first { $0.collection.name == "Favorites" }
+                .first { $0.collection.name == "Personal" }
         )
         var didDeleteCollection = false
         let sut = makeSUT(

--- a/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
+++ b/Features/BookmarksFeature/Tests/BookmarkCollectionsViewModelTests.swift
@@ -49,13 +49,13 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
 
     func test_deletableCollections_includesOldPageBookmarksAndUserCollections() {
         let collections = BookmarkCollectionsViewModel.deletableCollections(from: [
-            collection(name: "Favorites"),
+            collection(name: "Personal"),
             collection(name: oldPageBookmarksCollectionName),
         ])
 
         XCTAssertEqual(collections.map(\.collection.name), [
             oldPageBookmarksCollectionName,
-            "Favorites",
+            "Personal",
         ])
     }
 
@@ -64,7 +64,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
             collection(name: "Z Collection"),
             collection(name: oldPageBookmarksCollectionName),
             collection(name: "A Collection"),
-            collection(name: "Default", id: "__default__"),
+            collection(name: "Default", id: "__default__", isDefault: true, isSystem: true),
         ])
 
         XCTAssertEqual(collections.map(\.collection.name), [
@@ -92,14 +92,22 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
             collection(name: oldPageBookmarksCollectionName.uppercased()).kind,
             .oldPageBookmarks
         )
-        XCTAssertEqual(collection(name: "Default", id: "__default__").kind, .defaultBookmarks)
-        XCTAssertEqual(collection(name: "Favorites").kind, .user)
+        XCTAssertEqual(
+            collection(name: "Default", id: "__default__", isDefault: true, isSystem: true).kind,
+            .defaultBookmarks
+        )
+        XCTAssertEqual(collection(name: "Personal").kind, .user)
     }
 
     func test_collectionCapabilities_protectDefaultCollection() {
-        let defaultBookmarks = collection(name: "Default", id: "__default__")
+        let defaultBookmarks = collection(
+            name: "Default",
+            id: "__default__",
+            isDefault: true,
+            isSystem: true
+        )
         let oldPageBookmarks = collection(name: oldPageBookmarksCollectionName)
-        let user = collection(name: "Favorites")
+        let user = collection(name: "Personal")
 
         XCTAssertFalse(defaultBookmarks.kind.canRename)
         XCTAssertFalse(defaultBookmarks.kind.canDelete)
@@ -110,7 +118,12 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
     }
 
     func test_defaultCollectionPresentation_usesLocalizedFavoritesNameAndFilledStarIcon() {
-        let collection = collection(name: "Default", id: "__default__")
+        let collection = collection(
+            name: "Default",
+            id: "__default__",
+            isDefault: true,
+            isSystem: true
+        )
 
         XCTAssertEqual(collection.displayName, l("bookmarks.collections.favorites"))
         XCTAssertEqual(collection.displayImage, .starFilled)
@@ -152,7 +165,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
     }
 
     func test_collectionDetailsMenu_showsAllActionsForUserCollection() {
-        let collection = collection(name: "Favorites")
+        let collection = collection(name: "Personal")
         let viewModel = makeCollectionDetailsViewModel(collection: collection)
         let viewController = AyahSetViewController(viewModel: viewModel)
 
@@ -168,7 +181,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
     }
 
     func test_collectionDetailsController_showsDoneButtonInEditMode() {
-        let collection = collection(name: "Favorites")
+        let collection = collection(name: "Personal")
         let viewModel = makeCollectionDetailsViewModel(collection: collection)
         let viewController = AyahSetViewController(viewModel: viewModel)
 
@@ -303,20 +316,22 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
 
     func test_createPendingCollection_persistsThroughRealMobileSyncDatabase() async throws {
         let sut = makeSUT()
-        sut.newCollectionName = " Favorites "
+        sut.newCollectionName = " Personal "
 
         await sut.createPendingCollection()
 
         let collections = try await storedCollections {
-            $0.contains { $0.collection.name == "Favorites" }
+            $0.contains { $0.collection.name == "Personal" }
         }
-        XCTAssertEqual(collections.map(\.collection.name), ["Default", "Favorites"])
+        XCTAssertEqual(collections.count, 2)
+        XCTAssertTrue(collections.contains { $0.collection.isDefault })
+        XCTAssertTrue(collections.contains { $0.collection.name == "Personal" })
         XCTAssertNil(sut.error)
     }
 
     func test_requestDeleteCollection_deletesEmptyCollectionWithoutConfirmation() async throws {
         let service = makeService()
-        try await service.createCollection(named: "Favorites")
+        try await service.createCollection(named: "Personal")
         let stored = try await storedCollections()
         let collection = try XCTUnwrap(
             AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405)
@@ -329,7 +344,6 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         let collections = try await storedCollections {
             $0.count == 1 && $0[0].collection.isDefault
         }
-        XCTAssertEqual(collections.map(\.collection.name), ["Default"])
         XCTAssertTrue(collections[0].collection.isDefault)
         XCTAssertNil(sut.collectionPendingDeletion)
         XCTAssertNil(sut.error)
@@ -337,23 +351,23 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
 
     func test_requestDeleteCollection_requiresConfirmationBeforeDeletingNonEmptyCollection() async throws {
         let service = makeService()
-        try await service.createCollection(named: "Favorites")
+        try await service.createCollection(named: "Personal")
         var stored = try await storedCollections {
-            $0.contains { $0.collection.name == "Favorites" }
+            $0.contains { $0.collection.name == "Personal" }
         }
         let storedCollection = try XCTUnwrap(
-            stored.first { $0.collection.name == "Favorites" }
+            stored.first { $0.collection.name == "Personal" }
         )
         try await service.addAyahBookmarkToCollection(
             collectionId: storedCollection.collection.id,
             ayah: AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: 1)!
         )
         stored = try await storedCollections {
-            $0.first { $0.collection.name == "Favorites" }?.bookmarks.count == 1
+            $0.first { $0.collection.name == "Personal" }?.bookmarks.count == 1
         }
         let collection = try XCTUnwrap(
             AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405)
-                .first { $0.collection.name == "Favorites" }
+                .first { $0.collection.name == "Personal" }
         )
         let sut = makeSUT(collectionService: service)
 
@@ -451,7 +465,7 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
 
     func test_showCollection_pushesCollectionViewController() async throws {
         let service = makeService()
-        try await service.createCollection(named: "Favorites")
+        try await service.createCollection(named: "Personal")
         let stored = try await storedCollections()
         let collection = try XCTUnwrap(
             AyahBookmarkCollectionService.collections(from: stored, quran: .hafsMadani1405)
@@ -570,12 +584,19 @@ final class BookmarkCollectionsViewModelTests: XCTestCase {
         throw TestError.collectionNotFound
     }
 
-    private func collection(name: String, id: String? = nil) -> AyahBookmarkCollection {
+    private func collection(
+        name: String,
+        id: String? = nil,
+        isDefault: Bool = false,
+        isSystem: Bool = false
+    ) -> AyahBookmarkCollection {
         AyahBookmarkCollection(
             collection: Collection_(
                 name: name,
                 lastUpdated: .distantPast,
-                id: id ?? name
+                id: id ?? name,
+                isDefault: isDefault,
+                isSystem: isSystem
             ),
             bookmarks: []
         )

--- a/Features/QuranViewFeature/Tests/QuranSyncedCollectionsObserverTests.swift
+++ b/Features/QuranViewFeature/Tests/QuranSyncedCollectionsObserverTests.swift
@@ -29,7 +29,9 @@ final class QuranSyncedCollectionsObserverTests: XCTestCase {
             await Task.yield()
         }
 
-        XCTAssertEqual(observer.collections.map(\.collection.name), ["Default", "Duas"])
+        XCTAssertEqual(observer.collections.count, 2)
+        XCTAssertTrue(observer.collections.contains { $0.collection.isDefault })
+        XCTAssertTrue(observer.collections.contains { $0.collection.name == "Duas" })
         withExtendedLifetime(observer) {}
     }
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quran/mobile-sync-spm.git",
       "state" : {
-        "revision" : "e76b8ebc4cc4170b1567bee268dbe2abf088bb8d",
-        "version" : "0.1.18"
+        "revision" : "92a6f4e0a34dddc4774f1c9ae436fa9e893ec078",
+        "version" : "0.1.19"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let mobileSyncPackageDependency: Package.Dependency = {
     if let localMobileSyncPackagePath, !localMobileSyncPackagePath.isEmpty {
         return .package(path: localMobileSyncPackagePath)
     }
-    return .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.18")
+    return .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.19")
 }()
 
 let mobileSyncPackageDependencies: [Package.Dependency] =


### PR DESCRIPTION
## Summary

- upgrade `mobile-sync-spm` from 0.1.18 to 0.1.19
- adopt MobileSync’s explicit default/system collection metadata and reserved `Favorites` behavior in integration fixtures
- make async publisher tests deterministically join child tasks under the full test plan

## Why

MobileSync 0.1.19 packages the 0.1.17 binary, whose collection model adds `isDefault`/`isSystem`, reserves the built-in Favorites name, and exposes the default collection under its new storage name. Existing sync-only tests no longer compiled or modeled valid user collections. Full-suite verification also exposed escaped async test tasks that could stall XCTest teardown.

## Impact

Production dependency moves to the latest MobileSync package. Runtime collection behavior remains driven by explicit MobileSync metadata; test coverage no longer depends on internal default-collection names.

## Validation

- `make test-no-sync` — 386 passed
- `make test-sync` — 512 passed
- `make format-lint`