### PR TITLE
fix: restore Quran page navigation title

### DIFF
--- a/Features/QuranViewFeature/Sources/QuranView.swift
+++ b/Features/QuranViewFeature/Sources/QuranView.swift
@@ -50,6 +50,7 @@ class QuranView: UIView, UIGestureRecognizerDelegate, UINavigationBarDelegate {
     override func layoutSubviews() {
         navigationItem.titleView?.setNeedsLayout()
         super.layoutSubviews()
+        configureNavigationBarScrollEdgeEffectIfNeeded()
         configureAudioBarScrollEdgeEffectIfNeeded()
     }
 
@@ -100,7 +101,28 @@ class QuranView: UIView, UIGestureRecognizerDelegate, UINavigationBarDelegate {
 
     private let tapGesture = UITapGestureRecognizer()
     private var audioView: UIView?
+    private var navigationBarScrollEdgeInteraction: (any UIInteraction)?
     private var audioBarScrollEdgeInteraction: (any UIInteraction)?
+
+    private func configureNavigationBarScrollEdgeEffectIfNeeded() {
+        guard #available(iOS 26.0, *) else { return }
+        guard let scrollView = contentView?.findSubview(ofType: UIScrollView.self) else {
+            return
+        }
+
+        if let interaction = navigationBarScrollEdgeInteraction as? UIScrollEdgeElementContainerInteraction {
+            if interaction.scrollView !== scrollView {
+                interaction.scrollView = scrollView
+            }
+            return
+        }
+
+        let interaction = UIScrollEdgeElementContainerInteraction()
+        interaction.edge = .top
+        interaction.scrollView = scrollView
+        navigationBarScrollEdgeInteraction = interaction
+        navigationBar.addInteraction(interaction)
+    }
 
     private func configureAudioBarScrollEdgeEffectIfNeeded() {
         guard #available(iOS 26.0, *) else { return }

--- a/Features/QuranViewFeature/Sources/QuranViewController.swift
+++ b/Features/QuranViewFeature/Sources/QuranViewController.swift
@@ -83,12 +83,6 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         quranView?.navigationItem.largeTitleDisplayMode = .never
         quranView?.delegate = self
 
-        // set the custom title view
-        quranView?.navigationItem.titleView = TwoLineNavigationTitleView(
-            firstLineFont: .boldSystemFont(ofSize: 15),
-            secondLineFont: .systemFont(ofSize: 15, weight: .light)
-        )
-
         let backImage: UIImage?
         backImage = UIImage(systemName: "chevron.backward")
 
@@ -294,7 +288,6 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         return UIBarButtonItem(image: moreImage, style: .plain, target: self, action: #selector(onMoreBarButtonTapped(_:)))
     }()
 
-    private var titleView: TwoLineNavigationTitleView? { quranView?.navigationItem.titleView as? TwoLineNavigationTitleView }
     private var quranView: QuranView? {
         view as? QuranView
     }
@@ -368,9 +361,12 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
 
     private func updateTitle(_ pages: [Page]) {
         if pages.isEmpty {
-            titleView?.firstLine = ""
-            titleView?.secondLine = ""
-            titleView?.isAccessibilityElement = false
+            if #available(iOS 26.0, *) {
+                quranView?.navigationItem.attributedTitle = nil
+                quranView?.navigationItem.subtitle = nil
+            } else {
+                quranView?.navigationItem.title = nil
+            }
             return
         }
         let suras = pages.map(\.startSura)
@@ -384,10 +380,14 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         )
         let sura = suras.min()!
         let suraReference: MultipartText = "\(sura: sura)"
-        titleView?.firstLineAttributedText = suraReference.attributedString(ofSize: .subheadline)
-        titleView?.secondLine = pageDescription
-        titleView?.isAccessibilityElement = true
-        titleView?.accessibilityLabel = "\(suraReference.accessibilityText), \(pageDescription)"
+        if #available(iOS 26.0, *) {
+            quranView?.navigationItem.attributedTitle = AttributedString(
+                suraReference.attributedString(ofSize: .subheadline)
+            )
+            quranView?.navigationItem.subtitle = pageDescription
+        } else {
+            quranView?.navigationItem.title = "\(suraReference.accessibilityText) (\(pageDescription))"
+        }
     }
 
     private func updateRightBarItems(animated: Bool, isBookmarked: Bool) {

--- a/Features/QuranViewFeature/Sources/QuranViewController.swift
+++ b/Features/QuranViewFeature/Sources/QuranViewController.swift
@@ -83,6 +83,13 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         quranView?.navigationItem.largeTitleDisplayMode = .never
         quranView?.delegate = self
 
+        if #unavailable(iOS 26.0) {
+            quranView?.navigationItem.titleView = TwoLineNavigationTitleView(
+                firstLineFont: .boldSystemFont(ofSize: 15),
+                secondLineFont: .systemFont(ofSize: 15, weight: .light)
+            )
+        }
+
         let backImage: UIImage?
         backImage = UIImage(systemName: "chevron.backward")
 
@@ -288,6 +295,7 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         return UIBarButtonItem(image: moreImage, style: .plain, target: self, action: #selector(onMoreBarButtonTapped(_:)))
     }()
 
+    private var titleView: TwoLineNavigationTitleView? { quranView?.navigationItem.titleView as? TwoLineNavigationTitleView }
     private var quranView: QuranView? {
         view as? QuranView
     }
@@ -365,7 +373,9 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
                 quranView?.navigationItem.attributedTitle = nil
                 quranView?.navigationItem.subtitle = nil
             } else {
-                quranView?.navigationItem.title = nil
+                titleView?.firstLine = ""
+                titleView?.secondLine = ""
+                titleView?.isAccessibilityElement = false
             }
             return
         }
@@ -386,7 +396,10 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
             )
             quranView?.navigationItem.subtitle = pageDescription
         } else {
-            quranView?.navigationItem.title = "\(suraReference.accessibilityText) (\(pageDescription))"
+            titleView?.firstLineAttributedText = suraReference.attributedString(ofSize: .subheadline)
+            titleView?.secondLine = pageDescription
+            titleView?.isAccessibilityElement = true
+            titleView?.accessibilityLabel = "\(suraReference.accessibilityText), \(pageDescription)"
         }
     }
 


### PR DESCRIPTION
## Summary

- replace the zero-sized custom Quran navigation title on iOS 26 with native attributed title and subtitle APIs
- retain `TwoLineNavigationTitleView` unchanged on earlier iOS versions
- connect the embedded navigation bar to the Quran scroll view’s top-edge treatment for legibility

## Root cause

iOS 26.5 kept the custom `titleView` content but laid out its navigation title container at `0×0`, leaving only the back and trailing bar buttons visible.

## Impact

The Quran page again shows its locale-aware sura title, page number, and juz information on iOS 26. Existing two-line title behavior remains intact on older systems. The iOS 26 title stays readable over page content through the scroll-edge effect.

## Validation

- `make format-lint`
- `make build-no-sync TARGET=QuranViewFeature`
- built and launched `QuranEngineApp` on an iPhone 17e simulator running iOS 26.5
- visually verified the native title and subtitle alongside the existing navigation controls