### PR TITLE
fix: hide iPadOS 26 tab bar in Quran view

### DIFF
--- a/Features/QuranViewFeature/Sources/QuranViewController.swift
+++ b/Features/QuranViewFeature/Sources/QuranViewController.swift
@@ -111,12 +111,14 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
         crashContext.setScreen("quran")
         UIApplication.shared.isIdleTimerDisabled = true
         navigationController?.setNavigationBarHidden(true, animated: animated)
+        setOuterTabBarHiddenForIOS26(true, animated: animated)
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         crashContext.clearActiveList(owner: "quran_translation")
         navigationController?.setNavigationBarHidden(false, animated: animated)
+        setOuterTabBarHiddenForIOS26(false, animated: animated)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -342,6 +344,13 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
     private func stopBarHiddenTimer() {
         barsTimer?.cancel()
         barsTimer = nil
+    }
+
+    private func setOuterTabBarHiddenForIOS26(_ hidden: Bool, animated: Bool) {
+        // On iPadOS 26, UIKit can leave the top tab bar visible despite hidesBottomBarWhenPushed.
+        // Explicitly hiding the active tab bar works around that UIKit regression.
+        guard #available(iOS 26.0, *) else { return }
+        tabBarController?.setTabBarHidden(hidden, animated: animated)
     }
 
     @objc


### PR DESCRIPTION
## Summary

- explicitly hide the outer tab bar while the Quran view is visible on iOS 26
- restore the tab bar when leaving the Quran view
- document the iPadOS 26 UIKit regression that requires the workaround

## Testing

- `make format-lint`
- `make build-no-sync TARGET=QuranViewFeature`
- `make test-no-sync TARGET=QuranViewFeatureTests`