### PR TITLE
feat: add inline reading bookmark name editing

### DIFF
--- a/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuRow.swift
+++ b/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuRow.swift
@@ -1,0 +1,126 @@
+#if QURAN_SYNC
+import NoorUI
+import SwiftUI
+import UIx
+
+@MainActor
+struct ReadingBookmarkMenuRow: View {
+    let item: ReadingBookmarkMenuViewModel.Item
+    let title: String
+    @Binding var name: String
+    @Binding var editMode: EditMode
+    let select: AsyncAction
+
+    @ScaledMetric private var verticalPadding = 12.0
+    @ScaledMetric private var actionHorizontalPadding = 12.0
+    @ScaledMetric private var actionVerticalPadding = 6.0
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if editMode.isEditing {
+                editingRow
+            } else {
+                bookmarkRow
+            }
+        }
+        .disabled(!item.isEnabled)
+    }
+
+    private var editingRow: some View {
+        HStack {
+            pin
+            TextField(item.slot.displayName, text: $name)
+                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.words)
+                .disableAutocorrection(true)
+                .submitLabel(.done)
+                .onSubmit { editMode = .inactive }
+                .accessibilityLabel("\(item.slot.displayName) pin name")
+        }
+        .padding(.horizontal)
+        .padding(.vertical, verticalPadding)
+    }
+
+    private var bookmarkRow: some View {
+        AsyncButton {
+            await select()
+        } label: {
+            HStack {
+                pin
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                        .fontWeight(.semibold)
+                        .foregroundColor(item.isEnabled ? .label : .tertiaryLabel)
+                    item.subtitle.view(ofSize: .footnote)
+                        .foregroundColor(item.isEnabled ? .secondaryLabel : .tertiaryLabel)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 0)
+                actionLabel
+                    .opacity(item.isEnabled ? 1 : 0.4)
+            }
+            .padding(.horizontal)
+            .padding(.vertical, verticalPadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(BackgroundHighlightingStyle())
+    }
+
+    private var pin: some View {
+        ReadingBookmarkPin(style: .filled)
+            .foregroundColor(item.isEnabled ? item.slot.swiftUIColor : .tertiaryLabel)
+            .accessibilityHidden(true)
+    }
+
+    private var actionLabel: some View {
+        Group {
+            switch item.action {
+            case .remove:
+                Text(item.action.title)
+                    .foregroundStyle(Color.systemRed)
+            case .moveHere, .setHere:
+                Text(item.action.title)
+                    .foregroundStyle(item.action == .moveHere ? Color.white : Color.accentColor)
+                    .padding(.horizontal, actionHorizontalPadding)
+                    .padding(.vertical, actionVerticalPadding)
+                    .background(
+                        Color.accentColor.opacity(item.action == .moveHere ? 1 : 0.1),
+                        in: Capsule()
+                    )
+            }
+        }
+        .font(.footnote.bold())
+        .fixedSize()
+    }
+}
+
+#Preview {
+    ReadingBookmarkMenuRow(
+        item: .init(
+            slot: .coral,
+            subtitle: .text("Saved here"),
+            action: .remove,
+            isCurrent: true,
+            isEnabled: true
+        ),
+        title: "Coral",
+        name: .constant("Coral"),
+        editMode: .constant(.active),
+        select: {}
+    )
+}
+
+private extension ReadingBookmarkMenuViewModel.Item.Action {
+    var title: String {
+        switch self {
+        case .remove:
+            "Remove"
+        case .moveHere:
+            "Move here"
+        case .setHere:
+            "Set here"
+        }
+    }
+}
+#endif

--- a/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuView.swift
+++ b/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuView.swift
@@ -48,10 +48,10 @@ private struct ReadingBookmarkMenuContent: View {
     let start: AsyncAction
     let select: AsyncItemAction<ReadingBookmarkSlot>
 
+    @State private var editMode: EditMode = .inactive
+    @State private var draftNames: [ReadingBookmarkSlot: String] = [:]
+
     @ScaledMetric private var minimumWidth = 320.0
-    @ScaledMetric private var verticalPadding = 12.0
-    @ScaledMetric private var actionHorizontalPadding = 12.0
-    @ScaledMetric private var actionVerticalPadding = 6.0
 
     var body: some View {
         PreferredContentSizeMatchesScrollView {
@@ -60,7 +60,16 @@ private struct ReadingBookmarkMenuContent: View {
                     header
 
                     ForEach(items) { item in
-                        row(item)
+                        ReadingBookmarkMenuRow(
+                            item: item,
+                            title: displayName(for: item.slot),
+                            name: Binding(
+                                get: { draftNames[item.slot] ?? item.slot.displayName },
+                                set: { draftNames[item.slot] = $0 }
+                            ),
+                            editMode: $editMode,
+                            select: { await select(item.slot) }
+                        )
                         if item.id != items.last?.id {
                             Divider()
                                 .padding(.horizontal)
@@ -75,6 +84,11 @@ private struct ReadingBookmarkMenuContent: View {
             await start()
         }
         .errorAlert(error: $error)
+        .onChange(of: editMode) { mode in
+            if mode.isEditing {
+                draftNames.removeAll()
+            }
+        }
     }
 
     private var header: some View {
@@ -85,9 +99,9 @@ private struct ReadingBookmarkMenuContent: View {
                     .foregroundStyle(Color.label)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .accessibilityAddTraits(.isHeader)
-                Button("Edit", action: {})
+                EditModeButton(editMode: $editMode)
                     .buttonStyle(.plain)
-                    .foregroundStyle(Color.accentColor)
+                    .disabled(items.isEmpty || items.contains { !$0.isEnabled })
             }
             .font(.subheadline.weight(.semibold))
             Divider()
@@ -100,54 +114,9 @@ private struct ReadingBookmarkMenuContent: View {
         .padding()
     }
 
-    private func row(_ item: ReadingBookmarkMenuViewModel.Item) -> some View {
-        AsyncButton {
-            await select(item.slot)
-        } label: {
-            HStack(spacing: 14) {
-                ReadingBookmarkPin(style: .filled)
-                    .foregroundColor(item.isEnabled ? item.slot.swiftUIColor : .tertiaryLabel)
-                    .accessibilityHidden(true)
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(item.slot.displayName)
-                        .fontWeight(.semibold)
-                        .foregroundColor(item.isEnabled ? .label : .tertiaryLabel)
-                    item.subtitle.view(ofSize: .footnote)
-                        .foregroundColor(item.isEnabled ? .secondaryLabel : .tertiaryLabel)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                Spacer(minLength: 0)
-                actionLabel(item.action)
-                    .opacity(item.isEnabled ? 1 : 0.4)
-            }
-            .padding(.horizontal)
-            .padding(.vertical, verticalPadding)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(BackgroundHighlightingStyle())
-        .disabled(!item.isEnabled)
-    }
-
-    private func actionLabel(_ action: ReadingBookmarkMenuViewModel.Item.Action) -> some View {
-        Group {
-            switch action {
-            case .remove:
-                Text(action.title)
-                    .foregroundStyle(Color.systemRed)
-            case .moveHere, .setHere:
-                Text(action.title)
-                    .foregroundStyle(action == .moveHere ? Color.white : Color.accentColor)
-                    .padding(.horizontal, actionHorizontalPadding)
-                    .padding(.vertical, actionVerticalPadding)
-                    .background(
-                        Color.accentColor.opacity(action == .moveHere ? 1 : 0.1),
-                        in: Capsule()
-                    )
-            }
-        }
-        .font(.footnote.bold())
-        .fixedSize()
+    private func displayName(for slot: ReadingBookmarkSlot) -> String {
+        let name = draftNames[slot]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return name.isEmpty ? slot.displayName : name
     }
 }
 
@@ -182,16 +151,4 @@ private struct ReadingBookmarkMenuContent: View {
     )
 }
 
-private extension ReadingBookmarkMenuViewModel.Item.Action {
-    var title: String {
-        switch self {
-        case .remove:
-            "Remove"
-        case .moveHere:
-            "Move here"
-        case .setHere:
-            "Set here"
-        }
-    }
-}
 #endif

--- a/UI/NoorUI/Sources/Components/NavigationActions.swift
+++ b/UI/NoorUI/Sources/Components/NavigationActions.swift
@@ -112,7 +112,7 @@ public struct EditModeButton: View {
     public var body: some View {
         EditButton()
             .environment(\.editMode, $editMode)
-            .foregroundStyle(editMode.isEditing ? Color.appIdentity : Color.label)
+            .foregroundStyle(editMode.isEditing ? Color.accentColor : Color.label)
     }
 
     @Binding private var editMode: EditMode


### PR DESCRIPTION
## Summary

- Replace reading bookmark titles with prefilled text fields in Edit mode, hiding subtitles and bookmark actions until Done.
- Extract ReadingBookmarkMenuRow to own both editing and normal row layouts.
- Use the current accent color for the shared EditModeButton's Done state.

## Scope

Name changes are UI-only drafts. They are not persisted or synced, and entering Edit resets the drafts.

## Validation

- `make build-no-sync` — passed.
- `make build-sync` — passed.
- No tests run, as requested.

## Screenshots

| Normal mode | Editing mode |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/ecccaf82-ef61-4c67-9018-8cc6a2130f1a" alt="Reading bookmarks in normal mode" width="300"> | <img src="https://github.com/user-attachments/assets/7f053881-a9a6-45d0-96f7-bc66965bf607" alt="Reading bookmarks with editable pin names" width="300"> |
