### PR TITLE
fix: avoid audio banner glass effect crash

### DIFF
--- a/UI/NoorUI/Sources/Features/AudioBanner/AudioBannerViewUI.swift
+++ b/UI/NoorUI/Sources/Features/AudioBanner/AudioBannerViewUI.swift
@@ -354,7 +354,7 @@ private extension View {
 
     @ViewBuilder
     func audioBannerBackground() -> some View {
-        if #available(iOS 26.0, *) {
+        if #available(iOS 26.1, *) {
             glassEffect(in: .capsule)
                 .padding(.horizontal)
         } else {


### PR DESCRIPTION
## Summary

- use the existing material background on iOS 26.0
- enable the audio banner Liquid Glass background on iOS 26.1 and later

## Root cause

The `glassEffect` API is compile-time available starting in iOS 26.0, but the affected iOS 26.0 runtime can crash while applying it. A `#available(iOS 26.0, *)` check therefore admits the crashing runtime. Raising the runtime gate to iOS 26.1 keeps iOS 26.0 on the established fallback without extra type erasure or wrapper views.

## Impact

Audio banners remain functional on iOS 26.0 with the material fallback, while iOS 26.1+ retains Liquid Glass styling.

## Validation

- `make format-lint`
- `make build-no-sync TARGET=NoorUI`
- `make build-sync TARGET=NoorUI`
- `make test-no-sync`
- `make test-sync`