### PR TITLE
feat: show translated sura names

### DIFF
--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -30,6 +30,11 @@
 "quran.sura-name.indopak.41" = "Ḥā-Mīm al-Sajdah";
 "quran.sura-name.indopak.76" = "Al-Dahr";
 "quran.sura-name.indopak.111" = "Al-Lahab";
+"quran.sura-name-translation.indopak.17" = "Children of Israel";
+"quran.sura-name-translation.indopak.40" = "The Believer";
+"quran.sura-name-translation.indopak.41" = "Ḥā-Mīm The Prostration";
+"quran.sura-name-translation.indopak.76" = "The Time";
+"quran.sura-name-translation.indopak.111" = "The Flame";
 
 // MARK: - Translation
 

--- a/Core/Localization/Tests/LocalizationCatalogTests.swift
+++ b/Core/Localization/Tests/LocalizationCatalogTests.swift
@@ -9,9 +9,10 @@ final class LocalizationCatalogTests: XCTestCase {
         for localization in supportedLocalizations where localization != "en" {
             let localized = try strings(for: localization)
             let englishKeys = Set(english.keys)
-            let expectedKeys = localization == "ar"
-                ? englishKeys
-                : englishKeys.subtracting(englishFallbackKeys)
+            let fallbackKeys = localization == "ar"
+                ? englishOnlyFallbackKeys
+                : englishFallbackKeys
+            let expectedKeys = englishKeys.subtracting(fallbackKeys)
             XCTAssertEqual(
                 Set(localized.keys),
                 expectedKeys,
@@ -80,6 +81,19 @@ final class LocalizationCatalogTests: XCTestCase {
         "quran.sura-name.indopak.41",
         "quran.sura-name.indopak.76",
         "quran.sura-name.indopak.111",
+        "quran.sura-name-translation.indopak.17",
+        "quran.sura-name-translation.indopak.40",
+        "quran.sura-name-translation.indopak.41",
+        "quran.sura-name-translation.indopak.76",
+        "quran.sura-name-translation.indopak.111",
+    ]
+
+    private let englishOnlyFallbackKeys: Set<String> = [
+        "quran.sura-name-translation.indopak.17",
+        "quran.sura-name-translation.indopak.40",
+        "quran.sura-name-translation.indopak.41",
+        "quran.sura-name-translation.indopak.76",
+        "quran.sura-name-translation.indopak.111",
     ]
 
     private func strings(for localization: String) throws -> [String: String] {

--- a/Features/HomeFeature/Sources/HomeView.swift
+++ b/Features/HomeFeature/Sources/HomeView.swift
@@ -133,11 +133,11 @@ private struct HomeViewUI: View {
     func suraView(_ sura: Sura) -> some View {
         let ayahsString = lFormat("verses", table: .android, sura.verses.count)
         let suraType = sura.isMakki ? lAndroid("makki") : lAndroid("madani")
-        let subtitle = if Locale.preferredLanguageLocale.isArabicLanguage {
-            "\(suraType) - \(ayahsString)"
-        } else {
-            "\(sura.localizedTranslatedName()) · \(suraType) · \(ayahsString)"
+        var subtitleComponents = [suraType, ayahsString]
+        if !Locale.preferredLanguageLocale.isArabicLanguage {
+            subtitleComponents.insert(sura.localizedTranslatedName(), at: 0)
         }
+        let subtitle = subtitleComponents.joined(separator: " · ")
 
         return NoorListItem(
             title: "\(sura.localizedSuraNumber). \(sura: sura)",

--- a/Features/HomeFeature/Sources/HomeView.swift
+++ b/Features/HomeFeature/Sources/HomeView.swift
@@ -133,10 +133,15 @@ private struct HomeViewUI: View {
     func suraView(_ sura: Sura) -> some View {
         let ayahsString = lFormat("verses", table: .android, sura.verses.count)
         let suraType = sura.isMakki ? lAndroid("makki") : lAndroid("madani")
+        let subtitle = if Locale.preferredLanguageLocale.isArabicLanguage {
+            "\(suraType) - \(ayahsString)"
+        } else {
+            "\(sura.localizedTranslatedName()) · \(suraType) · \(ayahsString)"
+        }
 
         return NoorListItem(
             title: "\(sura.localizedSuraNumber). \(sura: sura)",
-            subtitle: .init(text: "\(suraType) - \(ayahsString)", location: .bottom),
+            subtitle: .init(text: .text(subtitle), location: .bottom),
             accessory: .text(sura.page.localizedNumber, accessibilityLabel: sura.page.localizedName),
             action: .sync { selectSura(sura) }
         )

--- a/Model/QuranLocalization/Sources/QuranKit+Localization.swift
+++ b/Model/QuranLocalization/Sources/QuranKit+Localization.swift
@@ -90,6 +90,13 @@ extension Sura {
         return suraName
     }
 
+    public func localizedTranslatedName(language: Language? = nil) -> String {
+        if quran == .hafsIndoPak, let localizationKey = indoPakTranslatedNameLocalizationKey {
+            return l(localizationKey, language: language)
+        }
+        return l("sura_names_translation[\(suraNumber - 1)]", table: .suras, language: language)
+    }
+
     private var indoPakNameLocalizationKey: String? {
         switch suraNumber {
         case 17: "quran.sura-name.indopak.17"
@@ -97,6 +104,17 @@ extension Sura {
         case 41: "quran.sura-name.indopak.41"
         case 76: "quran.sura-name.indopak.76"
         case 111: "quran.sura-name.indopak.111"
+        default: nil
+        }
+    }
+
+    private var indoPakTranslatedNameLocalizationKey: String? {
+        switch suraNumber {
+        case 17: "quran.sura-name-translation.indopak.17"
+        case 40: "quran.sura-name-translation.indopak.40"
+        case 41: "quran.sura-name-translation.indopak.41"
+        case 76: "quran.sura-name-translation.indopak.76"
+        case 111: "quran.sura-name-translation.indopak.111"
         default: nil
         }
     }

--- a/Model/QuranLocalization/Tests/QuranKitLocalizationTests.swift
+++ b/Model/QuranLocalization/Tests/QuranKitLocalizationTests.swift
@@ -102,6 +102,47 @@ final class QuranKitLocalizationTests: XCTestCase {
         )
     }
 
+    func testIndoPakTranslatedSuraNamesUseReadingSpecificEnglishNames() {
+        let names = [
+            17: "Children of Israel",
+            40: "The Believer",
+            41: "Ḥā-Mīm The Prostration",
+            76: "The Time",
+            111: "The Flame",
+        ]
+
+        for (suraNumber, name) in names {
+            XCTAssertEqual(
+                name,
+                Quran.hafsIndoPak.suras[suraNumber - 1].localizedTranslatedName(language: .english)
+            )
+        }
+    }
+
+    func testMadaniTranslatedSuraNamesRemainUnchanged() {
+        let names = [
+            17: "The Journey by Night",
+            40: "The Forgiver",
+            41: "They are explained in detail",
+            76: "Man",
+            111: "The Palm Fibre",
+        ]
+
+        for (suraNumber, name) in names {
+            XCTAssertEqual(
+                name,
+                Quran.hafsMadani1405.suras[suraNumber - 1].localizedTranslatedName(language: .english)
+            )
+        }
+    }
+
+    func testOtherIndoPakTranslatedSuraNamesContinueUsingSurasCatalog() {
+        XCTAssertEqual(
+            Quran.hafsMadani1405.firstSura.localizedTranslatedName(language: .english),
+            Quran.hafsIndoPak.firstSura.localizedTranslatedName(language: .english)
+        )
+    }
+
     // MARK: Private
 
     private let quran = Quran.hafsMadani1405


### PR DESCRIPTION
## Summary

- show localized translated sura names in the Surah list for non-Arabic locales
- use the existing Suras.strings catalog, with its English fallback behavior
- add reading-specific English meanings for the five IndoPak aliases
- preserve the existing Arabic Surah-list layout without the extra translated name

## Screenshots

| Madani 1405 | IndoPak |
|---|---|
| <img src="https://github.com/user-attachments/assets/ddc4a437-620c-46c6-b186-8f86df60a637" width="300"> | <img src="https://github.com/user-attachments/assets/74d26b2c-295c-400a-9d98-35ef7315744e" width="300"> |

## Testing

- make format-lint
- make test-no-sync TARGET=LocalizationTests
- make test-sync TARGET=LocalizationTests
- make test-no-sync TARGET=QuranLocalizationTests
- make test-sync TARGET=QuranLocalizationTests
- built and ran the private app on iPhone 17e (iOS 26.5), then verified Madani 1405 and IndoPak in the Surah list