### PR TITLE
fix: normalize IndoPak list spacing

### DIFF
--- a/UI/NoorUI/Sources/Components/MultipartText.swift
+++ b/UI/NoorUI/Sources/Components/MultipartText.swift
@@ -72,6 +72,7 @@ private struct TextPartView: View {
                 } : []
             )
             .optionalLineLimit(lineLimit)
+            .padding(.vertical, size.quranTextVerticalPadding(quranFont))
             .padding(quranTextPadding)
             .background(color)
         }

--- a/UI/NoorUI/Sources/Components/QuranReference.swift
+++ b/UI/NoorUI/Sources/Components/QuranReference.swift
@@ -189,6 +189,7 @@ struct QuranReferenceView: View {
             case .indoPakText(let text):
                 Text(text)
                     .font(size.quranFont(.indoPak))
+                    .padding(.vertical, size.indoPakReferenceVerticalPadding(glyphTopPadding: glyphTopPadding))
             }
 
             if let coordinate = reference.coordinate(locale: locale) {
@@ -233,6 +234,20 @@ extension MultipartText.FontSize {
             return quranUIFont(quranFont)
         }
         return UIFont(descriptor: descriptor, size: quranUIFont(quranFont).pointSize)
+    }
+
+    func quranTextVerticalPadding(_ quranFont: QuranFont) -> CGFloat {
+        guard quranFont == .indoPak else {
+            return 0
+        }
+        let excessLineHeight = quranUIFont(.indoPak).lineHeight - quranUIFont(.uthmanicHafs).lineHeight
+        return -max(0, excessLineHeight / 2)
+    }
+
+    func indoPakReferenceVerticalPadding(glyphTopPadding: CGFloat) -> CGFloat {
+        let madaniReferenceHeight = max(plainUIFont.lineHeight, suraUIFont.lineHeight + glyphTopPadding)
+        let excessLineHeight = quranUIFont(.indoPak).lineHeight - madaniReferenceHeight
+        return -max(0, excessLineHeight / 2)
     }
 
     private var uiTextStyle: UIFont.TextStyle {

--- a/UI/NoorUI/Tests/QuranTextViewTests.swift
+++ b/UI/NoorUI/Tests/QuranTextViewTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Localization
+import NoorFont
 import QuranKit
 import QuranText
 import SwiftUI
@@ -45,11 +46,46 @@ final class QuranTextViewTests: XCTestCase {
         XCTAssertEqual(sizes.1.height, sizes.0.height, accuracy: 1)
     }
 
+    func test_indopakJuzRow_matchesMadaniVerticalSpacing() async {
+        let sizes = await MainActor.run {
+            FontName.registerFonts()
+            let value = QuranText("بِسْمِ اللَّهِ الرَّحْمَنِ الرَّحِيمِ ١")
+            let uthmanicText: MultipartText = "\(quran: value, font: .uthmanicHafs, lineLimit: 1)"
+            let indoPakText: MultipartText = "\(quran: value, font: .indoPak, lineLimit: 1)"
+            let madaniReference: MultipartText = "\(ayah: Quran.hafsMadani1405.firstVerse)"
+            let indoPakReference: MultipartText = "\(ayah: Quran.hafsIndoPak.firstVerse)"
+            let madaniItem = NoorListItem(
+                subheading: "Hizb 1",
+                title: madaniReference,
+                rightSubtitle: uthmanicText,
+                accessory: .text("1")
+            )
+            let indoPakItem = NoorListItem(
+                subheading: "Hizb 1",
+                title: indoPakReference,
+                rightSubtitle: indoPakText,
+                accessory: .text("2")
+            )
+            return (
+                constrainedSize(madaniItem),
+                constrainedSize(indoPakItem)
+            )
+        }
+
+        XCTAssertEqual(sizes.1.height, sizes.0.height, accuracy: 1)
+    }
+
     @MainActor
     private func fittingSize(_ content: some View) -> CGSize {
         let controller = UIHostingController(rootView: content.fixedSize())
         return controller.sizeThatFits(
             in: CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         )
+    }
+
+    @MainActor
+    private func constrainedSize(_ content: some View) -> CGSize {
+        let controller = UIHostingController(rootView: content)
+        return controller.sizeThatFits(in: CGSize(width: 300, height: 1000))
     }
 }


### PR DESCRIPTION
## Summary

- Trim Noorehira's excess vertical font metrics in Quran snippets and IndoPak sura references.
- Make IndoPak Juz' and Notes spacing consistent with Madani 1405.
- Add a regression test for the complete Juz' row height.

## Screenshots

### Juz'

| Reading | Before | After |
| --- | --- | --- |
| IndoPak | <img src="https://github.com/user-attachments/assets/43addd6a-40f2-4482-91dc-85df55accaae" width="300"> | <img src="https://github.com/user-attachments/assets/f347bd74-738d-4a06-b12c-ce36df3f5447" width="300"> |
| Madani 1405 | <img src="https://github.com/user-attachments/assets/03ebd4a0-f9b4-4723-b67b-c8ac37811fba" width="300"> | <img src="https://github.com/user-attachments/assets/5d67b336-4479-4c13-b99b-88e2671c0b78" width="300"> |

### Notes

| Reading | Before | After |
| --- | --- | --- |
| IndoPak | <img src="https://github.com/user-attachments/assets/a001e3d0-eaaf-49b7-bd8c-92c2c46815ba" width="300"> | <img src="https://github.com/user-attachments/assets/bcf75622-8f69-47a8-9915-b91871eeff0c" width="300"> |
| Madani 1405 | <img src="https://github.com/user-attachments/assets/561511b7-a635-44e4-b80c-0678d1b5c338" width="300"> | <img src="https://github.com/user-attachments/assets/44e46b87-81f8-4935-8bce-15823a18ad85" width="300"> |

## Testing

- make format-lint
- make test-no-sync TARGET=NoorUITests
- make test-sync TARGET=NoorUITests
- Private app build and run on the iPhone 17e simulator
- Verified the IndoPak Juz' row shrinks from 174.3 pt to 124.3 pt, matching Madani 1405
- git diff --check
