### PR TITLE
Fix reversible page mapping between 604-page Mushafs

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/QuranKitTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/QuranKitTests.xcscheme
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2650"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "QuranKitTests"
+               BuildableName = "QuranKitTests"
+               BlueprintName = "QuranKitTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Domain/AnnotationsService/Tests/PageMappingServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/PageMappingServiceTests.swift
@@ -59,8 +59,8 @@ final class PageMappingServiceTests: XCTestCase {
     }
 
     func testPageBookmarksDeduplicatePagesAfterMapping() throws {
-        let sourceQuran = Quran.hafsMadani1405
-        let destinationQuran = Quran.hafsMadani1440
+        let sourceQuran = Quran.hafsIndoPak
+        let destinationQuran = Quran.hafsMadani1405
         let mapper = QuranPageMapper(destination: destinationQuran)
         let sourcePagesByDestination = Dictionary(grouping: sourceQuran.pages) { mapper.mapPage($0) }
         let duplicateSourcePages = try XCTUnwrap(
@@ -72,7 +72,7 @@ final class PageMappingServiceTests: XCTestCase {
             PageBookmarkPersistenceModel(page: olderPage.pageNumber, creationDate: date),
             PageBookmarkPersistenceModel(page: newerPage.pageNumber, creationDate: laterDate),
         ])
-        let service = PageBookmarkService(persistence: persistence)
+        let service = PageBookmarkService(persistence: persistence, storedPageQuran: sourceQuran)
 
         let bookmarks = value(from: service.pageBookmarks(quran: destinationQuran))
 
@@ -97,6 +97,49 @@ final class PageMappingServiceTests: XCTestCase {
         try await service.removePageBookmark(skippedPageQuran().pages[0])
 
         XCTAssertEqual(persistence.removedPages, [1])
+    }
+
+    func testInsertPageBookmarkPreservesExactPageAcrossDifferentPageLayouts() async throws {
+        let persistence = PageBookmarkPersistenceFake()
+        let service = PageBookmarkService(persistence: persistence)
+        let quran = Quran.hafsMadani1440
+        let page = try XCTUnwrap(Page(quran: quran, pageNumber: 534))
+
+        try await service.insertPageBookmark(page)
+        let bookmarks = value(from: service.pageBookmarks(quran: quran))
+
+        XCTAssertEqual(bookmarks.map(\.page), [page])
+    }
+
+    func testRemovePageBookmarkRemovesLegacyStoredPageThatMapsToDisplayedPage() async throws {
+        let persistence = PageBookmarkPersistenceFake(bookmarks: [
+            PageBookmarkPersistenceModel(page: 534, creationDate: date),
+        ])
+        let service = PageBookmarkService(persistence: persistence)
+        let quran = Quran.hafsMadani1440
+        let displayedBookmark = try XCTUnwrap(value(from: service.pageBookmarks(quran: quran)).first)
+
+        try await service.removePageBookmark(displayedBookmark.page)
+        let bookmarks = value(from: service.pageBookmarks(quran: quran))
+
+        XCTAssertTrue(bookmarks.isEmpty)
+    }
+
+    func testAdjacentCanonicalBookmarksRemainDistinctAfterMapping() async throws {
+        let persistence = PageBookmarkPersistenceFake(bookmarks: [
+            PageBookmarkPersistenceModel(page: 531, creationDate: date),
+            PageBookmarkPersistenceModel(page: 532, creationDate: laterDate),
+        ])
+        let service = PageBookmarkService(persistence: persistence)
+        let quran = Quran.hafsMadani1440
+        let displayedBookmarks = value(from: service.pageBookmarks(quran: quran))
+
+        XCTAssertEqual(displayedBookmarks.map(\.page.pageNumber), [532, 531])
+
+        try await service.removePageBookmark(try XCTUnwrap(displayedBookmarks.first).page)
+        let bookmarks = value(from: service.pageBookmarks(quran: quran))
+
+        XCTAssertEqual(bookmarks.map(\.page.pageNumber), [531])
     }
 
     func testPageBookmarksIgnoreInvalidStoredPages() {
@@ -197,10 +240,12 @@ private final class PageBookmarkPersistenceFake: PageBookmarkPersistence {
 
     func insertPageBookmark(_ page: Int) async throws {
         insertedPages.append(page)
+        bookmarks.append(PageBookmarkPersistenceModel(page: page, creationDate: Date()))
     }
 
     func removePageBookmark(_ page: Int) async throws {
         removedPages.append(page)
+        bookmarks.removeAll { $0.page == page }
     }
 
     func removeAllPageBookmarks() async throws {

--- a/Model/QuranKit/Sources/QuranPageMapper.swift
+++ b/Model/QuranKit/Sources/QuranPageMapper.swift
@@ -16,11 +16,53 @@ public struct QuranPageMapper {
 
     public let destination: Quran
 
-    public func mapPage(_ page: Page) -> Page? {
-        mapAyah(page.firstVerse)?.page
+    public func mapPage(_ sourcePage: Page) -> Page? {
+        guard let destinationPreferredPage = mapAyah(sourcePage.middleAyah)?.page,
+              let destinationFirstAyahPage = mapAyah(sourcePage.firstVerse)?.page,
+              let destinationLastAyahPage = mapAyah(sourcePage.lastVerse)?.page
+        else {
+            return nil
+        }
+
+        let destinationAnchorPages = [
+            destinationFirstAyahPage,
+            destinationPreferredPage,
+            destinationLastAyahPage,
+        ]
+        guard let destinationMinPage = destinationAnchorPages.min(),
+              let destinationMaxPage = destinationAnchorPages.max()
+        else {
+            return nil
+        }
+
+        let destinationCandidates = (destinationMinPage.pageNumber ... destinationMaxPage.pageNumber)
+            .compactMap { Page(quran: destination, pageNumber: $0) }
+
+        let roundTripCandidates = destinationCandidates.filter { destinationCandidate in
+            let destinationCandidateAyah = destinationCandidate.middleAyah
+            let sourceCandidateAyah = AyahNumber(
+                quran: sourcePage.quran,
+                sura: destinationCandidateAyah.sura.suraNumber,
+                ayah: destinationCandidateAyah.ayah
+            )
+            return sourceCandidateAyah?.page == sourcePage
+        }
+
+        return (roundTripCandidates.isEmpty ? destinationCandidates : roundTripCandidates)
+            .min {
+                abs($0.pageNumber - destinationPreferredPage.pageNumber) <
+                    abs($1.pageNumber - destinationPreferredPage.pageNumber)
+            }
     }
 
-    public func mapAyah(_ ayah: AyahNumber) -> AyahNumber? {
-        AyahNumber(quran: destination, sura: ayah.sura.suraNumber, ayah: ayah.ayah)
+    public func mapAyah(_ sourceAyah: AyahNumber) -> AyahNumber? {
+        AyahNumber(quran: destination, sura: sourceAyah.sura.suraNumber, ayah: sourceAyah.ayah)
+    }
+}
+
+private extension Page {
+    var middleAyah: AyahNumber {
+        let pageVerses = verses
+        return pageVerses[(pageVerses.count - 1) / 2]
     }
 }

--- a/Model/QuranKit/Tests/QuranPageMetadataTests.swift
+++ b/Model/QuranKit/Tests/QuranPageMetadataTests.swift
@@ -9,6 +9,11 @@ import XCTest
 @testable import QuranKit
 
 final class QuranPageMetadataTests: XCTestCase {
+    private struct SupportedQuran {
+        let name: String
+        let quran: Quran
+    }
+
     private struct SkippedFirstPageReadingInfoRawData: QuranReadingInfoRawData {
         // MARK: Internal
 
@@ -161,13 +166,61 @@ final class QuranPageMetadataTests: XCTestCase {
         XCTAssertFalse(skippedQuran.pages[1].isRightSide)
     }
 
-    func testPageMapperKeepsSameQuranPageNumber() {
-        let quran = Quran.hafsMadani1405
-        let mapper = QuranPageMapper(destination: quran)
+    func testPageMapperKeepsEveryPageInTheSameSupportedLayout() {
+        for supportedQuran in supportedQurans {
+            let mapper = QuranPageMapper(destination: supportedQuran.quran)
 
-        XCTAssertEqual(mapper.mapPage(quran.pages[0])?.pageNumber, 1)
-        XCTAssertEqual(mapper.mapPage(quran.pages[1])?.pageNumber, 2)
-        XCTAssertEqual(mapper.mapPage(quran.pages[603])?.pageNumber, 604)
+            for page in supportedQuran.quran.pages {
+                XCTAssertEqual(
+                    mapper.mapPage(page),
+                    page,
+                    "\(supportedQuran.name) page \(page.pageNumber)"
+                )
+            }
+        }
+    }
+
+    func testPageMapperMapsEveryPageBetweenEverySupportedLayout() throws {
+        for source in supportedQurans {
+            for destination in supportedQurans {
+                let mapper = QuranPageMapper(destination: destination.quran)
+
+                for sourcePage in source.quran.pages {
+                    let context = "\(source.name) page \(sourcePage.pageNumber) → \(destination.name)"
+                    let mappedPage = try XCTUnwrap(mapper.mapPage(sourcePage), context)
+
+                    XCTAssertEqual(mappedPage.quran, destination.quran, context)
+                    XCTAssertTrue(pagesOverlap(sourcePage, mappedPage), context)
+                }
+            }
+        }
+    }
+
+    func testPageMapperUsesRoundTripCandidateForEveryPageBetweenEverySupportedLayout() throws {
+        for source in supportedQurans {
+            for destination in supportedQurans {
+                let destinationMapper = QuranPageMapper(destination: destination.quran)
+                let sourceMapper = QuranPageMapper(destination: source.quran)
+
+                for sourcePage in source.quran.pages {
+                    let context = "\(source.name) page \(sourcePage.pageNumber) → \(destination.name)"
+                    let mappedPage = try XCTUnwrap(destinationMapper.mapPage(sourcePage), context)
+                    let candidates = try candidatePages(
+                        for: sourcePage,
+                        mapper: destinationMapper,
+                        destination: destination.quran,
+                        context: context
+                    )
+                    let roundTripCandidates = candidates.filter { candidate in
+                        sourceMapper.mapAyah(representativeAyah(on: candidate))?.page == sourcePage
+                    }
+
+                    if !roundTripCandidates.isEmpty {
+                        XCTAssertTrue(roundTripCandidates.contains(mappedPage), context)
+                    }
+                }
+            }
+        }
     }
 
     func testPageMapperMapsSourcePageFirstVerseToDestinationPage() {
@@ -182,6 +235,37 @@ final class QuranPageMetadataTests: XCTestCase {
         XCTAssertEqual(sourcePage.pageNumber, 2)
         XCTAssertEqual(mappedPage?.pageNumber, 3)
         XCTAssertEqual(mappedPage, mappedAyah?.page)
+    }
+
+    func testPageMapperPreservesMadani1440PageAcrossCanonicalRoundTrip() throws {
+        let sourceQuran = Quran.hafsMadani1440
+        let canonicalQuran = Quran.hafsMadani1405
+        let sourcePage = try XCTUnwrap(Page(quran: sourceQuran, pageNumber: 534))
+
+        let canonicalPage = try XCTUnwrap(QuranPageMapper(destination: canonicalQuran).mapPage(sourcePage))
+        let restoredPage = QuranPageMapper(destination: sourceQuran).mapPage(canonicalPage)
+
+        XCTAssertEqual(canonicalPage.pageNumber, 534)
+        XCTAssertEqual(restoredPage, sourcePage)
+    }
+
+    func testPageMapperRoundTripsEveryPageBetweenEqualSizedSupportedLayouts() throws {
+        for source in supportedQurans {
+            for destination in supportedQurans {
+                guard destination.quran.pages.count == source.quran.pages.count else {
+                    continue
+                }
+
+                let destinationMapper = QuranPageMapper(destination: destination.quran)
+                let sourceMapper = QuranPageMapper(destination: source.quran)
+
+                for sourcePage in source.quran.pages {
+                    let context = "\(source.name) page \(sourcePage.pageNumber) → \(destination.name)"
+                    let destinationPage = try XCTUnwrap(destinationMapper.mapPage(sourcePage), context)
+                    XCTAssertEqual(sourceMapper.mapPage(destinationPage), sourcePage, context)
+                }
+            }
+        }
     }
 
     func testPageMapperMapsSkippedPageBackToCanonicalPage() {
@@ -209,5 +293,54 @@ final class QuranPageMetadataTests: XCTestCase {
 
         XCTAssertEqual(mapper.mapAyah(firstAyah)?.page.pageNumber, 2)
         XCTAssertEqual(mapper.mapAyah(secondSuraFirstAyah)?.page.pageNumber, 3)
+    }
+
+    // MARK: Private
+
+    private var supportedQurans: [SupportedQuran] {
+        var seenQurans = Set<Quran>()
+        return Reading.allReadings.compactMap { reading in
+            guard seenQurans.insert(reading.quran).inserted else {
+                return nil
+            }
+            return SupportedQuran(name: String(describing: reading), quran: reading.quran)
+        }
+    }
+
+    private func candidatePages(
+        for sourcePage: Page,
+        mapper: QuranPageMapper,
+        destination: Quran,
+        context: String
+    ) throws -> [Page] {
+        let firstPage = try XCTUnwrap(mapper.mapAyah(sourcePage.firstVerse)?.page, context)
+        let lastPage = try XCTUnwrap(mapper.mapAyah(sourcePage.lastVerse)?.page, context)
+        let pageNumbers = min(firstPage.pageNumber, lastPage.pageNumber) ...
+            max(firstPage.pageNumber, lastPage.pageNumber)
+        return pageNumbers.compactMap { Page(quran: destination, pageNumber: $0) }
+    }
+
+    private func representativeAyah(on page: Page) -> AyahNumber {
+        let verses = page.verses
+        return verses[(verses.count - 1) / 2]
+    }
+
+    private func pagesOverlap(_ sourcePage: Page, _ destinationPage: Page) -> Bool {
+        guard let destinationFirstAyah = AyahNumber(
+            quran: sourcePage.quran,
+            sura: destinationPage.firstVerse.sura.suraNumber,
+            ayah: destinationPage.firstVerse.ayah
+        ),
+            let destinationLastAyah = AyahNumber(
+                quran: sourcePage.quran,
+                sura: destinationPage.lastVerse.sura.suraNumber,
+                ayah: destinationPage.lastVerse.ayah
+            )
+        else {
+            return false
+        }
+
+        return destinationFirstAyah <= sourcePage.lastVerse &&
+            sourcePage.firstVerse <= destinationLastAyah
     }
 }


### PR DESCRIPTION
## Summary

- Map pages using first, middle, and last ayah anchors.
- Prefer a destination page whose representative ayah maps back to the original source page.
- Add exhaustive mapper coverage and page-bookmark regression tests.

## Scope

This fixes the page-mapping and bookmark-removal problems between supported Mushaf layouts that have 604 Quran pages.

This does not fix the IndoPak mapping problem. IndoPak has a different page count, so the same round-trip guarantee does not apply. We will address the IndoPak case separately, inshaa’Allah.

## Testing

- QuranKitTests
- AnnotationsServiceTests
- SwiftFormat