### PR TITLE
fix: ignore incomplete Core Data notes

### DIFF
--- a/Data/NotePersistence/Sources/CoreDataNotePersistence.swift
+++ b/Data/NotePersistence/Sources/CoreDataNotePersistence.swift
@@ -25,6 +25,7 @@ public struct CoreDataNotePersistence: NotePersistence {
 
     public func notes() -> AnyPublisher<[NotePersistenceModel], Never> {
         let request: NSFetchRequest<MO_Note> = MO_Note.fetchRequest()
+        request.predicate = NSPredicate(format: "verses.@count > 0")
         request.relationshipKeyPathsForPrefetching = ["verses"]
         request.sortDescriptors = [NSSortDescriptor(key: Schema.Note.modifiedOn, ascending: false)]
 

--- a/Data/NotePersistence/Tests/CoreDataNotePersistenceTests.swift
+++ b/Data/NotePersistence/Tests/CoreDataNotePersistenceTests.swift
@@ -7,6 +7,7 @@
 
 import AsyncUtilitiesForTesting
 import CoreDataPersistence
+import CoreDataPersistenceTestSupport
 import SystemDependenciesFake
 import XCTest
 @testable import NotePersistence
@@ -95,6 +96,18 @@ class CoreDataNotePersistenceTests: XCTestCase {
         // 10. Assert no change to database
         XCTAssertEqual(updatedNote2, returnedNote2)
         XCTAssertEqual(numberOfUpdates, collector.items.count)
+    }
+
+    func test_notesExcludesNotesWithNoVerses() throws {
+        let context = stack.newBackgroundContext()
+        try context.performAndWait {
+            _ = context.newNote("Incomplete note", modifiedOn: 100)
+            try context.save()
+        }
+
+        let collector = PublisherCollector(sut.notes())
+
+        XCTAssertEqual(collector.items, [[]])
     }
 }
 

--- a/Domain/AnnotationsService/Sources/NoteService.swift
+++ b/Domain/AnnotationsService/Sources/NoteService.swift
@@ -35,7 +35,10 @@ public struct NoteService {
         analytics.highlight(verses: verses)
         let verses = verses.map(VersePersistenceModel.init)
         let persistenceModel = try await persistence.setNote(nil, verses: verses, color: color.rawValue)
-        return Note(quran: quran, persistenceModel)
+        guard let note = Note(quran: quran, persistenceModel) else {
+            throw NoteServiceError.invalidPersistenceModel
+        }
+        return note
     }
 
     public func setNote(_ note: String, verses: [AyahNumber], color: HighlightColor) async throws {
@@ -55,7 +58,7 @@ public struct NoteService {
 
     public func notes(quran: Quran) -> AnyPublisher<[Note], Never> {
         persistence.notes()
-            .map { notes in notes.map { Note(quran: quran, $0) } }
+            .map { notes in notes.compactMap { Note(quran: quran, $0) } }
             .eraseToAnyPublisher()
     }
     #endif
@@ -67,20 +70,25 @@ public struct NoteService {
 }
 
 #if !QURAN_SYNC
+private enum NoteServiceError: Error {
+    case invalidPersistenceModel
+}
+
 private extension Note {
-    init(quran: Quran, _ note: NotePersistenceModel) {
+    init?(quran: Quran, _ note: NotePersistenceModel) {
+        let verses = note.verses.compactMap {
+            AyahNumber(quran: quran, sura: $0.sura, ayah: $0.ayah)
+        }
+        guard verses.count == note.verses.count, !verses.isEmpty else {
+            return nil
+        }
+
         self.init(
-            verses: Set(note.verses.map { AyahNumber(quran: quran, $0) }),
+            verses: Set(verses),
             modifiedDate: note.modifiedDate,
             text: note.note,
             color: HighlightColor(rawValue: note.color) ?? .red
         )
-    }
-}
-
-private extension AyahNumber {
-    init(quran: Quran, _ other: VersePersistenceModel) {
-        self.init(quran: quran, sura: other.sura, ayah: other.ayah)!
     }
 }
 

--- a/Domain/AnnotationsService/Tests/NoteServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/NoteServiceTests.swift
@@ -1,0 +1,70 @@
+#if !QURAN_SYNC
+import Analytics
+import Combine
+import QuranKit
+import XCTest
+@testable import AnnotationsService
+@testable import NotePersistence
+@testable import QuranAnnotations
+
+final class NoteServiceTests: XCTestCase {
+    func test_notesIgnoresIncompleteAndInvalidPersistenceModels() {
+        let persistence = NotePersistenceFake(notes: [
+            NotePersistenceModel(
+                verses: [],
+                modifiedDate: .distantPast,
+                note: "Incomplete",
+                color: 0
+            ),
+            NotePersistenceModel(
+                verses: [VersePersistenceModel(ayah: 999, sura: 1)],
+                modifiedDate: .distantPast,
+                note: "Invalid",
+                color: 0
+            ),
+            NotePersistenceModel(
+                verses: [VersePersistenceModel(ayah: 1, sura: 1)],
+                modifiedDate: .distantPast,
+                note: "Valid",
+                color: 0
+            ),
+        ])
+        let sut = NoteService(persistence: persistence, analytics: NoopAnalytics())
+
+        var receivedNotes: [Note] = []
+        let cancellable = sut.notes(quran: Quran.hafsMadani1405).sink { receivedNotes = $0 }
+        withExtendedLifetime(cancellable) {}
+
+        XCTAssertEqual(receivedNotes.count, 1)
+        XCTAssertEqual(receivedNotes.first?.text, "Valid")
+    }
+}
+
+private final class NotePersistenceFake: NotePersistence {
+    init(notes: [NotePersistenceModel]) {
+        models = notes
+    }
+
+    func notes() -> AnyPublisher<[NotePersistenceModel], Never> {
+        Just(models).eraseToAnyPublisher()
+    }
+
+    func setNote(
+        _ note: String?,
+        verses: [VersePersistenceModel],
+        color: Int
+    ) async throws -> NotePersistenceModel {
+        fatalError("Unavailable")
+    }
+
+    func removeNotes(with verses: [VersePersistenceModel]) async throws -> [NotePersistenceModel] {
+        fatalError("Unavailable")
+    }
+
+    private let models: [NotePersistenceModel]
+}
+
+private struct NoopAnalytics: AnalyticsLibrary {
+    func logEvent(_ name: String, value: String) {}
+}
+#endif


### PR DESCRIPTION
## Summary

- exclude Core Data notes with no verse relationships from the notes publisher
- validate persisted verse coordinates before constructing `Note` domain models
- add persistence and service regressions for incomplete/invalid stored notes

## Root cause

Crashlytics issue `cf455c0cb12bd62beae8efd2b7c9d698` logged `Found 3 MO_Note with no associated verses` immediately before `Note.init` trapped. Remote Core Data changes could publish one of those incomplete notes before the uniquifier deleted it. `Note.init` assumes a non-empty verse set and indexed the empty sorted array.

## Validation

- `make format-lint`
- `make test-no-sync TARGET=NotePersistenceTests`
- `make test-no-sync TARGET=AnnotationsServiceTests`
- `make test-sync TARGET=NotePersistenceTests`
- `make test-sync TARGET=AnnotationsServiceTests`