### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-26
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setting up Xcode
       run: sudo xcode-select -s "/Applications/Xcode_26.2.app"
@@ -30,7 +30,7 @@ jobs:
     runs-on: macos-26
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setting up Xcode
       run: sudo xcode-select -s "/Applications/Xcode_26.2.app"
@@ -45,7 +45,7 @@ jobs:
     runs-on: macos-26
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setting up Xcode
         run: sudo xcode-select -s "/Applications/Xcode_26.2.app"
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-26
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setting up Xcode
         run: sudo xcode-select -s "/Applications/Xcode_26.2.app"
@@ -75,7 +75,7 @@ jobs:
     runs-on: macos-26
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setting up Xcode
         run: sudo xcode-select -s "/Applications/Xcode_26.2.app"


### PR DESCRIPTION
`actions/checkout@v2` runs on the deprecated Node 16 runtime; GitHub now warns on every run and will eventually brown it out. v4 is the current major (runs on Node 20). No other changes.