### PR TITLE
feat: refine reading bookmark menu

### DIFF
--- a/Features/QuranViewFeature/Sources/QuranInteractor.swift
+++ b/Features/QuranViewFeature/Sources/QuranInteractor.swift
@@ -417,7 +417,11 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
     #if QURAN_SYNC
     func onReadingBookmarkMenuTapped() {
-        let viewController = deps.readingBookmarkMenuBuilder.build(pages: visiblePages)
+        guard let firstPage = visiblePages.min() else {
+            logger.info("Quran: ignore reading bookmarks tap when no visible pages")
+            return
+        }
+        let viewController = deps.readingBookmarkMenuBuilder.build(page: firstPage, pages: visiblePages)
         presenter?.presentReadingBookmarkMenu(viewController)
     }
     #else

--- a/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuBuilder.swift
+++ b/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuBuilder.swift
@@ -16,8 +16,8 @@ public struct ReadingBookmarkMenuBuilder {
 
     // MARK: Public
 
-    public func build(pages: [Page]) -> UIViewController {
-        build(target: .pages(pages))
+    public func build(page: Page, pages: [Page]) -> UIViewController {
+        build(target: .pages(page, pages))
     }
 
     public func build(ayah: AyahNumber) -> UIViewController {

--- a/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuView.swift
+++ b/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuView.swift
@@ -1,9 +1,11 @@
 #if QURAN_SYNC
 import NoorUI
 import QuranAnnotations
+import QuranKit
 import SwiftUI
 import UIx
 
+@MainActor
 struct ReadingBookmarkMenuView: View {
     // MARK: Lifecycle
 
@@ -38,6 +40,7 @@ struct ReadingBookmarkMenuView: View {
     }
 }
 
+@MainActor
 private struct ReadingBookmarkMenuContent: View {
     @Binding var error: Error?
 
@@ -45,18 +48,24 @@ private struct ReadingBookmarkMenuContent: View {
     let start: AsyncAction
     let select: AsyncItemAction<ReadingBookmarkSlot>
 
-    @ScaledMetric private var minimumWidth = 280.0
+    @ScaledMetric private var minimumWidth = 320.0
     @ScaledMetric private var verticalPadding = 12.0
+    @ScaledMetric private var actionHorizontalPadding = 12.0
+    @ScaledMetric private var actionVerticalPadding = 6.0
 
     var body: some View {
         PreferredContentSizeMatchesScrollView {
             ScrollView {
                 VStack(spacing: 0) {
+                    header
+
                     ForEach(items) { item in
                         row(item)
-                        Divider()
+                        if item.id != items.last?.id {
+                            Divider()
+                                .padding(.horizontal)
+                        }
                     }
-                    editBookmarksRow
                 }
                 .frame(minWidth: minimumWidth)
             }
@@ -68,23 +77,48 @@ private struct ReadingBookmarkMenuContent: View {
         .errorAlert(error: $error)
     }
 
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text("Reading bookmarks")
+                    .font(.headline.bold())
+                    .foregroundStyle(Color.label)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .accessibilityAddTraits(.isHeader)
+                Button("Edit", action: {})
+                    .buttonStyle(.plain)
+                    .foregroundStyle(Color.accentColor)
+            }
+            .font(.subheadline.weight(.semibold))
+            Divider()
+            Text("Each pin marks one place — move it as you go")
+                .font(.footnote)
+                .foregroundStyle(Color.secondaryLabel)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding()
+    }
+
     private func row(_ item: ReadingBookmarkMenuViewModel.Item) -> some View {
         AsyncButton {
             await select(item.slot)
         } label: {
             HStack(spacing: 14) {
-                Image(uiImage: ReadingBookmarkPin.image(style: item.isCurrent ? .filled : .outline))
+                ReadingBookmarkPin(style: .filled)
                     .foregroundColor(item.isEnabled ? item.slot.swiftUIColor : .tertiaryLabel)
-                    .frame(width: 24)
+                    .accessibilityHidden(true)
                 VStack(alignment: .leading, spacing: 1) {
                     Text(item.slot.displayName)
+                        .fontWeight(.semibold)
                         .foregroundColor(item.isEnabled ? .label : .tertiaryLabel)
-                    item.subtitle.view(ofSize: .footnote, allowsWrapping: false)
+                    item.subtitle.view(ofSize: .footnote)
                         .foregroundColor(item.isEnabled ? .secondaryLabel : .tertiaryLabel)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer(minLength: 0)
+                actionLabel(item.action)
+                    .opacity(item.isEnabled ? 1 : 0.4)
             }
             .padding(.horizontal)
             .padding(.vertical, verticalPadding)
@@ -95,38 +129,69 @@ private struct ReadingBookmarkMenuContent: View {
         .disabled(!item.isEnabled)
     }
 
-    private var editBookmarksRow: some View {
-        Button(action: {}) {
-            HStack(spacing: 14) {
-                Image(systemName: "pencil")
-                    .foregroundColor(.label)
-                    .frame(width: 24)
-                Text("Edit reading bookmarks")
-                    .foregroundColor(.label)
-                Spacer(minLength: 0)
+    private func actionLabel(_ action: ReadingBookmarkMenuViewModel.Item.Action) -> some View {
+        Group {
+            switch action {
+            case .remove:
+                Text(action.title)
+                    .foregroundStyle(Color.systemRed)
+            case .moveHere, .setHere:
+                Text(action.title)
+                    .foregroundStyle(action == .moveHere ? Color.white : Color.accentColor)
+                    .padding(.horizontal, actionHorizontalPadding)
+                    .padding(.vertical, actionVerticalPadding)
+                    .background(
+                        Color.accentColor.opacity(action == .moveHere ? 1 : 0.1),
+                        in: Capsule()
+                    )
             }
-            .padding(.horizontal)
-            .padding(.vertical, verticalPadding)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
         }
-        .buttonStyle(BackgroundHighlightingStyle())
+        .font(.footnote.bold())
+        .fixedSize()
     }
 }
 
 #Preview {
     ReadingBookmarkMenuContent(
         error: .constant(nil),
-        items: ReadingBookmarkSlot.allCases.map { slot in
-            ReadingBookmarkMenuViewModel.Item(
-                slot: slot,
-                subtitle: .text("Not placed — tap to set here"),
+        items: [
+            .init(
+                slot: .coral,
+                subtitle: .text("Saved here"),
+                action: .remove,
+                isCurrent: true,
+                isEnabled: true
+            ),
+            .init(
+                slot: .teal,
+                subtitle: "at \(ayah: Quran.hafsMadani1405.suras[1].verses[29], decorationHidden: true)",
+                action: .moveHere,
                 isCurrent: false,
                 isEnabled: true
-            )
-        },
+            ),
+            .init(
+                slot: .indigo,
+                subtitle: .text("Not placed yet"),
+                action: .setHere,
+                isCurrent: false,
+                isEnabled: true
+            ),
+        ],
         start: {},
         select: { _ in }
     )
+}
+
+private extension ReadingBookmarkMenuViewModel.Item.Action {
+    var title: String {
+        switch self {
+        case .remove:
+            "Remove"
+        case .moveHere:
+            "Move here"
+        case .setHere:
+            "Set here"
+        }
+    }
 }
 #endif

--- a/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuViewModel.swift
+++ b/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuViewModel.swift
@@ -9,35 +9,38 @@ import QuranKit
 @MainActor
 final class ReadingBookmarkMenuViewModel: ObservableObject {
     enum Target {
-        case pages([Page])
+        case pages(Page, [Page])
         case ayah(AyahNumber)
 
-        var location: ReadingPositionBookmark.Location? {
+        var location: ReadingPositionBookmark.Location {
             switch self {
-            case .pages(let pages):
-                pages.min().map(ReadingPositionBookmark.Location.page)
+            case .pages(let page, _):
+                .page(page)
             case .ayah(let ayah):
                 .ayah(ayah)
             }
         }
 
-        var quran: Quran? {
+        var quran: Quran {
             switch self {
-            case .pages(let pages):
-                pages.first?.quran
+            case .pages(let page, _):
+                page.quran
             case .ayah(let ayah):
                 ayah.quran
             }
         }
-
-        var unavailableSubtitle: MultipartText {
-            .text("Reading position unavailable")
-        }
     }
 
     struct Item: Identifiable {
+        enum Action: Equatable {
+            case remove
+            case moveHere
+            case setHere
+        }
+
         let slot: ReadingBookmarkSlot
         let subtitle: MultipartText
+        let action: Action
         let isCurrent: Bool
         let isEnabled: Bool
 
@@ -63,14 +66,8 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
     @Published var error: Error?
 
     func start() async {
-        guard target.location != nil, let quran = target.quran else {
-            isLoading = false
-            refreshItems()
-            return
-        }
-
         do {
-            for try await bookmarks in service.readingBookmarksSequence(quran: quran) {
+            for try await bookmarks in service.readingBookmarksSequence(quran: target.quran) {
                 self.bookmarks = bookmarks
                 isLoading = false
                 refreshItems()
@@ -84,11 +81,12 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
     }
 
     func select(_ slot: ReadingBookmarkSlot) async -> Toast? {
-        guard !isMutating, let location = target.location else {
+        guard !isMutating else {
             return nil
         }
 
         isMutating = true
+        let location = target.location
         refreshItems()
         defer {
             isMutating = false
@@ -162,27 +160,16 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
         isLoading: Bool,
         isMutating: Bool
     ) -> [Item] {
-        ReadingBookmarkSlot.allCases.map { slot in
-            guard let location = target.location else {
-                return Item(
-                    slot: slot,
-                    subtitle: target.unavailableSubtitle,
-                    isCurrent: false,
-                    isEnabled: false
-                )
-            }
-            guard !isLoading else {
-                return Item(
-                    slot: slot,
-                    subtitle: .text("Loading…"),
-                    isCurrent: false,
-                    isEnabled: false
-                )
-            }
+        if isLoading {
+            return []
+        }
+        return ReadingBookmarkSlot.allCases.map { slot in
+            let location = target.location
             guard let bookmark = bookmarks.first(where: { $0.slot == slot }) else {
                 return Item(
                     slot: slot,
-                    subtitle: .text("Not placed — tap to set here"),
+                    subtitle: .text("Not placed yet"),
+                    action: .setHere,
                     isCurrent: false,
                     isEnabled: !isMutating
                 )
@@ -190,14 +177,16 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
             if bookmark.location == location {
                 return Item(
                     slot: slot,
-                    subtitle: .text("Saved here • Tap to remove"),
+                    subtitle: .text("Saved here"),
+                    action: .remove,
                     isCurrent: true,
                     isEnabled: !isMutating
                 )
             }
             return Item(
                 slot: slot,
-                subtitle: "Move here from \(Self.location(of: bookmark))",
+                subtitle: "at \(Self.location(of: bookmark))",
+                action: .moveHere,
                 isCurrent: false,
                 isEnabled: !isMutating
             )
@@ -207,20 +196,18 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
     private static func location(of bookmark: ReadingPositionBookmark) -> MultipartText {
         switch bookmark.location {
         case .ayah(let ayah):
-            "\(ayah: ayah)"
+            "\(ayah: ayah, decorationHidden: true)"
         case .page(let page):
             .text(page.localizedName)
         }
     }
 
+    // TODO: Fix
     private static func currentBookmarks(
         service: MobileSyncReadingBookmarkService,
         target: Target
     ) async throws -> [ReadingPositionBookmark] {
-        guard let quran = target.quran else {
-            return []
-        }
-        for try await bookmarks in service.readingBookmarksSequence(quran: quran) {
+        for try await bookmarks in service.readingBookmarksSequence(quran: target.quran) {
             return bookmarks
         }
         return []

--- a/Features/ReadingBookmarkMenuFeature/Tests/ReadingBookmarkMenuViewModelTests.swift
+++ b/Features/ReadingBookmarkMenuFeature/Tests/ReadingBookmarkMenuViewModelTests.swift
@@ -31,10 +31,30 @@ final class ReadingBookmarkMenuViewModelTests: XCTestCase {
 
         XCTAssertEqual(sut.items.map(\.slot), ReadingBookmarkSlot.allCases)
         XCTAssertTrue(sut.items.allSatisfy {
-            $0.subtitle.accessibilityText == "Not placed — tap to set here"
+            $0.subtitle.accessibilityText == "Not placed yet"
+                && $0.action == .setHere
                 && !$0.isCurrent
                 && $0.isEnabled
         })
+    }
+
+    func test_start_describesCurrentAndPlacedElsewhereSlots() async throws {
+        let selectedAyah = ayah(2)
+        try await service.addReadingBookmark(at: .ayah(selectedAyah), slot: .coral)
+        try await service.addReadingBookmark(at: .ayah(ayah(3)), slot: .teal)
+        let sut = makeSUT(target: .ayah(selectedAyah))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+
+        let current = sut.items.first { $0.slot == .coral }
+        XCTAssertEqual(current?.subtitle.accessibilityText, "Saved here")
+        XCTAssertEqual(current?.action, .remove)
+        XCTAssertEqual(current?.isCurrent, true)
+
+        let elsewhere = sut.items.first { $0.slot == .teal }
+        XCTAssertEqual(elsewhere?.subtitle.accessibilityText, "at Al-Fātihah, Ayah 3")
+        XCTAssertEqual(elsewhere?.action, .moveHere)
+        XCTAssertEqual(elsewhere?.isCurrent, false)
     }
 
     func test_selectUnsetSlot_persistsBookmarkAtTarget() async throws {
@@ -145,7 +165,7 @@ final class ReadingBookmarkMenuViewModelTests: XCTestCase {
     func test_pageTarget_usesFirstVisiblePage() async throws {
         let firstPage = Quran.hafsMadani1405.pages[40]
         let secondPage = Quran.hafsMadani1405.pages[41]
-        let sut = makeSUT(target: .pages([secondPage, firstPage]))
+        let sut = makeSUT(target: .pages(firstPage, [secondPage, firstPage]))
         let startTask = await start(sut)
         defer { startTask.cancel() }
 
@@ -153,6 +173,18 @@ final class ReadingBookmarkMenuViewModelTests: XCTestCase {
         let storedBookmark = try await storedBookmark(in: .teal)
 
         XCTAssertEqual(storedBookmark?.location, .page(firstPage))
+    }
+
+    func test_pageTarget_describesBookmarkOnCurrentPage() async throws {
+        let page = Quran.hafsMadani1405.pages[40]
+        try await service.addReadingBookmark(at: .page(page), slot: .coral)
+        let sut = makeSUT(target: .pages(page, [page]))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+
+        let current = sut.items.first { $0.slot == .coral }
+        XCTAssertEqual(current?.subtitle.accessibilityText, "Saved here")
+        XCTAssertEqual(current?.action, .remove)
     }
 
     private func makeSUT(target: ReadingBookmarkMenuViewModel.Target) -> ReadingBookmarkMenuViewModel {
@@ -163,7 +195,7 @@ final class ReadingBookmarkMenuViewModelTests: XCTestCase {
         let observed = expectation(description: "Loads reading bookmarks")
         var didFulfill = false
         let observation = sut.$items.sink { items in
-            guard !didFulfill, items.allSatisfy(\.isEnabled) else {
+            guard !didFulfill, !items.isEmpty, items.allSatisfy(\.isEnabled) else {
                 return
             }
             didFulfill = true

--- a/UI/NoorUI/Sources/Components/MultipartText+UIKit.swift
+++ b/UI/NoorUI/Sources/Components/MultipartText+UIKit.swift
@@ -27,8 +27,8 @@ private extension TextPart {
             highlightedAttributedString(text: text, ranges: ranges, size: size)
         case .sura(let sura):
             QuranReference.sura(sura).attributedString(size: size, locale: locale)
-        case .ayah(let ayah, let emphasizesSura):
-            QuranReference.ayah(ayah).attributedString(
+        case .ayah(let ayah, let emphasizesSura, let decorationHidden):
+            QuranReference.ayah(ayah, decorationHidden: decorationHidden).attributedString(
                 size: size,
                 locale: locale,
                 emphasizesSura: emphasizesSura

--- a/UI/NoorUI/Sources/Components/MultipartText.swift
+++ b/UI/NoorUI/Sources/Components/MultipartText.swift
@@ -48,9 +48,9 @@ private struct TextPartView: View {
                 .font(size.plainFont)
         case .sura(let sura):
             QuranReferenceView(reference: .sura(sura), size: size)
-        case .ayah(let ayah, let emphasizesSura):
+        case .ayah(let ayah, let emphasizesSura, let decorationHidden):
             QuranReferenceView(
-                reference: .ayah(ayah),
+                reference: .ayah(ayah, decorationHidden: decorationHidden),
                 size: size,
                 emphasizesSura: emphasizesSura
             )
@@ -123,7 +123,7 @@ enum TextPart {
     case plain(text: String)
     case highlighting(text: String, ranges: [HighlightingRange], lineLimit: Int?)
     case sura(Sura)
-    case ayah(AyahNumber, emphasizesSura: Bool)
+    case ayah(AyahNumber, emphasizesSura: Bool, decorationHidden: Bool = false)
     case ayahCoordinate(AyahNumber)
     case quran(
         text: QuranText,
@@ -141,8 +141,8 @@ enum TextPart {
             text
         case .sura(let sura):
             QuranReference.sura(sura).rawValue(locale: locale)
-        case .ayah(let ayah, _):
-            QuranReference.ayah(ayah).rawValue(locale: locale)
+        case .ayah(let ayah, _, let decorationHidden):
+            QuranReference.ayah(ayah, decorationHidden: decorationHidden).rawValue(locale: locale)
         case .ayahCoordinate(let ayah):
             ayah.localizedCoordinate(locale: locale)
         case .quran(let text, _, _, _, _):
@@ -156,7 +156,7 @@ enum TextPart {
             text
         case .sura(let sura):
             QuranReference.sura(sura).accessibilityText
-        case .ayah(let ayah, _):
+        case .ayah(let ayah, _, _):
             QuranReference.ayah(ayah).accessibilityText
         case .ayahCoordinate(let ayah):
             ayah.localizedCoordinate()
@@ -184,9 +184,10 @@ public struct MultipartText: ExpressibleByStringInterpolation {
 
         public mutating func appendInterpolation(
             ayah: AyahNumber,
-            emphasizingSura: Bool = false
+            emphasizingSura: Bool = false,
+            decorationHidden: Bool = false
         ) {
-            parts.append(.ayah(ayah, emphasizesSura: emphasizingSura))
+            parts.append(.ayah(ayah, emphasizesSura: emphasizingSura, decorationHidden: decorationHidden))
         }
 
         public mutating func appendInterpolation(ayahRange range: ClosedRange<AyahNumber>) {

--- a/UI/NoorUI/Sources/Components/QuranReference.swift
+++ b/UI/NoorUI/Sources/Components/QuranReference.swift
@@ -30,7 +30,7 @@ enum QuranReference {
     }
 
     case sura(Sura)
-    case ayah(AyahNumber)
+    case ayah(AyahNumber, decorationHidden: Bool = false)
 
     // MARK: Internal
 
@@ -38,7 +38,7 @@ enum QuranReference {
         switch self {
         case .sura(let sura):
             sura.localizedName()
-        case .ayah(let ayah):
+        case .ayah(let ayah, _):
             ayah.localizedName
         }
     }
@@ -56,14 +56,17 @@ enum QuranReference {
     }
 
     fileprivate func localizedName(locale: Locale) -> String? {
-        locale.isArabicLanguage ? nil : sura.localizedName()
+        if decorationHidden, locale.isArabicLanguage {
+            return sura.localizedName(language: .arabic)
+        }
+        return locale.isArabicLanguage ? nil : sura.localizedName()
     }
 
     fileprivate func coordinate(locale: Locale) -> String? {
         switch self {
         case .sura:
             nil
-        case .ayah(let ayah):
+        case .ayah(let ayah, _):
             ayah.localizedCoordinate(locale: locale)
         }
     }
@@ -73,7 +76,9 @@ enum QuranReference {
         if let localizedName = localizedName(locale: locale) {
             components.append(localizedName)
         }
-        components.append(arabicName.text)
+        if !decorationHidden {
+            components.append(arabicName.text)
+        }
 
         let suraReference = components.joined(separator: " ")
         if let coordinate = coordinate(locale: locale) {
@@ -93,18 +98,22 @@ enum QuranReference {
                 string: localizedName,
                 attributes: [.font: size.plainUIFont(emphasized: emphasizesSura)]
             ))
-            result.append(NSAttributedString(string: " "))
         }
 
-        let arabicNameFont: UIFont = switch arabicName {
-        case .decoratedGlyph: size.suraUIFont
-        case .indoPakText: size.quranUIFont(.indoPak)
+        if !decorationHidden {
+            if result.length > 0 {
+                result.append(NSAttributedString(string: " "))
+            }
+            let arabicNameFont: UIFont = switch arabicName {
+            case .decoratedGlyph: size.suraUIFont
+            case .indoPakText: size.quranUIFont(.indoPak)
+            }
+            var arabicNameAttributes: [NSAttributedString.Key: Any] = [.font: arabicNameFont]
+            if !arabicName.isIndoPakText {
+                arabicNameAttributes[.baselineOffset] = -2
+            }
+            result.append(NSAttributedString(string: arabicName.text, attributes: arabicNameAttributes))
         }
-        var arabicNameAttributes: [NSAttributedString.Key: Any] = [.font: arabicNameFont]
-        if !arabicName.isIndoPakText {
-            arabicNameAttributes[.baselineOffset] = -2
-        }
-        result.append(NSAttributedString(string: arabicName.text, attributes: arabicNameAttributes))
 
         if let coordinate = coordinate(locale: locale) {
             result.append(NSAttributedString(
@@ -115,13 +124,22 @@ enum QuranReference {
         return result
     }
 
+    fileprivate var decorationHidden: Bool {
+        switch self {
+        case .sura:
+            false
+        case .ayah(_, let decorationHidden):
+            decorationHidden
+        }
+    }
+
     // MARK: Private
 
     private var sura: Sura {
         switch self {
         case .sura(let sura):
             sura
-        case .ayah(let ayah):
+        case .ayah(let ayah, _):
             ayah.sura
         }
     }
@@ -181,15 +199,17 @@ struct QuranReferenceView: View {
                     .fontWeight(emphasizesSura ? .heavy : nil)
             }
 
-            switch arabicName {
-            case .decoratedGlyph(let text):
-                Text(text)
-                    .font(size.suraFont)
-                    .padding(.top, glyphTopPadding)
-            case .indoPakText(let text):
-                Text(text)
-                    .font(size.quranFont(.indoPak))
-                    .padding(.vertical, size.indoPakReferenceVerticalPadding(glyphTopPadding: glyphTopPadding))
+            if !reference.decorationHidden {
+                switch arabicName {
+                case .decoratedGlyph(let text):
+                    Text(text)
+                        .font(size.suraFont)
+                        .padding(.top, glyphTopPadding)
+                case .indoPakText(let text):
+                    Text(text)
+                        .font(size.quranFont(.indoPak))
+                        .padding(.vertical, size.indoPakReferenceVerticalPadding(glyphTopPadding: glyphTopPadding))
+                }
             }
 
             if let coordinate = reference.coordinate(locale: locale) {
@@ -202,6 +222,7 @@ struct QuranReferenceView: View {
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(reference.accessibilityText)
+        .fixedSize()
     }
 }
 

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -258,7 +258,7 @@ private struct AyahMenuViewList: View {
         case .available(let slot):
             Row(
                 title: l("ayah.menu.reading-bookmark.title"),
-                subtitle: .text(slot?.displayName ?? "Choose a bookmark"),
+                subtitle: .text(slot?.displayName ?? "Move here"),
                 subtitlePlacement: .below,
                 action: dataObject.actions.showReadingBookmarkMenu
             ) {

--- a/UI/NoorUI/Tests/MultipartTextQuranTests.swift
+++ b/UI/NoorUI/Tests/MultipartTextQuranTests.swift
@@ -58,6 +58,38 @@ final class MultipartTextQuranTests: XCTestCase {
         XCTAssertEqual(text.rawValue(locale: arabic), "\u{E905} · ٢:٢٥٥")
     }
 
+    func test_ayahReference_withDecorationHidden_keepsLocalizedNameAndCoordinate() {
+        let text: MultipartText = "\(ayah: ayah, decorationHidden: true)"
+
+        XCTAssertEqual(text.rawValue(locale: english), "\(sura.localizedName()) · 2:255")
+        XCTAssertEqual(text.accessibilityText, ayah.localizedName)
+    }
+
+    func test_ayahReference_withDecorationHidden_inArabicLocale_keepsPlainArabicName() {
+        let text: MultipartText = "\(ayah: ayah, decorationHidden: true)"
+
+        XCTAssertEqual(text.rawValue(locale: arabic), "\(sura.localizedName(language: .arabic)) · ٢:٢٥٥")
+    }
+
+    func test_indoPakAyahReference_withDecorationHidden_omitsAdditionalArabicName() {
+        let ayah = Quran.hafsIndoPak.suras[1].verses[254]
+        let text: MultipartText = "\(ayah: ayah, decorationHidden: true)"
+
+        XCTAssertEqual(text.rawValue(locale: english), "\(ayah.sura.localizedName()) · 2:255")
+    }
+
+    @MainActor
+    func test_ayahReference_withDecorationHidden_preservesUIKitRendering() {
+        let text: MultipartText = "\(ayah: ayah, emphasizingSura: true, decorationHidden: true)"
+
+        XCTAssertEqual(text.attributedString(ofSize: .body).string, text.rawValue)
+        XCTAssertFalse(text.attributedString(ofSize: .body).string.contains("\u{E905}"))
+        XCTAssertEqual(
+            QuranReference.ayah(ayah, decorationHidden: true).attributedString(size: .body, locale: arabic).string,
+            text.rawValue(locale: arabic)
+        )
+    }
+
     func test_singleAyahRange_usesStartReference() {
         let text: MultipartText = "\(ayahRange: ayah ... ayah)"
 


### PR DESCRIPTION
## Summary

- Refine the reading bookmark menu with a leading header, explanatory subtitle, existing colored pins, and explicit Remove, Move here, and Set here actions.
- Add the MultipartText ayah decorationHidden option across SwiftUI and UIKit while preserving localization and accessibility.
- Make the page target explicit, simplify loading state, and update regression coverage.

## Validation

- make format-lint
- make test-sync: 565 tests passed
- make test-no-sync: 445 tests passed (iPhone 17 Pro Max, iOS 26.5)
- make build-example-sync: passed for iOS Simulator
- Visually checked the app on iPhone 17 Pro Max and iPad (A16); captured the menu states without changing saved bookmarks.

Edit remains the existing placeholder action.

## Screenshots

| iPhone — page bookmark menu | iPhone — ayah bookmark menu |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/8a030b0c-f2e9-4578-869f-a5570ccebf5f" alt="iPhone — page bookmark menu" width="300"> | <img src="https://github.com/user-attachments/assets/d913b923-d3c3-422b-8608-34f26f3b68ae" alt="iPhone — ayah bookmark menu" width="300"> |

| iPad — page bookmark menu | iPad — ayah actions |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/702746df-e937-48d1-8d10-6ba4e1bc89be" alt="iPad — page bookmark menu" width="300"> | <img src="https://github.com/user-attachments/assets/04985916-a2cc-4307-a8cf-993a76906037" alt="iPad — ayah actions" width="300"> |
