### PR TITLE
fix: use IndoPak sura names

### DIFF
--- a/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -20,6 +20,13 @@
 "surah" = "السورة";
 "quran_alquran" = "القرآن";
 
+// IndoPak sura names
+"quran.sura-name.indopak.17" = "بَنِي إِسْرَائِيل";
+"quran.sura-name.indopak.40" = "الْمُؤْمِن";
+"quran.sura-name.indopak.41" = "حمٓ السَّجْدَة";
+"quran.sura-name.indopak.76" = "الدَّهْر";
+"quran.sura-name.indopak.111" = "اللَّهَب";
+
 // MARK: - Translation
 
 "translation.text-type.translation" = "الترجمة إلى الإنجليزية";

--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -24,6 +24,13 @@
 // Metadata: Translated by AI; human review required.
 "quran_alquran" = "Quran";
 
+// IndoPak sura names
+"quran.sura-name.indopak.17" = "Banī Isrā’īl";
+"quran.sura-name.indopak.40" = "Al-Mu’min";
+"quran.sura-name.indopak.41" = "Ḥā-Mīm al-Sajdah";
+"quran.sura-name.indopak.76" = "Al-Dahr";
+"quran.sura-name.indopak.111" = "Al-Lahab";
+
 // MARK: - Translation
 
 "translation.text-type.translation" = "Translation";

--- a/Core/Localization/Tests/LocalizationCatalogTests.swift
+++ b/Core/Localization/Tests/LocalizationCatalogTests.swift
@@ -8,9 +8,13 @@ final class LocalizationCatalogTests: XCTestCase {
 
         for localization in supportedLocalizations where localization != "en" {
             let localized = try strings(for: localization)
+            let englishKeys = Set(english.keys)
+            let expectedKeys = localization == "ar"
+                ? englishKeys
+                : englishKeys.subtracting(englishFallbackKeys)
             XCTAssertEqual(
                 Set(localized.keys),
-                Set(english.keys),
+                expectedKeys,
                 "\(localization) Localizable.strings keys differ from English."
             )
 
@@ -68,6 +72,14 @@ final class LocalizationCatalogTests: XCTestCase {
         "uz",
         "vi",
         "zh",
+    ]
+
+    private let englishFallbackKeys: Set<String> = [
+        "quran.sura-name.indopak.17",
+        "quran.sura-name.indopak.40",
+        "quran.sura-name.indopak.41",
+        "quran.sura-name.indopak.76",
+        "quran.sura-name.indopak.111",
     ]
 
     private func strings(for localization: String) throws -> [String: String] {

--- a/Model/QuranLocalization/Sources/QuranKit+Localization.swift
+++ b/Model/QuranLocalization/Sources/QuranKit+Localization.swift
@@ -79,10 +79,25 @@ extension Sura {
     }
 
     public func localizedName(withPrefix: Bool = false, language: Language? = nil) -> String {
-        var suraName = l("sura_names[\(suraNumber - 1)]", table: .suras, language: language)
+        var suraName = if quran == .hafsIndoPak, let localizationKey = indoPakNameLocalizationKey {
+            l(localizationKey, language: language)
+        } else {
+            l("sura_names[\(suraNumber - 1)]", table: .suras, language: language)
+        }
         if withPrefix {
             suraName = lFormat("quran_sura_title", table: .android, language: language, suraName)
         }
         return suraName
+    }
+
+    private var indoPakNameLocalizationKey: String? {
+        switch suraNumber {
+        case 17: "quran.sura-name.indopak.17"
+        case 40: "quran.sura-name.indopak.40"
+        case 41: "quran.sura-name.indopak.41"
+        case 76: "quran.sura-name.indopak.76"
+        case 111: "quran.sura-name.indopak.111"
+        default: nil
+        }
     }
 }

--- a/Model/QuranLocalization/Tests/QuranKitLocalizationTests.swift
+++ b/Model/QuranLocalization/Tests/QuranKitLocalizationTests.swift
@@ -44,6 +44,64 @@ final class QuranKitLocalizationTests: XCTestCase {
         XCTAssertEqual("Juz' 30", quran.pages[599].localizedQuarterName)
     }
 
+    func testIndoPakSuraNamesUseReadingSpecificEnglishNames() {
+        let names = [
+            17: "Banī Isrā’īl",
+            40: "Al-Mu’min",
+            41: "Ḥā-Mīm al-Sajdah",
+            76: "Al-Dahr",
+            111: "Al-Lahab",
+        ]
+
+        for (suraNumber, name) in names {
+            XCTAssertEqual(
+                name,
+                Quran.hafsIndoPak.suras[suraNumber - 1].localizedName(language: .english)
+            )
+        }
+    }
+
+    func testIndoPakSuraNamesUseReadingSpecificArabicNames() {
+        let names = [
+            17: "بَنِي إِسْرَائِيل",
+            40: "الْمُؤْمِن",
+            41: "حمٓ السَّجْدَة",
+            76: "الدَّهْر",
+            111: "اللَّهَب",
+        ]
+
+        for (suraNumber, name) in names {
+            XCTAssertEqual(
+                name,
+                Quran.hafsIndoPak.suras[suraNumber - 1].localizedName(language: .arabic)
+            )
+        }
+    }
+
+    func testMadaniSuraNamesRemainUnchanged() {
+        let names = [
+            17: "Al-Isrāʾ",
+            40: "Ghāfir",
+            41: "Fuṣṣilat",
+            76: "Al-Insān",
+            111: "Al-Masad",
+        ]
+
+        for (suraNumber, name) in names {
+            XCTAssertEqual(
+                name,
+                Quran.hafsMadani1405.suras[suraNumber - 1].localizedName(language: .english)
+            )
+        }
+    }
+
+    func testOtherIndoPakSuraNamesContinueUsingSurasCatalog() {
+        XCTAssertEqual(
+            Quran.hafsMadani1405.firstSura.localizedName(language: .english),
+            Quran.hafsIndoPak.firstSura.localizedName(language: .english)
+        )
+    }
+
     // MARK: Private
 
     private let quran = Quran.hafsMadani1405

--- a/UI/NoorUI/Sources/Components/QuranReference.swift
+++ b/UI/NoorUI/Sources/Components/QuranReference.swift
@@ -20,6 +20,13 @@ enum QuranReference {
             case .decoratedGlyph(let text), .indoPakText(let text): text
             }
         }
+
+        var isIndoPakText: Bool {
+            if case .indoPakText = self {
+                return true
+            }
+            return false
+        }
     }
 
     case sura(Sura)
@@ -93,10 +100,10 @@ enum QuranReference {
         case .decoratedGlyph: size.suraUIFont
         case .indoPakText: size.quranUIFont(.indoPak)
         }
-        let arabicNameAttributes: [NSAttributedString.Key: Any] = [
-            .font: arabicNameFont,
-            .baselineOffset: -2,
-        ]
+        var arabicNameAttributes: [NSAttributedString.Key: Any] = [.font: arabicNameFont]
+        if !arabicName.isIndoPakText {
+            arabicNameAttributes[.baselineOffset] = -2
+        }
         result.append(NSAttributedString(string: arabicName.text, attributes: arabicNameAttributes))
 
         if let coordinate = coordinate(locale: locale) {
@@ -166,14 +173,15 @@ struct QuranReferenceView: View {
     @ScaledMetric private var glyphTopPadding = 5
 
     var body: some View {
-        HStack(spacing: spacing) {
+        let arabicName = reference.arabicName
+        HStack(alignment: arabicName.isIndoPakText ? .firstTextBaseline : .center, spacing: spacing) {
             if let localizedName = reference.localizedName(locale: locale) {
                 Text(localizedName)
                     .font(size.plainFont)
                     .fontWeight(emphasizesSura ? .heavy : nil)
             }
 
-            switch reference.arabicName {
+            switch arabicName {
             case .decoratedGlyph(let text):
                 Text(text)
                     .font(size.suraFont)
@@ -181,7 +189,6 @@ struct QuranReferenceView: View {
             case .indoPakText(let text):
                 Text(text)
                     .font(size.quranFont(.indoPak))
-                    .padding(.top, glyphTopPadding)
             }
 
             if let coordinate = reference.coordinate(locale: locale) {

--- a/UI/NoorUI/Sources/Components/QuranReference.swift
+++ b/UI/NoorUI/Sources/Components/QuranReference.swift
@@ -11,6 +11,17 @@ import SwiftUI
 import UIKit
 
 enum QuranReference {
+    fileprivate enum ArabicName {
+        case decoratedGlyph(String)
+        case indoPakText(String)
+
+        var text: String {
+            switch self {
+            case .decoratedGlyph(let text), .indoPakText(let text): text
+            }
+        }
+    }
+
     case sura(Sura)
     case ayah(AyahNumber)
 
@@ -28,6 +39,13 @@ enum QuranReference {
     fileprivate var decoratedGlyph: String {
         let codePoint = Self.decoratedSuraNameCodePoints[sura.suraNumber - 1]
         return String(UnicodeScalar(codePoint)!)
+    }
+
+    fileprivate var arabicName: ArabicName {
+        if sura.quran == .hafsIndoPak {
+            return .indoPakText(sura.localizedName(language: .arabic))
+        }
+        return .decoratedGlyph(decoratedGlyph)
     }
 
     fileprivate func localizedName(locale: Locale) -> String? {
@@ -48,7 +66,7 @@ enum QuranReference {
         if let localizedName = localizedName(locale: locale) {
             components.append(localizedName)
         }
-        components.append(decoratedGlyph)
+        components.append(arabicName.text)
 
         let suraReference = components.joined(separator: " ")
         if let coordinate = coordinate(locale: locale) {
@@ -71,11 +89,15 @@ enum QuranReference {
             result.append(NSAttributedString(string: " "))
         }
 
-        let glyphAttributes: [NSAttributedString.Key: Any] = [
-            .font: size.suraUIFont,
+        let arabicNameFont: UIFont = switch arabicName {
+        case .decoratedGlyph: size.suraUIFont
+        case .indoPakText: size.quranUIFont(.indoPak)
+        }
+        let arabicNameAttributes: [NSAttributedString.Key: Any] = [
+            .font: arabicNameFont,
             .baselineOffset: -2,
         ]
-        result.append(NSAttributedString(string: decoratedGlyph, attributes: glyphAttributes))
+        result.append(NSAttributedString(string: arabicName.text, attributes: arabicNameAttributes))
 
         if let coordinate = coordinate(locale: locale) {
             result.append(NSAttributedString(
@@ -151,9 +173,16 @@ struct QuranReferenceView: View {
                     .fontWeight(emphasizesSura ? .heavy : nil)
             }
 
-            Text(reference.decoratedGlyph)
-                .font(size.suraFont)
-                .padding(.top, glyphTopPadding)
+            switch reference.arabicName {
+            case .decoratedGlyph(let text):
+                Text(text)
+                    .font(size.suraFont)
+                    .padding(.top, glyphTopPadding)
+            case .indoPakText(let text):
+                Text(text)
+                    .font(size.quranFont(.indoPak))
+                    .padding(.top, glyphTopPadding)
+            }
 
             if let coordinate = reference.coordinate(locale: locale) {
                 Text("·")

--- a/UI/NoorUI/Tests/MultipartTextQuranTests.swift
+++ b/UI/NoorUI/Tests/MultipartTextQuranTests.swift
@@ -27,6 +27,25 @@ final class MultipartTextQuranTests: XCTestCase {
         XCTAssertEqual(text.rawValue(locale: Locale(identifier: "fa-IR")), "\(sura.localizedName()) \u{E905}")
     }
 
+    func test_indoPakSuraReference_usesArabicTextInsteadOfDecoratedGlyph() {
+        let sura = Quran.hafsIndoPak.suras[1]
+        let text: MultipartText = "\(sura: sura)"
+
+        XCTAssertEqual(
+            text.rawValue(locale: english),
+            "\(sura.localizedName()) \(sura.localizedName(language: .arabic))"
+        )
+        XCTAssertEqual(text.rawValue(locale: arabic), sura.localizedName(language: .arabic))
+    }
+
+    func test_indoPakSuraReference_usesReadingSpecificArabicName() {
+        let sura = Quran.hafsIndoPak.suras[16]
+        let text: MultipartText = "\(sura: sura)"
+
+        XCTAssertEqual(text.rawValue(locale: english), "Banī Isrā’īl بَنِي إِسْرَائِيل")
+        XCTAssertEqual(text.rawValue(locale: arabic), "بَنِي إِسْرَائِيل")
+    }
+
     func test_ayahReference_inNonArabicLocale_usesCanonicalReference() {
         let text: MultipartText = "\(ayah: ayah)"
 


### PR DESCRIPTION
## Summary

- use reading-specific names for the five suras that differ in the IndoPak mushaf
- add fully marked Arabic names and accented English transliterations to `Localizable.strings`
- fall back to English for other localizations while keeping Madani names unchanged
- render every IndoPak Arabic sura name with the bundled Noorehira font for a consistent style

## Testing

- `make format-lint`
- `make test-no-sync TARGET=LocalizationTests`
- `make test-sync TARGET=LocalizationTests`
- `make test-no-sync TARGET=QuranLocalizationTests`
- `make test-sync TARGET=QuranLocalizationTests`
- `make test-no-sync TARGET=NoorUITests`
- `make test-sync TARGET=NoorUITests`
- `plutil -lint` for English and Arabic `Localizable.strings`
- `git diff --check`

## Screenshot

<img src="https://github.com/user-attachments/assets/2aba86f1-b130-431a-a25a-38015273f8c5" width="300">