### PR TITLE
perf(ci): cache Xcode builds by sync mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
     - name: Setting up Xcode
       run: sudo xcode-select -s "/Applications/Xcode_26.2.app"
 
+    - name: Restore Xcode build cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .build/DerivedData/no-sync
+        key: ${{ runner.os }}-xcode-26.2-${{ github.job }}-${{ hashFiles('Package.resolved', 'Package.swift') }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-xcode-26.2-${{ github.job }}-${{ hashFiles('Package.resolved', 'Package.swift') }}-
+
     - name: Install xcbeautify
       run: brew install xcbeautify
 
@@ -44,6 +52,14 @@ jobs:
     - name: Setting up Xcode
       run: sudo xcode-select -s "/Applications/Xcode_26.2.app"
 
+    - name: Restore Xcode build cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .build/DerivedData/sync
+        key: ${{ runner.os }}-xcode-26.2-${{ github.job }}-${{ hashFiles('Package.resolved', 'Package.swift') }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-xcode-26.2-${{ github.job }}-${{ hashFiles('Package.resolved', 'Package.swift') }}-
+
     - name: Install xcbeautify
       run: brew install xcbeautify
 
@@ -60,6 +76,14 @@ jobs:
       - name: Setting up Xcode
         run: sudo xcode-select -s "/Applications/Xcode_26.2.app"
 
+      - name: Restore Xcode build cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .build/DerivedData/no-sync
+          key: ${{ runner.os }}-xcode-26.2-${{ github.job }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Example/QuranEngineApp.xcodeproj/project.pbxproj') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-26.2-${{ github.job }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Example/QuranEngineApp.xcodeproj/project.pbxproj') }}-
+
       - name: Install xcbeautify
         run: brew install xcbeautify
       
@@ -75,6 +99,14 @@ jobs:
 
       - name: Setting up Xcode
         run: sudo xcode-select -s "/Applications/Xcode_26.2.app"
+
+      - name: Restore Xcode build cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .build/DerivedData/sync
+          key: ${{ runner.os }}-xcode-26.2-${{ github.job }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Example/QuranEngineApp.xcodeproj/project.pbxproj') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-xcode-26.2-${{ github.job }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Example/QuranEngineApp.xcodeproj/project.pbxproj') }}-
 
       - name: Install xcbeautify
         run: brew install xcbeautify


### PR DESCRIPTION
## Why

The current iOS CI spends about 9–10 minutes compiling each package mode while XCTest execution itself takes only seconds. `Package` and `PackageSync` also need different build products because `QURAN_SYNC` changes compilation.

## Change

- cache the existing `.build/DerivedData/no-sync` and `.build/DerivedData/sync` directories
- isolate caches by GitHub job, Xcode 26.2, package/project dependency hashes, and commit
- restore the latest compatible cache for incremental builds across commits
- keep all sync/no-sync package and example-app coverage unchanged

The job-specific key prevents parallel package/example jobs from racing to save different build products into one cache. GitHub-hosted macOS remains the runner; this does not move iOS CI onto QF self-hosted infrastructure.

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`

The first run is expected to populate a cold cache. Compare a subsequent run before merging; if cache restore/save overhead exceeds the compilation saving, adjust or close this PR.