### PR TITLE
Fix IndoPak page count text

### DIFF
--- a/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ar.lproj/Localizable.strings
@@ -333,7 +333,7 @@
 // Reading selector
 "reading.indopak.description" = "مصحف برواية حفص بخط النسخ الهندي الباكستاني، الشائع في جنوب آسيا. صور الصفحات من مجمع الملك فهد لطباعة المصحف الشريف.";
 "reading.indopak.title" = "الهندي الباكستاني – ١٥ سطرًا";
-"reading.selector.property.pages.611" = "٦١١ صفحة";
+"reading.selector.property.pages.610" = "٦١٠ صفحة";
 
 // Translation
 "translation.text.ayah-number" = "%d:%d";

--- a/Core/Localization/Sources/Resources/de.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/de.lproj/Localizable.strings
@@ -514,7 +514,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "Indisch-pakistanisch – 15 Zeilen";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "611 Seiten";
+"reading.selector.property.pages.610" = "610 Seiten";
 
 // Quran.com account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/en.lproj/Localizable.strings
@@ -251,7 +251,7 @@
 "reading.selector.selection-description" = "Tap on a Mushaf for more information.";
 "reading.selector.property.hafs" = "Hafs Mushaf";
 "reading.selector.property.pages.604" = "604 pages";
-"reading.selector.property.pages.611" = "611 pages";
+"reading.selector.property.pages.610" = "610 pages";
 "reading.selector.property.lines.15" = "15-line page";
 "reading.selector.property.word-translation.supported" = "Word-by-word translation";
 "reading.selector.property.word-translation.not-supported" = "No Word-by-word translation";

--- a/Core/Localization/Sources/Resources/es.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/es.lproj/Localizable.strings
@@ -514,7 +514,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "Indopakistaní de 15 líneas";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "611 páginas";
+"reading.selector.property.pages.610" = "610 páginas";
 
 // Quran.com account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/fa.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/fa.lproj/Localizable.strings
@@ -516,7 +516,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "هندی-پاکستانی ۱۵ سطری";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "۶۱۱ صفحه";
+"reading.selector.property.pages.610" = "۶۱۰ صفحه";
 
 // Quran.com account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/fr.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/fr.lproj/Localizable.strings
@@ -514,7 +514,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "Indo-pakistanais – 15 lignes";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "611 pages";
+"reading.selector.property.pages.610" = "610 pages";
 
 // Quran.com account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/kk.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/kk.lproj/Localizable.strings
@@ -498,7 +498,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "Үнді-пәкістандық — 15 жол";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "611 бет";
+"reading.selector.property.pages.610" = "610 бет";
 
 // Quran.com account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ms.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ms.lproj/Localizable.strings
@@ -497,7 +497,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "India-Pakistan 15 Baris";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "611 halaman";
+"reading.selector.property.pages.610" = "610 halaman";
 
 // Quran.com account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/nl.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/nl.lproj/Localizable.strings
@@ -426,7 +426,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "Indo-Pakistaans – 15 regels";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "611 pagina’s";
+"reading.selector.property.pages.610" = "610 pagina’s";
 
 // Quran.com account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/pt.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/pt.lproj/Localizable.strings
@@ -515,7 +515,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "Indo-paquistanês — 15 linhas";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "611 páginas";
+"reading.selector.property.pages.610" = "610 páginas";
 
 // Quran.com account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ru.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ru.lproj/Localizable.strings
@@ -514,7 +514,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "Индо-пакистанский — 15 строк";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "611 страниц";
+"reading.selector.property.pages.610" = "610 страниц";
 
 // Quran.com account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/tr.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/tr.lproj/Localizable.strings
@@ -456,7 +456,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "Hint-Pakistan — 15 Satır";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "611 sayfa";
+"reading.selector.property.pages.610" = "610 sayfa";
 
 // Quran.com account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/ug.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/ug.lproj/Localizable.strings
@@ -517,7 +517,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "ھىندى-پاكىستان — 15 قۇر";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "611 بەت";
+"reading.selector.property.pages.610" = "610 بەت";
 
 // Quran.com account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/uz.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/uz.lproj/Localizable.strings
@@ -516,7 +516,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "Hind-Pokiston — 15 qator";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "611 sahifa";
+"reading.selector.property.pages.610" = "610 sahifa";
 
 // Quran.com account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/vi.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/vi.lproj/Localizable.strings
@@ -423,7 +423,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "Ấn Độ–Pakistan – 15 dòng";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "611 trang";
+"reading.selector.property.pages.610" = "610 trang";
 
 // Quran.com Account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Core/Localization/Sources/Resources/zh.lproj/Localizable.strings
+++ b/Core/Localization/Sources/Resources/zh.lproj/Localizable.strings
@@ -515,7 +515,7 @@
 // Metadata: Translated by ChatGPT; human review required.
 "reading.indopak.title" = "印巴版（15 行）";
 // Metadata: Translated by ChatGPT; human review required.
-"reading.selector.property.pages.611" = "611 页";
+"reading.selector.property.pages.610" = "610 页";
 
 // Quran.com Account
 // Metadata: Translated by ChatGPT; human review required.

--- a/Features/ReadingSelectorFeature/Sources/View/Reading+Resources.swift
+++ b/Features/ReadingSelectorFeature/Sources/View/Reading+Resources.swift
@@ -113,7 +113,7 @@ extension Reading {
         case .indoPak:
             return [
                 Property(type: .supports, property: l("reading.selector.property.hafs")),
-                Property(type: .supports, property: l("reading.selector.property.pages.611")),
+                Property(type: .supports, property: l("reading.selector.property.pages.610")),
                 Property(type: .supports, property: l("reading.selector.property.lines.15")),
                 Property(type: .lacks, property: l("reading.selector.property.word-translation.not-supported")),
             ]


### PR DESCRIPTION
## Summary

- show 610 usable pages for the IndoPak 15-line reading
- rename the localization key from pages.611 to pages.610
- update the value across all supported localizations

## Tests

- make test-no-sync TARGET=LocalizationTests
- make test-sync TARGET=LocalizationTests
- make format-lint