### PR TITLE
Fix iPad search navigation crash

### DIFF
--- a/Features/SearchFeature/Sources/SearchViewController.swift
+++ b/Features/SearchFeature/Sources/SearchViewController.swift
@@ -71,6 +71,11 @@ final class SearchViewController: UIViewController, UISearchBarDelegate {
             .store(in: &cancellables)
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        searchController.isActive = false
+    }
+
     // MARK: - Search delegate methods
 
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {


### PR DESCRIPTION
## Summary

- Deactivate `UISearchController` before Search leaves the screen.
- Preserve the search term and results while avoiding an invalid UIKit interaction lifecycle during navigation.

## Root cause

On iPadOS 26.0, returning from Quran to an active Search screen unhides the navigation bar while UIKit moves the search bar back into the window. The still-active search controller attempts to attach `_UIPassthroughScrollInteraction` again and raises `NSInternalInconsistencyException`: `The view should already be in the window before adding a _UIPassthroughScrollInteraction`.

Deactivating the search controller in `viewWillDisappear` completes its presentation lifecycle before the navigation transition begins.

## Validation

- Reproduced before the fix on iPad mini (A17 Pro), iPadOS 26.0: Search `5:75` → open Quran result → Back; crashed on the fourth repeated transition with the same exception and stack as Crashlytics.
- Repeated seven transitions after the fix on the same simulator; app remained alive and Search results were preserved.
- `make format-lint`
- `make build-no-sync TARGET=SearchFeature`
- `make build-sync TARGET=SearchFeature`
- `make test-no-sync`
- `make test-sync`