### PR TITLE
Fix Quran bar interactions after page changes

### DIFF
--- a/Features/QuranContentFeature/Sources/ContentViewModel.swift
+++ b/Features/QuranContentFeature/Sources/ContentViewModel.swift
@@ -25,6 +25,7 @@ import VLogging
 @MainActor
 public protocol ContentListener: AnyObject {
     func userWillBeginDragScroll()
+    func contentViewDidChangeVisiblePage()
     func presentAyahMenu(in sourceView: UIView, at point: CGPoint, verses: [AyahNumber])
 }
 
@@ -173,6 +174,10 @@ public final class ContentViewModel: ObservableObject {
 
     func onViewLongPressCancelled() {
         longPressData = nil
+    }
+
+    func onVisiblePageChanged() {
+        listener?.contentViewDidChangeVisiblePage()
     }
 
     // MARK: Private

--- a/Features/QuranContentFeature/Sources/PagesView.swift
+++ b/Features/QuranContentFeature/Sources/PagesView.swift
@@ -18,7 +18,8 @@ struct PagesView: View {
             QuranPaginationView(
                 pagingStrategy: pagingStrategy(with: geometry),
                 selection: $viewModel.visiblePages,
-                pages: viewModel.deps.quran.pages
+                pages: viewModel.deps.quran.pages,
+                onVisiblePageChanged: viewModel.onVisiblePageChanged
             ) { page in
                 Group {
                     switch viewModel.quranMode {

--- a/Features/QuranPagesFeature/Sources/QuranPaginationView.swift
+++ b/Features/QuranPagesFeature/Sources/QuranPaginationView.swift
@@ -17,10 +17,17 @@ public enum PagingStrategy {
 public struct QuranPaginationView<Content: View>: View {
     // MARK: Lifecycle
 
-    public init(pagingStrategy: PagingStrategy, selection: Binding<[Page]>, pages: [Page], content: @escaping (Page) -> Content) {
+    public init(
+        pagingStrategy: PagingStrategy,
+        selection: Binding<[Page]>,
+        pages: [Page],
+        onVisiblePageChanged: @escaping () -> Void = {},
+        content: @escaping (Page) -> Content
+    ) {
         self.pagingStrategy = pagingStrategy
         _selection = selection
         self.pages = pages
+        self.onVisiblePageChanged = onVisiblePageChanged
         self.content = content
     }
 
@@ -33,12 +40,14 @@ public struct QuranPaginationView<Content: View>: View {
                 QuranSinglePaginationView(
                     selection: singlePageSelection,
                     pages: pages,
+                    onVisiblePageChanged: onVisiblePageChanged,
                     content: contentView
                 )
             case .doublePage:
                 QuranDoublePaginationView(
                     selection: $selection,
                     pages: pages,
+                    onVisiblePageChanged: onVisiblePageChanged,
                     content: contentView
                 )
             }
@@ -60,6 +69,7 @@ public struct QuranPaginationView<Content: View>: View {
 
     @Binding private var selection: [Page]
     private let pages: [Page]
+    private let onVisiblePageChanged: () -> Void
 
     @ViewBuilder private let content: (Page) -> Content
 
@@ -93,6 +103,7 @@ private struct QuranDoublePaginationView<Content: View>: View {
 
     @Binding var selection: [Page]
     let pages: [Page]
+    let onVisiblePageChanged: () -> Void
     @ViewBuilder let content: (Page) -> Content
 
     var body: some View {
@@ -101,7 +112,8 @@ private struct QuranDoublePaginationView<Content: View>: View {
             navigationOrientation: .horizontal,
             interPageSpacing: ContentDimension.interPageSpacing,
             animated: true,
-            selection: doublePageSelection
+            selection: doublePageSelection,
+            onVisiblePageChanged: onVisiblePageChanged
         ) {
             ForEach(doublePages) { doublePage in
                 HStack(spacing: 0) {
@@ -143,6 +155,7 @@ private struct QuranSinglePaginationView<Content: View>: View {
 
     @Binding var selection: Page
     let pages: [Page]
+    let onVisiblePageChanged: () -> Void
     @ViewBuilder let content: (Page) -> Content
 
     var body: some View {
@@ -151,7 +164,8 @@ private struct QuranSinglePaginationView<Content: View>: View {
             navigationOrientation: .horizontal,
             interPageSpacing: ContentDimension.interPageSpacing,
             animated: true,
-            selection: $selection
+            selection: $selection,
+            onVisiblePageChanged: onVisiblePageChanged
         ) {
             ForEach(pages) { page in
                 Group {

--- a/Features/QuranViewFeature/Sources/QuranInteractor.swift
+++ b/Features/QuranViewFeature/Sources/QuranInteractor.swift
@@ -42,6 +42,7 @@ protocol QuranPresentable: UIViewController {
 
     func startHiddenBarsTimer()
     func hideBars()
+    func refreshBarScrollEdgeInteractions()
 
     func setVisiblePages(_ pages: [Page])
     func updateBookmark(_ isBookmarked: Bool)
@@ -466,6 +467,10 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     func userWillBeginDragScroll() {
         logger.info("Quran: userWillBeginDragScroll")
         presenter?.hideBars()
+    }
+
+    func contentViewDidChangeVisiblePage() {
+        presenter?.refreshBarScrollEdgeInteractions()
     }
 
     func toogleBookmark() async {

--- a/Features/QuranViewFeature/Sources/QuranView.swift
+++ b/Features/QuranViewFeature/Sources/QuranView.swift
@@ -141,6 +141,11 @@ class QuranView: UIView, UIGestureRecognizerDelegate, UINavigationBarDelegate {
         updateAudioBarVisibility()
     }
 
+    func refreshScrollEdgeInteractions() {
+        configureNavigationBarScrollEdgeEffectIfNeeded()
+        configureAudioBarScrollEdgeEffectIfNeeded()
+    }
+
     @objc
     func onViewTapped(_ sender: UITapGestureRecognizer) {
         if let audioView, audioView.bounds.contains(sender.location(in: audioView)), audioView.isUserInteractionEnabled {

--- a/Features/QuranViewFeature/Sources/QuranViewController.swift
+++ b/Features/QuranViewFeature/Sources/QuranViewController.swift
@@ -134,6 +134,10 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         setBarsHidden(true)
     }
 
+    func refreshBarScrollEdgeInteractions() {
+        quranView?.refreshScrollEdgeInteractions()
+    }
+
     func startHiddenBarsTimer() {
         // increate the timer duration to give existing users the time to see the new buttons
         barsTimer = Timer(interval: 5) { [weak self] in

--- a/Features/QuranViewFeature/Tests/QuranViewTests.swift
+++ b/Features/QuranViewFeature/Tests/QuranViewTests.swift
@@ -82,6 +82,28 @@ final class QuranViewTests: XCTestCase {
         XCTAssertIdentical(interaction.scrollView, context.contentScrollView)
     }
 
+    func test_refreshingScrollEdgeInteractionsReconnectsBarsToNewVisiblePage() throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("UIScrollEdgeElementContainerInteraction requires iOS 26.")
+        }
+        let context = makeSut()
+        let newPageViewController = UIViewController()
+        let newContentScrollView = UIScrollView(frame: context.sut.bounds)
+        newPageViewController.view.addSubview(newContentScrollView)
+        context.pageViewController.setViewControllers(
+            [newPageViewController],
+            direction: .forward,
+            animated: false
+        )
+
+        context.sut.refreshScrollEdgeInteractions()
+
+        let navigationInteraction = try scrollEdgeInteraction(in: context.sut.navigationBar)
+        let audioInteraction = try audioBarInteraction(in: context.audioView)
+        XCTAssertIdentical(navigationInteraction.scrollView, newContentScrollView)
+        XCTAssertIdentical(audioInteraction.scrollView, newContentScrollView)
+    }
+
     func test_hidingBarsImmediatelyHidesBarsWithoutChangingTheirAlpha() {
         let context = makeSut()
 
@@ -164,6 +186,7 @@ final class QuranViewTests: XCTestCase {
     private struct TestContext {
         let retainedHostViewController: UIViewController
         let sut: QuranView
+        let pageViewController: UIPageViewController
         let contentScrollView: UIScrollView
         let audioView: UIView
     }
@@ -205,6 +228,7 @@ final class QuranViewTests: XCTestCase {
         return TestContext(
             retainedHostViewController: hostViewController,
             sut: sut,
+            pageViewController: pageViewController,
             contentScrollView: contentScrollView,
             audioView: audioView
         )

--- a/UI/NoorUI/Sources/Pager/PageViewController.swift
+++ b/UI/NoorUI/Sources/Pager/PageViewController.swift
@@ -25,12 +25,14 @@ public struct PageViewController<Element, Content>: View
         interPageSpacing: CGFloat,
         animated: Bool,
         selection: Binding<Element>,
+        onVisiblePageChanged: @escaping () -> Void = {},
         @ViewBuilder forEach: () -> ForEach<[Element], Element.ID, Content>
     ) {
         self.transitionStyle = transitionStyle
         self.navigationOrientation = navigationOrientation
         self.interPageSpacing = interPageSpacing
         self.animated = animated
+        self.onVisiblePageChanged = onVisiblePageChanged
         _selection = selection
         self.forEach = forEach()
     }
@@ -44,6 +46,7 @@ public struct PageViewController<Element, Content>: View
             interPageSpacing: interPageSpacing,
             animated: animated,
             forEach: forEach,
+            onVisiblePageChanged: onVisiblePageChanged,
             selection: $selection
         )
     }
@@ -54,6 +57,7 @@ public struct PageViewController<Element, Content>: View
     let navigationOrientation: UIPageViewController.NavigationOrientation
     let interPageSpacing: CGFloat
     let animated: Bool
+    let onVisiblePageChanged: () -> Void
 
     @Binding var selection: Element
     let forEach: ForEach<[Element], Element.ID, Content>
@@ -71,6 +75,7 @@ private struct _PageViewController<Element, Content>: UIViewControllerRepresenta
     let animated: Bool
 
     let forEach: ForEach<[Element], Element.ID, Content>
+    let onVisiblePageChanged: () -> Void
     @Binding var selection: Element
 
     @State var userDraggingStartedTransitionInProgress = false
@@ -108,6 +113,9 @@ private struct _PageViewController<Element, Content>: UIViewControllerRepresenta
     }
 
     func updateUIViewController(_ pageViewController: UIPageViewController, context: Context) {
+        let previousSelection = context.coordinator.parent.selection
+        context.coordinator.parent = self
+
         // Early return if showing selection's view controller.
         if let visibleController = pageViewController.mostVisibleViewController as? PageContentController {
             if visibleController.element == selection {
@@ -133,9 +141,6 @@ private struct _PageViewController<Element, Content>: UIViewControllerRepresenta
             return
         }
 
-        let previousSelection = context.coordinator.parent.selection
-        context.coordinator.parent = self
-
         let viewController = makeController(selection)
 
         let previousIndex = forEach.data.firstIndex { $0 == previousSelection }
@@ -146,7 +151,12 @@ private struct _PageViewController<Element, Content>: UIViewControllerRepresenta
             .forward
         }
 
-        pageViewController.setViewControllers([viewController], direction: direction, animated: animated)
+        pageViewController.setViewControllers([viewController], direction: direction, animated: animated) {
+            [weak coordinator = context.coordinator] completed in
+            if completed {
+                coordinator?.visiblePageDidChange()
+            }
+        }
     }
 
     func makeController(_ element: Element) -> UIViewController {
@@ -221,6 +231,13 @@ extension _PageViewController {
                let contentController = visibleViewController as? PageContentController
             {
                 parent.selection = contentController.element
+                visiblePageDidChange()
+            }
+        }
+
+        func visiblePageDidChange() {
+            DispatchQueue.main.async { [weak self] in
+                self?.parent.onVisiblePageChanged()
             }
         }
 

--- a/UI/NoorUI/Tests/PageViewControllerTests.swift
+++ b/UI/NoorUI/Tests/PageViewControllerTests.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+import XCTest
+@testable import NoorUI
+
+@MainActor
+final class PageViewControllerTests: XCTestCase {
+    func test_notifiesWhenInitialAndProgrammaticPagesBecomeVisible() {
+        let pages = [Page(id: 1), Page(id: 2)]
+        let model = PageSelectionModel(selection: pages[0])
+        let initialPageVisible = expectation(description: "Initial page visible")
+        let changedPageVisible = expectation(description: "Changed page visible")
+        var callbackCount = 0
+        let view = PageViewControllerTestView(model: model, pages: pages) {
+            callbackCount += 1
+            if callbackCount == 1 {
+                initialPageVisible.fulfill()
+            } else if callbackCount == 2 {
+                changedPageVisible.fulfill()
+            }
+        }
+        let hostingController = UIHostingController(rootView: view)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = hostingController
+        window.makeKeyAndVisible()
+        window.layoutIfNeeded()
+        wait(for: [initialPageVisible], timeout: 1)
+
+        model.selection = pages[1]
+        window.layoutIfNeeded()
+
+        wait(for: [changedPageVisible], timeout: 1)
+        window.isHidden = true
+    }
+}
+
+private struct PageViewControllerTestView: View {
+    @ObservedObject var model: PageSelectionModel
+    let pages: [Page]
+    let onVisiblePageChanged: () -> Void
+
+    var body: some View {
+        PageViewController(
+            transitionStyle: .scroll,
+            navigationOrientation: .horizontal,
+            interPageSpacing: 0,
+            animated: false,
+            selection: $model.selection,
+            onVisiblePageChanged: onVisiblePageChanged
+        ) {
+            ForEach(pages) { page in
+                Text("Page \(page.id)")
+            }
+        }
+    }
+}
+
+private final class PageSelectionModel: ObservableObject {
+    init(selection: Page) {
+        self.selection = selection
+    }
+
+    @Published var selection: Page
+}
+
+private struct Page: Identifiable, Equatable {
+    let id: Int
+}


### PR DESCRIPTION
## Summary

- notify consumers after the pager installs its initial page or completes a page transition
- propagate visible-page lifecycle changes through Quran content to refresh the bar scroll-edge interactions
- reconnect both Quran bars to the newly visible page vertical scroll view
- refresh naturally when Arabic/translation mode recreates the pager
- add regression coverage for pager notifications and interaction rebinding

## Root cause

The bar interactions were configured during outer layout and bar visibility changes. Initial SwiftUI page mounting could finish after that layout, while page transitions and Arabic/translation changes could replace the visible page without laying out QuranView again. The interactions were therefore absent or retained the previous page scroll view until the bars were hidden and shown again.

## Verification

- make test-no-sync TARGET=NoorUITests — 33 tests passed
- make test-no-sync TARGET=QuranViewFeatureTests — 13 tests passed
- make build-sync TARGET=QuranViewFeature — succeeded
- make build-no-sync TARGET=QuranViewFeature — succeeded
- make format-lint — 0/734 files require formatting
