### PR TITLE
fix: restore previous reading bookmark on undo

### DIFF
--- a/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuViewModel.swift
+++ b/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuViewModel.swift
@@ -99,9 +99,9 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
                 let clearedBookmark = try await service.clearReadingBookmark(in: slot)
                 bookmarks.removeAll { $0.slot == slot }
                 bookmarks.append(clearedBookmark)
-                return ReadingBookmarkUndoToast.removed(bookmark) { [service, target] in
+                return ReadingBookmarkUndoToast.removed(bookmark) {
                     Task { @MainActor in
-                        await Self.undoRemoval(bookmark, service: service, target: target)
+                        await self.restore(bookmark)
                     }
                 }
             }
@@ -114,14 +114,9 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
                 return ReadingBookmarkUndoToast.moved(
                     from: previousBookmark,
                     to: bookmark
-                ) { [service, target] in
+                ) {
                     Task { @MainActor in
-                        await Self.undoMove(
-                            bookmark,
-                            to: previousBookmark,
-                            service: service,
-                            target: target
-                        )
+                        await self.restore(previousBookmark)
                     }
                 }
             }
@@ -203,50 +198,11 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
         }
     }
 
-    // TODO: Fix
-    private static func currentBookmarks(
-        service: MobileSyncReadingBookmarkService,
-        target: Target
-    ) async throws -> [PlacedReadingBookmark] {
-        for try await bookmarks in service.placedReadingBookmarksSequence(quran: target.quran) {
-            return bookmarks
-        }
-        return []
-    }
-
-    private static func undoRemoval(
-        _ bookmark: PlacedReadingBookmark,
-        service: MobileSyncReadingBookmarkService,
-        target: Target
-    ) async {
+    private func restore(_ bookmark: PlacedReadingBookmark) async {
         do {
-            let bookmarks = try await currentBookmarks(service: service, target: target)
-            guard !bookmarks.contains(where: { $0.slot == bookmark.slot }) else {
-                return
-            }
             try await service.addReadingBookmark(at: bookmark.placement, slot: bookmark.slot)
         } catch {
-            crasher.recordError(error, reason: "Failed to undo reading bookmark removal")
-        }
-    }
-
-    private static func undoMove(
-        _ movedBookmark: PlacedReadingBookmark,
-        to previousBookmark: PlacedReadingBookmark,
-        service: MobileSyncReadingBookmarkService,
-        target: Target
-    ) async {
-        do {
-            let bookmarks = try await currentBookmarks(service: service, target: target)
-            guard bookmarks.first(where: { $0.slot == movedBookmark.slot }) == movedBookmark else {
-                return
-            }
-            try await service.addReadingBookmark(
-                at: previousBookmark.placement,
-                slot: previousBookmark.slot
-            )
-        } catch {
-            crasher.recordError(error, reason: "Failed to undo reading bookmark move")
+            crasher.recordError(error, reason: "Failed to restore reading bookmark")
         }
     }
 }

--- a/Features/ReadingBookmarkMenuFeature/Tests/ReadingBookmarkMenuViewModelTests.swift
+++ b/Features/ReadingBookmarkMenuFeature/Tests/ReadingBookmarkMenuViewModelTests.swift
@@ -140,6 +140,44 @@ final class ReadingBookmarkMenuViewModelTests: XCTestCase {
         restored.task.cancel()
     }
 
+    func test_removedBookmarkUndo_restoresPreviousLocationAfterSlotChanges() async throws {
+        let previousAyah = ayah(2)
+        try await service.addReadingBookmark(at: .ayah(previousAyah), slot: .coral)
+        let sut = makeSUT(target: .ayah(previousAyah))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+        let toast = await sut.select(.coral)
+        try await service.addReadingBookmark(at: .ayah(ayah(3)), slot: .coral)
+        let restored = bookmarkExpectation(
+            description: "Restores removed bookmark over a later placement",
+            slot: .coral,
+            placement: .ayah(previousAyah)
+        )
+        defer { restored.task.cancel() }
+
+        try XCTUnwrap(toast?.action).handler()
+        await fulfillment(of: [restored.expectation], timeout: 2)
+    }
+
+    func test_movedBookmarkUndo_restoresPreviousLocationAfterSlotChanges() async throws {
+        let previousPage = Quran.hafsMadani1405.pages[40]
+        try await service.addReadingBookmark(at: .page(previousPage), slot: .indigo)
+        let sut = makeSUT(target: .ayah(ayah(2)))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+        let toast = await sut.select(.indigo)
+        try await service.addReadingBookmark(at: .ayah(ayah(3)), slot: .indigo)
+        let restored = bookmarkExpectation(
+            description: "Restores moved bookmark over a later placement",
+            slot: .indigo,
+            placement: .page(previousPage)
+        )
+        defer { restored.task.cancel() }
+
+        try XCTUnwrap(toast?.action).handler()
+        await fulfillment(of: [restored.expectation], timeout: 2)
+    }
+
     func test_start_updatesItemsWhenServicePublishesNewBookmark() async throws {
         let selectedAyah = ayah(2)
         let sut = makeSUT(target: .ayah(selectedAyah))


### PR DESCRIPTION
## Summary

- Restore the captured previous bookmark placement directly for move and removal undo, without fetching or comparing current bookmarks.
- Keep restore as an instance method on the view model.
- Add regression coverage for restoring ayah and page placements after the slot has changed again.

## Validation

- Formatting passed.
- Full suites passed before the final instance-method adjustment: 445 no-sync and 573 sync tests.
- ReadingBookmarkMenuFeatureTests passed against the final commit: 13 tests, zero failures.

## Scope

Unstaged Example project and scheme changes are excluded.