### PR TITLE
chore: upgrade mobile-sync-spm to 0.1.20

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quran/mobile-sync-spm.git",
       "state" : {
-        "revision" : "92a6f4e0a34dddc4774f1c9ae436fa9e893ec078",
-        "version" : "0.1.19"
+        "revision" : "6134e6329b9feef3bbccb475b9e5390e9cb822e0",
+        "version" : "0.1.20"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let mobileSyncPackageDependency: Package.Dependency = {
     if let localMobileSyncPackagePath, !localMobileSyncPackagePath.isEmpty {
         return .package(path: localMobileSyncPackagePath)
     }
-    return .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.19")
+    return .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.20")
 }()
 
 let mobileSyncPackageDependencies: [Package.Dependency] =


### PR DESCRIPTION
## Summary

- upgrade mobile-sync-spm from 0.1.19 to 0.1.20
- refresh Package.resolved to the v0.1.20 release commit
- consume MobileSync 0.1.18 through the Swift package wrapper

## Impact

Aligns QuranEngine with the released MobileSync bookmark API cleanup and updated ayah collection replacement behavior.

## Validation

- make build-sync PACKAGE_DESTINATION="generic/platform=iOS Simulator"