### PR TITLE
feat: add IndoPak line display settings

### DIFF
--- a/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -66,6 +66,8 @@
 "menu.arabicFontSize" = "حجم خط القرآن";
 "menu.twoPages" = "عرض صفحتين في الوضع الأفقي";
 "menu.verticalScrolling" = "تمرير رأسي";
+"menu.linePageDividers" = "فواصل الأسطر";
+"menu.linePageSidelines" = "الخطوط الجانبية";
 "menu.theme_settings" = "المظهر والإعدادات";
 
 // MARK: - Theme

--- a/Core/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -96,6 +96,8 @@
 "menu.twoPages" = "2 Seiten nebeneinander (im Querformat)";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.verticalScrolling" = "Vertikales Scrollen";
+"menu.linePageDividers" = "Zeilentrenner";
+"menu.linePageSidelines" = "Seitenlinien";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "Themen & Einstellungen";
 

--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -73,6 +73,8 @@
 "menu.arabicFontSize" = "Quran Size";
 "menu.twoPages" = "2 pages side-by-side (in landscape)";
 "menu.verticalScrolling" = "Vertical scrolling";
+"menu.linePageDividers" = "Line dividers";
+"menu.linePageSidelines" = "Side lines";
 "menu.theme_settings" = "Themes & Settings";
 
 // MARK: - Theme

--- a/Core/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -96,6 +96,8 @@
 "menu.twoPages" = "2 páginas una al lado de la otra (en paisaje)";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.verticalScrolling" = "Desplazamiento vertical";
+"menu.linePageDividers" = "Separadores de línea";
+"menu.linePageSidelines" = "Líneas laterales";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "Temas y configuraciones";
 

--- a/Core/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -96,6 +96,8 @@
 "menu.twoPages" = "2 صفحه کنار هم (در حالت افقی)";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.verticalScrolling" = "اسکرول عمودی";
+"menu.linePageDividers" = "جداکننده‌های سطر";
+"menu.linePageSidelines" = "خطوط کناری";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "پوسته‌ها و تنظیمات";
 

--- a/Core/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -96,6 +96,8 @@
 "menu.twoPages" = "2 pages côte à côte (en paysage)";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.verticalScrolling" = "Défilement vertical";
+"menu.linePageDividers" = "Séparateurs de lignes";
+"menu.linePageSidelines" = "Lignes latérales";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "Thèmes et paramètres";
 

--- a/Core/Localization/Sources/Resources/kk.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/kk.lproj/Localizable.strings
@@ -82,6 +82,8 @@
 "menu.twoPages" = "2 бет жанасып (альбомдық бетте)";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.verticalScrolling" = "Тік жылжыту";
+"menu.linePageDividers" = "Жол бөлгіштері";
+"menu.linePageSidelines" = "Бүйір сызықтар";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "Тақырыптар мен параметрлер";
 

--- a/Core/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -79,6 +79,8 @@
 "menu.twoPages" = "2 halaman bersebelahan (dalam landskap)";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.verticalScrolling" = "Skrol menegak";
+"menu.linePageDividers" = "Pemisah baris";
+"menu.linePageSidelines" = "Garis sisi";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "Tema & Tetapan";
 

--- a/Core/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -66,6 +66,8 @@
 "menu.arabicFontSize" = "Koran Grootte";
 "menu.twoPages" = "2 pagina's naast elkaar (liggend)";
 "menu.verticalScrolling" = "Verticaal scrollen";
+"menu.linePageDividers" = "Regelscheiding";
+"menu.linePageSidelines" = "Zijlijnen";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "Thema's en instellingen";
 

--- a/Core/Localization/Sources/Resources/pt.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/pt.lproj/Localizable.strings
@@ -96,6 +96,8 @@
 "menu.twoPages" = "2 páginas lado a lado (em paisagem)";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.verticalScrolling" = "Rolagem vertical";
+"menu.linePageDividers" = "Separadores de linha";
+"menu.linePageSidelines" = "Linhas laterais";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "Temas e configurações";
 

--- a/Core/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -96,6 +96,8 @@
 "menu.twoPages" = "2 страницы рядом (в альбомном формате)";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.verticalScrolling" = "Вертикальная прокрутка";
+"menu.linePageDividers" = "Разделители строк";
+"menu.linePageSidelines" = "Боковые линии";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "Темы и настройки";
 

--- a/Core/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -71,6 +71,8 @@
 "menu.twoPages" = "Yan yana 2 sayfa (yatayda)";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.verticalScrolling" = "Dikey kaydırma";
+"menu.linePageDividers" = "Satır ayırıcıları";
+"menu.linePageSidelines" = "Yan çizgiler";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "Temalar ve ayarlar";
 

--- a/Core/Localization/Sources/Resources/ug.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ug.lproj/Localizable.strings
@@ -96,6 +96,8 @@
 "menu.twoPages" = "ئىككى بەت يانما-يان (شەكىل تەرتىپىدە)";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.verticalScrolling" = "تىك مېكىش";
+"menu.linePageDividers" = "قۇر ئايرىغۇچلار";
+"menu.linePageSidelines" = "يان سىزىقلار";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "ئۆرنەك ۋە تەڭشەك";
 

--- a/Core/Localization/Sources/Resources/uz.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/uz.lproj/Localizable.strings
@@ -96,6 +96,8 @@
 "menu.twoPages" = "Yonma-yon 2 sahifa (gorizontal formatda)";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.verticalScrolling" = "Vertikal aylantirish";
+"menu.linePageDividers" = "Qator ajratgichlari";
+"menu.linePageSidelines" = "Yon chiziqlar";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "Mavzular va sozlamalar";
 

--- a/Core/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -66,6 +66,8 @@
 "menu.arabicFontSize" = "Cỡ chữ Quran";
 "menu.twoPages" = "2 trang cạnh nhau (xoay ngang)";
 "menu.verticalScrolling" = "Cuộn dọc";
+"menu.linePageDividers" = "Đường phân cách dòng";
+"menu.linePageSidelines" = "Đường bên";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "Chủ đề & Cài đặt";
 

--- a/Core/Localization/Sources/Resources/zh.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/zh.lproj/Localizable.strings
@@ -96,6 +96,8 @@
 "menu.twoPages" = "2页并排（横向模式）";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.verticalScrolling" = "垂直滚动";
+"menu.linePageDividers" = "行分隔线";
+"menu.linePageSidelines" = "侧边线";
 // Metadata: Translated by ChatGPT; human review required.
 "menu.theme_settings" = "主题和设置";
 

--- a/Domain/QuranTextKit/Sources/Preferences/QuranContentStatePreferences.swift
+++ b/Domain/QuranTextKit/Sources/Preferences/QuranContentStatePreferences.swift
@@ -26,11 +26,19 @@ public struct QuranContentStatePreferences {
     @Preference(verticalScrollingEnabled)
     public var verticalScrollingEnabled: Bool
 
+    @Preference(showLinePageDividers)
+    public var showLinePageDividers: Bool
+
+    @Preference(showLinePageSidelines)
+    public var showLinePageSidelines: Bool
+
     // MARK: Private
 
     private static let showQuranTranslationView = PreferenceKey<Bool>(key: "showQuranTranslationView", defaultValue: false)
     private static let twoPagesEnabled = PreferenceKey<Bool>(key: "twoPagesEnabled", defaultValue: TwoPagesUtils.settingDefaultValue)
     private static let verticalScrollingEnabled = PreferenceKey<Bool>(key: "verticalScrollingEnabled", defaultValue: false)
+    private static let showLinePageDividers = PreferenceKey<Bool>(key: "showLinePageDividers", defaultValue: true)
+    private static let showLinePageSidelines = PreferenceKey<Bool>(key: "showLinePageSidelines", defaultValue: true)
 
     private static let quranModeTransfomer = PreferenceTransformer<Bool, QuranMode>(
         rawToValue: { $0 ? .translation : .arabic },

--- a/Features/MoreMenuFeature/Sources/MoreMenuModel.swift
+++ b/Features/MoreMenuFeature/Sources/MoreMenuModel.swift
@@ -35,6 +35,7 @@ public struct MoreMenuControlsState {
     public var mode = ConfigState.conditional
     public var translationsSelection = ConfigState.conditional
     public var wordPointer = ConfigState.conditional
+    public var linePageDisplay = ConfigState.alwaysOff
     public var orientation = ConfigState.conditional
     public var fontSize = ConfigState.conditional
     public var twoPages = ConfigState.conditional

--- a/Features/MoreMenuFeature/Sources/MoreMenuViewModel.swift
+++ b/Features/MoreMenuFeature/Sources/MoreMenuViewModel.swift
@@ -34,6 +34,8 @@ final class MoreMenuViewModel: ObservableObject {
         arabicFontSize = fontSizePreferences.arabicFontSize
         twoPagesEnabled = preferences.twoPagesEnabled
         verticalScrollingEnabled = preferences.verticalScrollingEnabled
+        showLinePageDividers = preferences.showLinePageDividers
+        showLinePageSidelines = preferences.showLinePageSidelines
         appearanceMode = themeService.appearanceMode
 
         state.twoPages = (model.state.twoPages == .conditional && TwoPagesUtils.hasEnoughHorizontalSpace()) ? .conditional : .alwaysOff
@@ -94,6 +96,22 @@ final class MoreMenuViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
+        $showLinePageDividers
+            .dropFirst()
+            .sink { [weak self] newValue in
+                logger.info("More Menu: set line page dividers visible \(newValue)")
+                self?.preferences.showLinePageDividers = newValue
+            }
+            .store(in: &cancellables)
+
+        $showLinePageSidelines
+            .dropFirst()
+            .sink { [weak self] newValue in
+                logger.info("More Menu: set line page sidelines visible \(newValue)")
+                self?.preferences.showLinePageSidelines = newValue
+            }
+            .store(in: &cancellables)
+
         $appearanceMode
             .dropFirst()
             .sink { [weak self] newValue in
@@ -126,6 +144,8 @@ final class MoreMenuViewModel: ObservableObject {
 
     @Published var twoPagesEnabled: Bool
     @Published var verticalScrollingEnabled: Bool
+    @Published var showLinePageDividers: Bool
+    @Published var showLinePageSidelines: Bool
 
     @Published var appearanceMode: AppearanceMode
 

--- a/Features/MoreMenuFeature/Sources/views/MoreMenuLinePageDisplay.swift
+++ b/Features/MoreMenuFeature/Sources/views/MoreMenuLinePageDisplay.swift
@@ -1,0 +1,27 @@
+import Localization
+import SwiftUI
+
+struct MoreMenuLinePageDisplay: View {
+    @Binding var showDividers: Bool
+    @Binding var showSidelines: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Toggle(l("menu.linePageDividers"), isOn: $showDividers)
+                .padding()
+
+            Divider()
+                .padding(.leading)
+
+            Toggle(l("menu.linePageSidelines"), isOn: $showSidelines)
+                .padding()
+        }
+    }
+}
+
+#Preview {
+    MoreMenuLinePageDisplay(
+        showDividers: .constant(true),
+        showSidelines: .constant(true)
+    )
+}

--- a/Features/MoreMenuFeature/Sources/views/MoreMenuView.swift
+++ b/Features/MoreMenuFeature/Sources/views/MoreMenuView.swift
@@ -70,6 +70,15 @@ private struct MoreMenuRootView: View {
                         empty
                     }
 
+                    viewBasedOn(state.linePageDisplay, customCondition: store.mode == .arabic) {
+                        MoreMenuLinePageDisplay(
+                            showDividers: $store.showLinePageDividers,
+                            showSidelines: $store.showLinePageSidelines
+                        )
+                        .background(Color.systemBackground)
+                        empty
+                    }
+
                     viewBasedOn(state.orientation, customCondition: store.mode == .arabic) {
                         MoreMenuDeviceRotation()
                             .background(Color.systemBackground)

--- a/Features/QuranImageFeature/Sources/ContentImageBuilder.swift
+++ b/Features/QuranImageFeature/Sources/ContentImageBuilder.swift
@@ -38,9 +38,7 @@ public struct ContentImageBuilder {
                 reading: reading,
                 page: page,
                 linePageAssetService: linePageAssetService,
-                highlightsService: highlightsService,
-                showSidelines: reading.usesLinePageSidelines,
-                showLineDividers: reading.usesLinePageDividers
+                highlightsService: highlightsService
             )
             ContentLineView(viewModel: viewModel)
         } else {

--- a/Features/QuranImageFeature/Sources/ContentLineViewModel.swift
+++ b/Features/QuranImageFeature/Sources/ContentLineViewModel.swift
@@ -13,6 +13,7 @@ import NoorUI
 import QuranAnnotations
 import QuranGeometry
 import QuranKit
+import QuranTextKit
 import SwiftUI
 import VLogging
 
@@ -24,15 +25,14 @@ final class ContentLineViewModel: ObservableObject {
         reading: Reading,
         page: Page,
         linePageAssetService: LinePageAssetService,
-        highlightsService: QuranHighlightsService,
-        showSidelines: Bool = false,
-        showLineDividers: Bool = false
+        highlightsService: QuranHighlightsService
     ) {
         self.reading = reading
         self.page = page
         self.linePageAssetService = linePageAssetService
-        self.showSidelines = showSidelines
-        self.showLineDividers = showLineDividers
+        let contentStatePreferences = QuranContentStatePreferences.shared
+        showSidelines = reading.usesLinePageSidelines && contentStatePreferences.showLinePageSidelines
+        showLineDividers = reading.usesLinePageDividers && contentStatePreferences.showLinePageDividers
         linePageMetrics = reading.linePageMetrics ?? .madaniLinePages(widthParameter: 1080)
         highlights = highlightsService.highlights
 
@@ -46,6 +46,18 @@ final class ContentLineViewModel: ObservableObject {
 
         highlightsService.$highlights
             .sink { [weak self] in self?.highlights = $0 }
+            .store(in: &cancellables)
+
+        contentStatePreferences.$showLinePageSidelines
+            .sink { [weak self] showSidelines in
+                self?.showSidelines = reading.usesLinePageSidelines && showSidelines
+            }
+            .store(in: &cancellables)
+
+        contentStatePreferences.$showLinePageDividers
+            .sink { [weak self] showLineDividers in
+                self?.showLineDividers = reading.usesLinePageDividers && showLineDividers
+            }
             .store(in: &cancellables)
 
         highlightsService.scrolling
@@ -193,8 +205,8 @@ final class ContentLineViewModel: ObservableObject {
     private let reading: Reading
     private let linePageAssetService: LinePageAssetService
     private let linePageMetrics: LinePageMetrics
-    private let showSidelines: Bool
-    private let showLineDividers: Bool
+    @Published private var showSidelines: Bool
+    @Published private var showLineDividers: Bool
     private let wordFrameAdapter = LinePageWordFrameAdapter()
     private let geometryEngine = LinePageGeometryEngine()
     private var cancellables: Set<AnyCancellable> = []

--- a/Features/QuranViewFeature/Sources/QuranInteractor.swift
+++ b/Features/QuranViewFeature/Sources/QuranInteractor.swift
@@ -175,6 +175,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         logger.info("Quran: more bar button tapped")
         var state = MoreMenuControlsState()
         state.wordPointer = readingPreferences.reading.supportsWordPositions ? .conditional : .alwaysOff
+        state.linePageDisplay = readingPreferences.reading == .indoPak ? .conditional : .alwaysOff
         // TODO: Enable vertical scrolling.
         state.verticalScrolling = .alwaysOff
         let model = MoreMenuModel(isWordPointerActive: isWordPointerActive, state: state)


### PR DESCRIPTION
## Summary

- add persisted IndoPak-only toggles for line dividers and side lines
- update line-page rendering immediately when either setting changes
- localize both menu labels across all supported languages

## Testing

- [x] SwiftFormat lint
- [x] MoreMenuFeatureTests
- [x] LocalizationTests
- [x] `quran-ios-private` Debug build and Simulator UI verification

## Screenshots

| Settings | Lines enabled | Lines disabled |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/34619199-b36b-4f77-b785-ffd8a83b6acb" width="300" alt="IndoPak display settings"> | <img src="https://github.com/user-attachments/assets/5bbe17ca-0af2-4655-b638-c36d661ae924" width="300" alt="IndoPak lines enabled"> | <img src="https://github.com/user-attachments/assets/35952067-3aa1-45f4-a165-3287d0f54477" width="300" alt="IndoPak lines disabled"> |
