### PR TITLE
fix: recover invalid Core Data history

### DIFF
--- a/Data/CoreDataPersistence/Sources/CoreDataPersistentHistoryProcessor.swift
+++ b/Data/CoreDataPersistence/Sources/CoreDataPersistentHistoryProcessor.swift
@@ -46,44 +46,22 @@ class CoreDataPersistentHistoryProcessor {
     private let name: String
     private let trasactionsMerger: CoreDataPersistentHistoryTransactionsMerger
 
-    /// The file URL for persisting the persistent history token.
-    private lazy var tokenFile: URL = {
+    private lazy var tokenStore = CoreDataPersistentHistoryTokenStore(fileURL: {
         let url = NSPersistentContainer.defaultDirectoryURL().appendingPathComponent(name, isDirectory: true)
-        if !FileManager.default.fileExists(atPath: url.path) {
-            do {
-                try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
-            } catch {
-                logger.error("###\(#function): Failed to create persistent container URL. Error = \(error)")
-            }
-        }
         return url.appendingPathComponent("token.data", isDirectory: false)
-    }()
+    }())
 
     /// Track the last history token processed for a store, and write its value to file.
     ///
     /// The historyQueue reads the token when executing operations, and updates it after processing is complete.
     private lazy var lastHistoryToken: NSPersistentHistoryToken? = initialLastHistoryToken() {
         didSet {
-            guard let token = lastHistoryToken,
-                  let data = try? NSKeyedArchiver.archivedData(withRootObject: token, requiringSecureCoding: true) else { return }
-
-            do {
-                try data.write(to: tokenFile)
-            } catch {
-                logger.error("###\(#function): Failed to write token data. Error = \(error)")
-            }
+            guard let token = lastHistoryToken else { return }
+            tokenStore.save(token)
         }
     }
 
     private func initialLastHistoryToken() -> NSPersistentHistoryToken? {
-        // Load the last token from the token file.
-        if let tokenData = try? Data(contentsOf: tokenFile) {
-            do {
-                return try NSKeyedUnarchiver.unarchivedObject(ofClass: NSPersistentHistoryToken.self, from: tokenData)
-            } catch {
-                logger.error("###\(#function): Failed to unarchive NSPersistentHistoryToken. Error = \(error)")
-            }
-        }
-        return nil
+        tokenStore.load()
     }
 }

--- a/Data/CoreDataPersistence/Sources/CoreDataPersistentHistoryTokenStore.swift
+++ b/Data/CoreDataPersistence/Sources/CoreDataPersistentHistoryTokenStore.swift
@@ -1,0 +1,52 @@
+//
+//  CoreDataPersistentHistoryTokenStore.swift
+//  Quran
+//
+
+import CoreData
+import Foundation
+import VLogging
+
+struct CoreDataPersistentHistoryTokenStore {
+    // MARK: Internal
+
+    let fileURL: URL
+
+    func load() -> NSPersistentHistoryToken? {
+        guard let tokenData = try? Data(contentsOf: fileURL) else { return nil }
+
+        do {
+            return try NSKeyedUnarchiver.unarchivedObject(
+                ofClass: NSPersistentHistoryToken.self,
+                from: tokenData
+            )
+        } catch {
+            logger.error("###\(#function): Failed to unarchive NSPersistentHistoryToken. Error = \(error)")
+            removeUnreadableToken()
+            return nil
+        }
+    }
+
+    func save(_ token: NSPersistentHistoryToken) {
+        do {
+            let data = try NSKeyedArchiver.archivedData(withRootObject: token, requiringSecureCoding: true)
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            logger.error("###\(#function): Failed to write token data. Error = \(error)")
+        }
+    }
+
+    // MARK: Private
+
+    private func removeUnreadableToken() {
+        do {
+            try FileManager.default.removeItem(at: fileURL)
+        } catch {
+            logger.error("###\(#function): Failed to remove unreadable token data. Error = \(error)")
+        }
+    }
+}

--- a/Data/CoreDataPersistence/Sources/CoreDataTypes.swift
+++ b/Data/CoreDataPersistence/Sources/CoreDataTypes.swift
@@ -21,9 +21,21 @@ public extension NSSortDescriptor {
 
 public extension NSManagedObject {
     func predicate<Key: CoreDataKey>(equals keys: Key...) -> NSPredicate {
-        let keysAndValues = keys.map {
-            ($0, self.value(forKey: $0.rawValue)!)
+        predicateIfValuesExist(equals: keys) ?? NSPredicate(value: false)
+    }
+}
+
+extension NSManagedObject {
+    func predicateIfValuesExist<Key: CoreDataKey>(equals keys: Key...) -> NSPredicate? {
+        predicateIfValuesExist(equals: keys)
+    }
+
+    private func predicateIfValuesExist<Key: CoreDataKey>(equals keys: [Key]) -> NSPredicate? {
+        let keysAndValues = keys.compactMap { key -> (Key, Any)? in
+            guard let value = value(forKey: key.rawValue) else { return nil }
+            return (key, value)
         }
+        guard keysAndValues.count == keys.count else { return nil }
         return .init(equals: keysAndValues)
     }
 }

--- a/Data/CoreDataPersistence/Sources/merging/SimpleCoreDataEntityUniquifier.swift
+++ b/Data/CoreDataPersistence/Sources/merging/SimpleCoreDataEntityUniquifier.swift
@@ -15,12 +15,12 @@ public struct SimpleCoreDataEntityUniquifier<T: NSManagedObject>: CoreDataEntity
 
     public init<Key: CoreDataKey>(sortBy: Key, ascending: Bool, key: Key) {
         sortDescriptors = [NSSortDescriptor(key: sortBy, ascending: ascending)]
-        predicate = { $0.predicate(equals: key) }
+        predicate = { $0.predicateIfValuesExist(equals: key) }
     }
 
     public init(sortDescriptors: [NSSortDescriptor], predicate: @escaping (T) -> NSPredicate) {
         self.sortDescriptors = sortDescriptors
-        self.predicate = predicate
+        self.predicate = { predicate($0) }
     }
 
     // MARK: Public
@@ -45,13 +45,23 @@ public struct SimpleCoreDataEntityUniquifier<T: NSManagedObject>: CoreDataEntity
     // MARK: Private
 
     private let sortDescriptors: [NSSortDescriptor]
-    private let predicate: (T) -> NSPredicate
+    private let predicate: (T) -> NSPredicate?
 
     private func findDuplicates(of objectID: NSManagedObjectID, using context: NSManagedObjectContext) throws -> [NSManagedObject]? {
-        guard let managedObject = context.object(with: objectID) as? T else {
+        let existingObject: NSManagedObject
+        do {
+            existingObject = try context.existingObject(with: objectID)
+        } catch {
+            logger.notice("[CoreData] Skipping missing \(T.self) with object ID \(objectID).")
             return nil
         }
-        let fetchRequest = fetchRequestDuplicating(managedObject)
+        guard let managedObject = existingObject as? T, !managedObject.isDeleted else {
+            return nil
+        }
+        guard let fetchRequest = fetchRequestDuplicating(managedObject) else {
+            logger.error("[CoreData] Skipping \(T.self) with missing uniqueness values.")
+            return nil
+        }
         let duplicatedEntities = try context.fetch(fetchRequest)
         guard duplicatedEntities.count > 1 else {
             return nil
@@ -60,10 +70,11 @@ public struct SimpleCoreDataEntityUniquifier<T: NSManagedObject>: CoreDataEntity
         return duplicatesToDelete
     }
 
-    private func fetchRequestDuplicating(_ managedObject: T) -> NSFetchRequest<T> {
+    private func fetchRequestDuplicating(_ managedObject: T) -> NSFetchRequest<T>? {
+        guard let predicate = predicate(managedObject) else { return nil }
         let fetchRequest = NSFetchRequest<T>(entityName: T.entity().name!)
         fetchRequest.sortDescriptors = sortDescriptors
-        fetchRequest.predicate = predicate(managedObject)
+        fetchRequest.predicate = predicate
         return fetchRequest
     }
 

--- a/Data/CoreDataPersistence/Tests/CoreDataPersistentHistoryTokenStoreTests.swift
+++ b/Data/CoreDataPersistence/Tests/CoreDataPersistentHistoryTokenStoreTests.swift
@@ -1,0 +1,23 @@
+//
+//  CoreDataPersistentHistoryTokenStoreTests.swift
+//
+
+import Foundation
+import XCTest
+@testable import CoreDataPersistence
+
+final class CoreDataPersistentHistoryTokenStoreTests: XCTestCase {
+    func test_load_removesUnreadableToken() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CoreDataPersistentHistoryTokenStoreTests-\(UUID().uuidString)")
+        let fileURL = directoryURL.appendingPathComponent("token.data")
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        try Data("unreadable token".utf8).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let sut = CoreDataPersistentHistoryTokenStore(fileURL: fileURL)
+
+        XCTAssertNil(sut.load())
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
+    }
+}

--- a/Data/CoreDataPersistence/Tests/SimpleCoreDataEntityUniquifierTests.swift
+++ b/Data/CoreDataPersistence/Tests/SimpleCoreDataEntityUniquifierTests.swift
@@ -72,4 +72,31 @@ class SimpleCoreDataEntityUniquifierTests: XCTestCase {
 
         XCTAssertEqual([45, 500], try stack.newBackgroundContext().allPageBookmarks().map(\.page))
     }
+
+    func test_merge_skipsInsertedEntityWithMissingUniquenessValue() throws {
+        let entity = MO_PageBookmark(context: context)
+        entity.modifiedOn = Date()
+        try context.save()
+        XCTAssertNil(entity.value(forKey: Schema.PageBookmark.page.rawValue))
+        let transactions = [
+            PersistentHistoryTransactionFake(historyChanges: [
+                PersistentHistoryChangeFake(object: entity, changeType: .insert),
+            ]),
+        ]
+
+        XCTAssertNoThrow(try sut.merge(transactions: transactions, using: context))
+    }
+
+    func test_merge_skipsInsertedEntityThatNoLongerExists() throws {
+        let objectID = entity2.objectID
+        context.delete(entity2)
+        try context.save()
+        let transactions = [
+            PersistentHistoryTransactionFake(historyChanges: [
+                PersistentHistoryChangeFake(changedObjectID: objectID, changeType: .insert),
+            ]),
+        ]
+
+        XCTAssertNoThrow(try sut.merge(transactions: transactions, using: context))
+    }
 }


### PR DESCRIPTION
## Summary

- remove unreadable persistent-history tokens and write replacement tokens atomically
- skip missing or deleted managed objects while deduplicating remote history
- avoid force-unwrapping absent Core Data uniqueness values
- add regression coverage for corrupt tokens, missing uniqueness values, and deleted history objects

## Root cause

A persistent-history token could fail to unarchive, causing Core Data to replay all available history. Deduplication then used `context.object(with:)` and force-unwrapped the optional uniqueness value. A stale or malformed `MO_LastPage` record with no `page` value trapped before the processor could advance its token, producing a repeated launch-crash loop.

## Impact

Remote-history processing now recovers from the corrupt token and safely ignores stale or incomplete records, allowing the history token to advance and preventing the crash from repeating.

## Validation

- `make format-lint`
- `make test-no-sync TARGET=CoreDataPersistenceTests` — 11 tests passed
- `make test-sync TARGET=CoreDataPersistenceTests` — 11 tests passed
- `git diff --check`
