### PR TITLE
fix: improve more menu segmented control layout

### DIFF
--- a/Features/MoreMenuFeature/Sources/views/MoreMenuModeSelector.swift
+++ b/Features/MoreMenuFeature/Sources/views/MoreMenuModeSelector.swift
@@ -20,7 +20,8 @@ struct MoreMenuModeSelector: View {
                 .tag(QuranMode.translation)
         }
         .pickerStyle(SegmentedPickerStyle())
-        .padding(.bottom, 1)
+        .controlSize(.large)
+        .padding(8)
     }
 }
 


### PR DESCRIPTION
## Summary

- use the native large control size for the Quran mode segmented picker
- inset the picker so its curvature reads independently from the popover corners
- preserve the existing theme and native segmented-control styling

## Why

On iOS 26, the segmented control sat flush against the popover edge with a different corner radius, making the top of the menu appear clipped. The larger inset native control gives the header a balanced shape while keeping standard system behavior.

## Validation

- `make format-lint`
- `make test-no-sync TARGET=MoreMenuFeatureTests`
- built and visually verified on iPhone 17e Simulator running iOS 26.5

## Screenshot

<img width="300" alt="More menu with the larger inset segmented control" src="https://github.com/user-attachments/assets/aa87e755-8479-4849-a25e-b3d8f04e765f" />

Related to #994 (does not close the issue).