### PR TITLE
Remove contributor credit from What's New

### DIFF
--- a/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -276,11 +276,11 @@
 
 // Reading layouts
 "new.reading_layouts" = "مصاحف مدنية جديدة";
-"new.reading_layouts.details" = "* تمت إضافة مصحفي المدينة ١٤٣٩ و١٤٤١، وقد حُسِّنا لملء الشاشة بالكامل — بفضل @ahmedre.";
+"new.reading_layouts.details" = "* تمت إضافة مصحفي المدينة ١٤٣٩ و١٤٤١، وقد حُسِّنا لملء الشاشة بالكامل.";
 
 // Experimental IndoPak
 "new.experimental_indopak" = "الهندي الباكستاني – ١٥ سطرًا";
-"new.experimental_indopak.details" = "* جرّب المصحف الهندي الباكستاني الجديد المكوّن من ١٥ سطرًا بخط النسخ - بفضل @ahmedre.\n* ما زالت بعض الميزات غير متاحة وستُضاف في تحديثات مستقبلية.";
+"new.experimental_indopak.details" = "* جرّب المصحف الهندي الباكستاني الجديد المكوّن من ١٥ سطرًا بخط النسخ.\n* ما زالت بعض الميزات غير متاحة وستُضاف في تحديثات مستقبلية.";
 
 // Audio controls
 "new.audio_controls" = "خيارات الصوت المتقدمة";

--- a/Core/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -322,13 +322,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Neue Madani-Mushafs";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Madani Mushaf 1439 und 1441 hinzugefügt, optimiert, um den gesamten Bildschirm auszufüllen – dank @ahmedre.";
+"new.reading_layouts.details" = "* Madani Mushaf 1439 und 1441 hinzugefügt, optimiert, um den gesamten Bildschirm auszufüllen.";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "Indisch-pakistanisch – 15 Zeilen";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* Probiere das neue 15-zeilige indisch-pakistanische Leselayout im Naskh-Stil aus – dank @ahmedre.\n* Einige Funktionen fehlen noch und werden in zukünftigen Updates ergänzt.";
+"new.experimental_indopak.details" = "* Probiere das neue 15-zeilige indisch-pakistanische Leselayout im Naskh-Stil aus.\n* Einige Funktionen fehlen noch und werden in zukünftigen Updates ergänzt.";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -302,11 +302,11 @@
 
 // Reading layouts
 "new.reading_layouts" = "New Madani Mushafs";
-"new.reading_layouts.details" = "* Added Madani Mushaf 1439 and 1441, optimized to fill the entire screen — thanks to @ahmedre.";
+"new.reading_layouts.details" = "* Added Madani Mushaf 1439 and 1441, optimized to fill the entire screen.";
 
 // Experimental IndoPak
 "new.experimental_indopak" = "IndoPak 15-Line";
-"new.experimental_indopak.details" = "* Try the new IndoPak 15-line reading layout in the Naskh style - thanks to @ahmedre.\n* A few features are still missing and will be added in future updates.";
+"new.experimental_indopak.details" = "* Try the new IndoPak 15-line reading layout in the Naskh style.\n* A few features are still missing and will be added in future updates.";
 
 // Audio controls
 "new.audio_controls" = "Advanced Audio Options";

--- a/Core/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -322,13 +322,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Nuevos mushafs de Medina";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Se añadieron los Mushaf de Medina 1439 y 1441, optimizados para ocupar toda la pantalla — gracias a @ahmedre.";
+"new.reading_layouts.details" = "* Se añadieron los Mushaf de Medina 1439 y 1441, optimizados para ocupar toda la pantalla.";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "Indopakistaní de 15 líneas";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* Prueba el nuevo diseño de lectura indopakistaní de 15 líneas en estilo naskh, gracias a @ahmedre.\n* Todavía faltan algunas funciones y se añadirán en futuras actualizaciones.";
+"new.experimental_indopak.details" = "* Prueba el nuevo diseño de lectura indopakistaní de 15 líneas en estilo naskh.\n* Todavía faltan algunas funciones y se añadirán en futuras actualizaciones.";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -324,13 +324,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "مصحف‌های جدید مدینه";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* مصحف‌های مدینه ۱۴۳۹ و ۱۴۴۱ اضافه شدند؛ برای پر کردن تمام صفحه بهینه‌سازی شده‌اند — با تشکر از @ahmedre.";
+"new.reading_layouts.details" = "* مصحف‌های مدینه ۱۴۳۹ و ۱۴۴۱ اضافه شدند؛ برای پر کردن تمام صفحه بهینه‌سازی شده‌اند.";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "هندی-پاکستانی ۱۵ سطری";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* چیدمان جدید ۱۵ سطری هندی-پاکستانی با سبک نسخ را امتحان کنید - با تشکر از @ahmedre.\n* چند قابلیت هنوز در دسترس نیست و در به‌روزرسانی‌های آینده اضافه خواهد شد.";
+"new.experimental_indopak.details" = "* چیدمان جدید ۱۵ سطری هندی-پاکستانی با سبک نسخ را امتحان کنید.\n* چند قابلیت هنوز در دسترس نیست و در به‌روزرسانی‌های آینده اضافه خواهد شد.";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -322,13 +322,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Nouveaux mushafs de Médine";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Ajout des Mushafs de Médine 1439 et 1441, optimisés pour occuper tout l’écran — grâce à @ahmedre.";
+"new.reading_layouts.details" = "* Ajout des Mushafs de Médine 1439 et 1441, optimisés pour occuper tout l’écran.";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "Indo-pakistanais – 15 lignes";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* Essayez la nouvelle mise en page de lecture indo-pakistanaise à 15 lignes dans le style naskh, grâce à @ahmedre.\n* Certaines fonctionnalités manquent encore et seront ajoutées lors de futures mises à jour.";
+"new.experimental_indopak.details" = "* Essayez la nouvelle mise en page de lecture indo-pakistanaise à 15 lignes dans le style naskh.\n* Certaines fonctionnalités manquent encore et seront ajoutées lors de futures mises à jour.";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/kk.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/kk.lproj/Localizable.strings
@@ -306,13 +306,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Жаңа Мәдина мұсхафтары";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Мәдина мұсхафы 1439 және 1441 қосылды, бүкіл экранды толтыру үшін оңтайландырылған — @ahmedre-ға рақмет.";
+"new.reading_layouts.details" = "* Мәдина мұсхафы 1439 және 1441 қосылды, бүкіл экранды толтыру үшін оңтайландырылған.";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "Үнді-пәкістандық — 15 жол";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* Насх стиліндегі жаңа 15 жолдық үнді-пәкістандық оқу үлгісін қолданып көріңіз — @ahmedre-ға рақмет.\n* Кейбір мүмкіндіктер әлі жоқ және болашақ жаңартуларда қосылады.";
+"new.experimental_indopak.details" = "* Насх стиліндегі жаңа 15 жолдық үнді-пәкістандық оқу үлгісін қолданып көріңіз.\n* Кейбір мүмкіндіктер әлі жоқ және болашақ жаңартуларда қосылады.";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -305,13 +305,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Mushaf Madani Baharu";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Mushaf Madani 1439 dan 1441 ditambah, dioptimumkan untuk memenuhi seluruh skrin — terima kasih kepada @ahmedre.";
+"new.reading_layouts.details" = "* Mushaf Madani 1439 dan 1441 ditambah, dioptimumkan untuk memenuhi seluruh skrin.";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "India-Pakistan 15 Baris";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* Cuba susun atur bacaan India-Pakistan 15 baris yang baharu dalam gaya Naskh — terima kasih kepada @ahmedre.\n* Beberapa ciri masih belum tersedia dan akan ditambah dalam kemas kini akan datang.";
+"new.experimental_indopak.details" = "* Cuba susun atur bacaan India-Pakistan 15 baris yang baharu dalam gaya Naskh.\n* Beberapa ciri masih belum tersedia dan akan ditambah dalam kemas kini akan datang.";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -234,13 +234,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Nieuwe Madani-mushafs";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Madani Mushaf 1439 en 1441 toegevoegd, geoptimaliseerd om het volledige scherm te vullen — met dank aan @ahmedre.";
+"new.reading_layouts.details" = "* Madani Mushaf 1439 en 1441 toegevoegd, geoptimaliseerd om het volledige scherm te vullen.";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "Indo-Pakistaans – 15 regels";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* Probeer de nieuwe 15-regelige Indo-Pakistaanse leesindeling in Naskh-stijl — met dank aan @ahmedre.\n* Enkele functies ontbreken nog en worden in toekomstige updates toegevoegd.";
+"new.experimental_indopak.details" = "* Probeer de nieuwe 15-regelige Indo-Pakistaanse leesindeling in Naskh-stijl.\n* Enkele functies ontbreken nog en worden in toekomstige updates toegevoegd.";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/pt.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/pt.lproj/Localizable.strings
@@ -323,13 +323,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Novos mushafs de Medina";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Adicionados os Mushafs de Medina 1439 e 1441, otimizados para preencher toda a tela — graças a @ahmedre.";
+"new.reading_layouts.details" = "* Adicionados os Mushafs de Medina 1439 e 1441, otimizados para preencher toda a tela.";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "Indo-paquistanês — 15 linhas";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* Experimente o novo layout de leitura indo-paquistanês de 15 linhas no estilo Naskh, graças a @ahmedre.\n* Alguns recursos ainda não estão disponíveis e serão adicionados em futuras atualizações.";
+"new.experimental_indopak.details" = "* Experimente o novo layout de leitura indo-paquistanês de 15 linhas no estilo Naskh.\n* Alguns recursos ainda não estão disponíveis e serão adicionados em futuras atualizações.";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -322,13 +322,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Новые мединские мусхафы";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Добавлены «Мединский мусхаф 1439» и «Мединский мусхаф 1441», оптимизированные для отображения во весь экран — благодаря @ahmedre.";
+"new.reading_layouts.details" = "* Добавлены «Мединский мусхаф 1439» и «Мединский мусхаф 1441», оптимизированные для отображения во весь экран.";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "Индо-пакистанский — 15 строк";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* Попробуйте новый 15-строчный индо-пакистанский вариант чтения в стиле насх — благодаря @ahmedre.\n* Некоторые функции пока отсутствуют и будут добавлены в будущих обновлениях.";
+"new.experimental_indopak.details" = "* Попробуйте новый 15-строчный индо-пакистанский вариант чтения в стиле насх.\n* Некоторые функции пока отсутствуют и будут добавлены в будущих обновлениях.";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -264,13 +264,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Yeni Medine Mushafları";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Medine Mushafı 1439 ve 1441 eklendi; ekranın tamamını dolduracak şekilde optimize edildi — @ahmedre sayesinde.";
+"new.reading_layouts.details" = "* Medine Mushafı 1439 ve 1441 eklendi; ekranın tamamını dolduracak şekilde optimize edildi.";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "Hint-Pakistan — 15 Satır";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* Nesih stilindeki yeni 15 satırlık Hint-Pakistan okuma düzenini deneyin — @ahmedre sayesinde.\n* Bazı özellikler henüz eksik ve gelecekteki güncellemelerde eklenecek.";
+"new.experimental_indopak.details" = "* Nesih stilindeki yeni 15 satırlık Hint-Pakistan okuma düzenini deneyin.\n* Bazı özellikler henüz eksik ve gelecekteki güncellemelerde eklenecek.";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ug.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ug.lproj/Localizable.strings
@@ -325,13 +325,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "يېڭى مەدىنە مۇشاپلىرى";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* مەدىنە مۇشاپى 1439 ۋە 1441 قوشۇلدى، پۈتۈن ئېكراننى تولدۇرۇش ئۈچۈن ئەلالاشتۇرۇلدى — @ahmedre غا رەھمەت.";
+"new.reading_layouts.details" = "* مەدىنە مۇشاپى 1439 ۋە 1441 قوشۇلدى، پۈتۈن ئېكراننى تولدۇرۇش ئۈچۈن ئەلالاشتۇرۇلدى.";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "ھىندى-پاكىستان — 15 قۇر";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* يېڭى 15 قۇرلۇق ھىندى-پاكىستان نەسخ ئۇسلۇبىدىكى ئوقۇش كۆرۈنۈشىنى سىناپ بېقىڭ — @ahmedre غا رەھمەت.\n* بەزى ئىقتىدارلار تېخى يوق، كېيىنكى يېڭىلانمىلاردا قوشۇلىدۇ.";
+"new.experimental_indopak.details" = "* يېڭى 15 قۇرلۇق ھىندى-پاكىستان نەسخ ئۇسلۇبىدىكى ئوقۇش كۆرۈنۈشىنى سىناپ بېقىڭ.\n* بەزى ئىقتىدارلار تېخى يوق، كېيىنكى يېڭىلانمىلاردا قوشۇلىدۇ.";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/uz.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/uz.lproj/Localizable.strings
@@ -324,13 +324,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Yangi Madina mushaflari";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Madina mushafi 1439 va 1441 qo‘shildi, butun ekranni to‘ldirish uchun optimallashtirildi — @ahmedre ga rahmat.";
+"new.reading_layouts.details" = "* Madina mushafi 1439 va 1441 qo‘shildi, butun ekranni to‘ldirish uchun optimallashtirildi.";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "Hind-Pokiston — 15 qator";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* Nasx uslubidagi yangi 15 qatorli Hind-Pokiston o‘qish ko‘rinishini sinab ko‘ring — @ahmedre ga rahmat.\n* Ayrim imkoniyatlar hali mavjud emas va kelgusi yangilanishlarda qo‘shiladi.";
+"new.experimental_indopak.details" = "* Nasx uslubidagi yangi 15 qatorli Hind-Pokiston o‘qish ko‘rinishini sinab ko‘ring.\n* Ayrim imkoniyatlar hali mavjud emas va kelgusi yangilanishlarda qo‘shiladi.";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -231,13 +231,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "Các Mushaf Madani mới";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* Đã thêm Mushaf Madani 1439 và 1441, được tối ưu hóa để hiển thị toàn màn hình — cảm ơn @ahmedre.";
+"new.reading_layouts.details" = "* Đã thêm Mushaf Madani 1439 và 1441, được tối ưu hóa để hiển thị toàn màn hình.";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "Ấn Độ–Pakistan – 15 dòng";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* Hãy thử bố cục đọc Ấn Độ–Pakistan 15 dòng mới theo phong cách Naskh — cảm ơn @ahmedre.\n* Một số tính năng vẫn còn thiếu và sẽ được bổ sung trong các bản cập nhật sau.";
+"new.experimental_indopak.details" = "* Hãy thử bố cục đọc Ấn Độ–Pakistan 15 dòng mới theo phong cách Naskh.\n* Một số tính năng vẫn còn thiếu và sẽ được bổ sung trong các bản cập nhật sau.";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/zh.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/zh.lproj/Localizable.strings
@@ -323,13 +323,13 @@
 // Metadata: Translated by ChatGPT; human review required.
 "new.reading_layouts" = "全新麦地那穆沙夫";
 // Metadata: Translated by ChatGPT; human review required.
-"new.reading_layouts.details" = "* 新增麦地那穆沙夫 1439 和 1441，已优化为全屏显示 — 感谢 @ahmedre。";
+"new.reading_layouts.details" = "* 新增麦地那穆沙夫 1439 和 1441，已优化为全屏显示。";
 
 // Experimental IndoPak
 // Metadata: Translated by ChatGPT; human review required.
 "new.experimental_indopak" = "印巴版（15 行）";
 // Metadata: Translated by ChatGPT; human review required.
-"new.experimental_indopak.details" = "* 试用采用纳斯赫风格的全新 15 行印巴版阅读布局 — 感谢 @ahmedre。\n* 目前仍缺少部分功能，未来更新将陆续补充。";
+"new.experimental_indopak.details" = "* 试用采用纳斯赫风格的全新 15 行印巴版阅读布局。\n* 目前仍缺少部分功能，未来更新将陆续补充。";
 
 // Audio controls
 // Metadata: Translated by ChatGPT; human review required.


### PR DESCRIPTION
## Summary

- remove the `@ahmedre` attribution from the Madani Mushaf announcement
- remove the attribution from the experimental IndoPak announcement
- update all 16 supported localizations without leaving dangling credit clauses

## Why

The contributor credit should no longer appear in the What's New content.

## Impact

Users will see the same feature announcements without the contributor attribution.

## Validation

- `make test-no-sync TARGET=LocalizationTests`
- `make test-sync TARGET=LocalizationTests`
- `git diff --check`
- verified no remaining `ahmedre` references