### PR TITLE
feat: persist custom reading bookmark names

### DIFF
--- a/Domain/AnnotationsService/Sources/MobileSyncReadingBookmarkService.swift
+++ b/Domain/AnnotationsService/Sources/MobileSyncReadingBookmarkService.swift
@@ -84,7 +84,24 @@ public struct MobileSyncReadingBookmarkService {
         )
     }
 
+    @discardableResult
+    public func renameReadingBookmark(
+        in slot: QuranAnnotations.ReadingBookmarkSlot,
+        name: String?,
+        quran: Quran
+    ) async throws -> QuranAnnotations.ReadingBookmark {
+        let bookmark = try await quranDataService.renameReadingBookmark(slot: slot.mobileSyncSlot, name: name)
+        guard let renamed = Self.readingBookmark(from: bookmark, quran: quran, storedPageQuran: storedPageQuran) else {
+            throw MappingError.invalidBookmark
+        }
+        return renamed
+    }
+
     // MARK: Private
+
+    private enum MappingError: Error {
+        case invalidBookmark
+    }
 
     private let quranDataService: QuranDataService
     private let storedPageQuran: Quran

--- a/Domain/AnnotationsService/Tests/MobileSyncReadingBookmarkServiceTests.swift
+++ b/Domain/AnnotationsService/Tests/MobileSyncReadingBookmarkServiceTests.swift
@@ -134,6 +134,66 @@ final class MobileSyncReadingBookmarkServiceTests: XCTestCase {
         XCTAssertEqual(placed?.first?.sura, expectedPage.firstVerse.sura)
     }
 
+    func test_renameReadingBookmark_preservesPlacedBookmark() async throws {
+        let original = try await service.addReadingBookmark(at: .ayah(ayah(255)), slot: .coral)
+
+        let renamed = try await service.renameReadingBookmark(in: .coral, name: "Daily reading", quran: .hafsMadani1405)
+        let stored = try await storedBookmark()
+
+        XCTAssertEqual(stored, renamed)
+        XCTAssertEqual(stored?.id, original.id)
+        XCTAssertEqual(stored?.placement, .ayah(ayah(255)))
+        XCTAssertEqual(stored?.name, "Daily reading")
+    }
+
+    func test_renameReadingBookmark_createsUnplacedPin() async throws {
+        let renamed = try await service.renameReadingBookmark(in: .teal, name: "Review", quran: .hafsMadani1405)
+
+        let stored = try await storedBookmark(in: .teal)
+        XCTAssertEqual(stored, renamed)
+        XCTAssertEqual(stored?.slot, .teal)
+        XCTAssertEqual(stored?.placement, .unplaced)
+        XCTAssertEqual(stored?.name, "Review")
+    }
+
+    func test_renameReadingBookmark_nilClearsNameWithoutClearingPage() async throws {
+        let page = Quran.hafsMadani1405.pages[40]
+        try await service.addReadingBookmark(at: .page(page), slot: .coral)
+        try await service.renameReadingBookmark(in: .coral, name: "Review", quran: .hafsMadani1405)
+
+        let renamed = try await service.renameReadingBookmark(in: .coral, name: nil, quran: .hafsMadani1405)
+        let stored = try await storedBookmark()
+
+        XCTAssertEqual(stored, renamed)
+        XCTAssertNil(stored?.name)
+        XCTAssertEqual(stored?.placement, .page(page))
+    }
+
+    func test_namedBookmark_preservesNameWhenMovedAndCleared() async throws {
+        try await service.renameReadingBookmark(in: .coral, name: "Daily reading", quran: .hafsMadani1405)
+
+        let moved = try await service.addReadingBookmark(at: .ayah(ayah(255)), slot: .coral)
+        let cleared = try await service.clearReadingBookmark(in: .coral)
+
+        XCTAssertEqual(moved.name, "Daily reading")
+        XCTAssertEqual(cleared.name, "Daily reading")
+        XCTAssertEqual(cleared.placement, .unplaced)
+    }
+
+    func test_renameReadingBookmark_returnsPageInRequestedQuran() async throws {
+        let page = Quran.hafsMadani1405.pages[40]
+        try await service.addReadingBookmark(at: .page(page), slot: .coral)
+        let quran = Quran.hafsIndoPak
+        let mappedPage = try XCTUnwrap(QuranPageMapper(destination: quran).mapPage(page))
+
+        let renamed = try await service.renameReadingBookmark(in: .coral, name: "Review", quran: quran)
+        let stored = try await storedBookmark(quran: quran)
+
+        XCTAssertEqual(renamed, stored)
+        XCTAssertEqual(renamed.placement, .page(mappedPage))
+        XCTAssertEqual(renamed.name, "Review")
+    }
+
     private func storedBookmark(
         in slot: ReadingBookmarkSlot = .coral,
         quran: Quran = .hafsMadani1405

--- a/Features/FeaturesSupport/Sources/ReadingBookmarkListItem.swift
+++ b/Features/FeaturesSupport/Sources/ReadingBookmarkListItem.swift
@@ -30,7 +30,7 @@ public struct ReadingBookmarkListItem: View {
                 Image(uiImage: ReadingBookmarkPin.image(style: .filled)),
                 color: bookmark.slot.swiftUIColor
             ),
-            title: "\(bookmark.slot.displayName) · \(sura: bookmark.sura)",
+            title: "\(bookmark.name ?? bookmark.slot.displayName) · \(sura: bookmark.sura)",
             subtitle: .init(
                 text: "\(locationTitle) · \(bookmark.modifiedOn.timeAgo())",
                 location: .bottom

--- a/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuRow.swift
+++ b/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuRow.swift
@@ -1,19 +1,60 @@
 #if QURAN_SYNC
 import NoorUI
+import QuranAnnotations
+import QuranKit
 import SwiftUI
 import UIx
 
 @MainActor
 struct ReadingBookmarkMenuRow: View {
+    enum Action {
+        case remove
+        case moveHere
+        case setHere
+    }
+
     let item: ReadingBookmarkMenuViewModel.Item
-    let title: String
+    let target: PlacedReadingBookmark.Placement
     @Binding var name: String
-    @Binding var editMode: EditMode
+    let isEnabled: Bool
+    let editMode: EditMode
+    let save: () async -> Bool
     let select: AsyncAction
+
+    @FocusState private var isNameFocused: Bool
 
     @ScaledMetric private var verticalPadding = 12.0
     @ScaledMetric private var actionHorizontalPadding = 12.0
     @ScaledMetric private var actionVerticalPadding = 6.0
+
+    var action: Action {
+        switch item.placement {
+        case .unplaced:
+            .setHere
+        case .ayah(let ayah):
+            target == .ayah(ayah) ? .remove : .moveHere
+        case .page(let page):
+            target == .page(page) ? .remove : .moveHere
+        }
+    }
+
+    var subtitle: MultipartText {
+        switch action {
+        case .remove:
+            return .text("Saved here")
+        case .setHere:
+            return .text("Not placed yet")
+        case .moveHere:
+            switch item.placement {
+            case .ayah(let ayah):
+                return "at \(ayah: ayah, decorationHidden: true)"
+            case .page(let page):
+                return "at \(page.localizedName)"
+            case .unplaced:
+                return .text("Not placed yet")
+            }
+        }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -23,18 +64,25 @@ struct ReadingBookmarkMenuRow: View {
                 bookmarkRow
             }
         }
-        .disabled(!item.isEnabled)
+        .disabled(!isEnabled)
     }
 
     private var editingRow: some View {
         HStack {
             pin
             TextField(item.slot.displayName, text: $name)
+                .focused($isNameFocused)
                 .textFieldStyle(.roundedBorder)
                 .textInputAutocapitalization(.words)
                 .disableAutocorrection(true)
                 .submitLabel(.done)
-                .onSubmit { editMode = .inactive }
+                .onSubmit {
+                    Task { @MainActor in
+                        if await save() {
+                            isNameFocused = false
+                        }
+                    }
+                }
                 .accessibilityLabel("\(item.slot.displayName) pin name")
         }
         .padding(.horizontal)
@@ -48,16 +96,16 @@ struct ReadingBookmarkMenuRow: View {
             HStack {
                 pin
                 VStack(alignment: .leading, spacing: 1) {
-                    Text(title)
+                    Text(item.name ?? item.slot.displayName)
                         .fontWeight(.semibold)
-                        .foregroundColor(item.isEnabled ? .label : .tertiaryLabel)
-                    item.subtitle.view(ofSize: .footnote)
-                        .foregroundColor(item.isEnabled ? .secondaryLabel : .tertiaryLabel)
+                        .foregroundColor(isEnabled ? .label : .tertiaryLabel)
+                    subtitle.view(ofSize: .footnote)
+                        .foregroundColor(isEnabled ? .secondaryLabel : .tertiaryLabel)
                         .fixedSize(horizontal: false, vertical: true)
                 }
                 Spacer(minLength: 0)
                 actionLabel
-                    .opacity(item.isEnabled ? 1 : 0.4)
+                    .opacity(isEnabled ? 1 : 0.4)
             }
             .padding(.horizontal)
             .padding(.vertical, verticalPadding)
@@ -69,23 +117,23 @@ struct ReadingBookmarkMenuRow: View {
 
     private var pin: some View {
         ReadingBookmarkPin(style: .filled)
-            .foregroundColor(item.isEnabled ? item.slot.swiftUIColor : .tertiaryLabel)
+            .foregroundColor(isEnabled ? item.slot.swiftUIColor : .tertiaryLabel)
             .accessibilityHidden(true)
     }
 
     private var actionLabel: some View {
         Group {
-            switch item.action {
+            switch action {
             case .remove:
-                Text(item.action.title)
+                Text(action.title)
                     .foregroundStyle(Color.systemRed)
             case .moveHere, .setHere:
-                Text(item.action.title)
-                    .foregroundStyle(item.action == .moveHere ? Color.white : Color.accentColor)
+                Text(action.title)
+                    .foregroundStyle(action == .moveHere ? Color.white : Color.accentColor)
                     .padding(.horizontal, actionHorizontalPadding)
                     .padding(.vertical, actionVerticalPadding)
                     .background(
-                        Color.accentColor.opacity(item.action == .moveHere ? 1 : 0.1),
+                        Color.accentColor.opacity(action == .moveHere ? 1 : 0.1),
                         in: Capsule()
                     )
             }
@@ -99,19 +147,19 @@ struct ReadingBookmarkMenuRow: View {
     ReadingBookmarkMenuRow(
         item: .init(
             slot: .coral,
-            subtitle: .text("Saved here"),
-            action: .remove,
-            isCurrent: true,
-            isEnabled: true
+            name: nil,
+            placement: .page(Quran.hafsMadani1405.pages[0])
         ),
-        title: "Coral",
-        name: .constant("Coral"),
-        editMode: .constant(.active),
+        target: .page(Quran.hafsMadani1405.pages[0]),
+        name: .constant(""),
+        isEnabled: true,
+        editMode: .active,
+        save: { true },
         select: {}
     )
 }
 
-private extension ReadingBookmarkMenuViewModel.Item.Action {
+private extension ReadingBookmarkMenuRow.Action {
     var title: String {
         switch self {
         case .remove:

--- a/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuView.swift
+++ b/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuView.swift
@@ -20,8 +20,13 @@ struct ReadingBookmarkMenuView: View {
     var body: some View {
         ReadingBookmarkMenuContent(
             error: $viewModel.error,
+            draftNames: $viewModel.draftNames,
+            editMode: viewModel.editModeBinding,
             items: viewModel.items,
+            target: viewModel.target.placement,
+            isEnabled: !viewModel.isMutating,
             start: { await viewModel.start() },
+            saveNames: { await viewModel.saveNames(in: $0) },
             select: { slot in await select(slot) }
         )
     }
@@ -43,13 +48,15 @@ struct ReadingBookmarkMenuView: View {
 @MainActor
 private struct ReadingBookmarkMenuContent: View {
     @Binding var error: Error?
+    @Binding var draftNames: [ReadingBookmarkSlot: String]
+    @Binding var editMode: EditMode
 
     let items: [ReadingBookmarkMenuViewModel.Item]
+    let target: PlacedReadingBookmark.Placement
+    let isEnabled: Bool
     let start: AsyncAction
+    let saveNames: ([ReadingBookmarkSlot]) async -> Bool
     let select: AsyncItemAction<ReadingBookmarkSlot>
-
-    @State private var editMode: EditMode = .inactive
-    @State private var draftNames: [ReadingBookmarkSlot: String] = [:]
 
     @ScaledMetric private var minimumWidth = 320.0
 
@@ -62,15 +69,17 @@ private struct ReadingBookmarkMenuContent: View {
                     ForEach(items) { item in
                         ReadingBookmarkMenuRow(
                             item: item,
-                            title: displayName(for: item.slot),
+                            target: target,
                             name: Binding(
-                                get: { draftNames[item.slot] ?? item.slot.displayName },
+                                get: { draftNames[item.slot] ?? item.name ?? "" },
                                 set: { draftNames[item.slot] = $0 }
                             ),
-                            editMode: $editMode,
+                            isEnabled: isEnabled,
+                            editMode: editMode,
+                            save: { await saveNames([item.slot]) },
                             select: { await select(item.slot) }
                         )
-                        if item.id != items.last?.id {
+                        if item.slot != items.last?.slot {
                             Divider()
                                 .padding(.horizontal)
                         }
@@ -84,11 +93,6 @@ private struct ReadingBookmarkMenuContent: View {
             await start()
         }
         .errorAlert(error: $error)
-        .onChange(of: editMode) { mode in
-            if mode.isEditing {
-                draftNames.removeAll()
-            }
-        }
     }
 
     private var header: some View {
@@ -101,7 +105,7 @@ private struct ReadingBookmarkMenuContent: View {
                     .accessibilityAddTraits(.isHeader)
                 EditModeButton(editMode: $editMode)
                     .buttonStyle(.plain)
-                    .disabled(items.isEmpty || items.contains { !$0.isEnabled })
+                    .disabled(items.isEmpty || !isEnabled)
             }
             .font(.subheadline.weight(.semibold))
             Divider()
@@ -113,40 +117,34 @@ private struct ReadingBookmarkMenuContent: View {
         }
         .padding()
     }
-
-    private func displayName(for slot: ReadingBookmarkSlot) -> String {
-        let name = draftNames[slot]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return name.isEmpty ? slot.displayName : name
-    }
 }
 
 #Preview {
     ReadingBookmarkMenuContent(
         error: .constant(nil),
+        draftNames: .constant([:]),
+        editMode: .constant(.inactive),
         items: [
             .init(
                 slot: .coral,
-                subtitle: .text("Saved here"),
-                action: .remove,
-                isCurrent: true,
-                isEnabled: true
+                name: nil,
+                placement: .page(Quran.hafsMadani1405.pages[0])
             ),
             .init(
                 slot: .teal,
-                subtitle: "at \(ayah: Quran.hafsMadani1405.suras[1].verses[29], decorationHidden: true)",
-                action: .moveHere,
-                isCurrent: false,
-                isEnabled: true
+                name: nil,
+                placement: .ayah(Quran.hafsMadani1405.suras[1].verses[29])
             ),
             .init(
                 slot: .indigo,
-                subtitle: .text("Not placed yet"),
-                action: .setHere,
-                isCurrent: false,
-                isEnabled: true
+                name: nil,
+                placement: .unplaced
             ),
         ],
+        target: .page(Quran.hafsMadani1405.pages[0]),
+        isEnabled: true,
         start: {},
+        saveNames: { _ in true },
         select: { _ in }
     )
 }

--- a/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuViewModel.swift
+++ b/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuViewModel.swift
@@ -5,9 +5,18 @@ import Crashing
 import NoorUI
 import QuranAnnotations
 import QuranKit
+import SwiftUI
 
 @MainActor
 final class ReadingBookmarkMenuViewModel: ObservableObject {
+    struct Item: Identifiable {
+        let slot: ReadingBookmarkSlot
+        let name: String?
+        let placement: ReadingBookmark.Placement
+
+        var id: ReadingBookmarkSlot { slot }
+    }
+
     enum Target {
         case pages(Page, [Page])
         case ayah(AyahNumber)
@@ -31,51 +40,100 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
         }
     }
 
-    struct Item: Identifiable {
-        enum Action: Equatable {
-            case remove
-            case moveHere
-            case setHere
-        }
-
-        let slot: ReadingBookmarkSlot
-        let subtitle: MultipartText
-        let action: Action
-        let isCurrent: Bool
-        let isEnabled: Bool
-
-        var id: ReadingBookmarkSlot { slot }
-    }
-
     // MARK: Lifecycle
 
     init(service: MobileSyncReadingBookmarkService, target: Target) {
         self.service = service
         self.target = target
-        items = Self.makeItems(
-            bookmarks: [],
-            target: target,
-            isLoading: true,
-            isMutating: false
-        )
     }
 
     // MARK: Internal
 
-    @Published private(set) var items: [Item]
+    let target: Target
     @Published var error: Error?
+    @Published var draftNames: [ReadingBookmarkSlot: String] = [:]
+    @Published private(set) var editMode: EditMode = .inactive
+
+    var items: [Item] {
+        if isLoading {
+            return []
+        }
+        return ReadingBookmarkSlot.allCases.map { slot in
+            let bookmark = bookmark(in: slot)
+            return Item(
+                slot: slot,
+                name: bookmark?.name,
+                placement: bookmark?.placement ?? .unplaced
+            )
+        }
+    }
+
+    var editModeBinding: Binding<EditMode> {
+        Binding(
+            get: { self.editMode },
+            set: { mode in
+                if mode.isEditing {
+                    self.beginEditing()
+                } else {
+                    Task { @MainActor in
+                        await self.finishEditing()
+                    }
+                }
+            }
+        )
+    }
+
+    func beginEditing() {
+        draftNames = [:]
+        editMode = .active
+    }
+
+    func finishEditing() async {
+        if await saveNames(in: ReadingBookmarkSlot.allCases) {
+            editMode = .inactive
+        }
+    }
+
+    func saveNames(in slots: [ReadingBookmarkSlot]) async -> Bool {
+        guard !isLoading, !isMutating else { return false }
+        isMutating = true
+        defer {
+            isMutating = false
+        }
+
+        do {
+            for slot in slots {
+                guard let draft = draftNames[slot] else { continue }
+                let name = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+                if name != (bookmark(in: slot)?.name ?? "") {
+                    let renamed = try await service.renameReadingBookmark(
+                        in: slot,
+                        name: name.isEmpty ? nil : name,
+                        quran: target.quran
+                    )
+                    storedBookmarks.removeAll { $0.slot == slot }
+                    storedBookmarks.append(renamed)
+                }
+                draftNames.removeValue(forKey: slot)
+            }
+            return true
+        } catch is CancellationError {
+            return false
+        } catch {
+            self.error = error
+            return false
+        }
+    }
 
     func start() async {
         do {
             for try await bookmarks in service.readingBookmarksSequence(quran: target.quran) {
-                self.bookmarks = bookmarks
+                storedBookmarks = bookmarks
                 isLoading = false
-                refreshItems()
             }
         } catch is CancellationError {
         } catch {
             isLoading = false
-            refreshItems()
             self.error = error
         }
     }
@@ -87,18 +145,16 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
 
         isMutating = true
         let placement = target.placement
-        refreshItems()
         defer {
             isMutating = false
-            refreshItems()
         }
 
         do {
             let previousBookmark = bookmark(in: slot).flatMap(PlacedReadingBookmark.init)
             if let bookmark = previousBookmark, bookmark.placement == placement {
                 let clearedBookmark = try await service.clearReadingBookmark(in: slot)
-                bookmarks.removeAll { $0.slot == slot }
-                bookmarks.append(clearedBookmark)
+                storedBookmarks.removeAll { $0.slot == slot }
+                storedBookmarks.append(clearedBookmark)
                 return ReadingBookmarkUndoToast.removed(bookmark) {
                     Task { @MainActor in
                         await self.restore(bookmark)
@@ -107,8 +163,8 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
             }
 
             let bookmark = try await service.addReadingBookmark(at: placement, slot: slot)
-            bookmarks.removeAll { $0.slot == slot }
-            bookmarks.append(ReadingBookmark(bookmark))
+            storedBookmarks.removeAll { $0.slot == slot }
+            storedBookmarks.append(ReadingBookmark(bookmark))
 
             if let previousBookmark {
                 return ReadingBookmarkUndoToast.moved(
@@ -132,70 +188,12 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
     // MARK: Private
 
     private let service: MobileSyncReadingBookmarkService
-    private let target: Target
-    private var bookmarks: [ReadingBookmark] = []
-    private var isLoading = true
-    private var isMutating = false
+    @Published private var storedBookmarks: [ReadingBookmark] = []
+    @Published private var isLoading = true
+    @Published private(set) var isMutating = false
 
     private func bookmark(in slot: ReadingBookmarkSlot) -> ReadingBookmark? {
-        bookmarks.first { $0.slot == slot }
-    }
-
-    private func refreshItems() {
-        items = Self.makeItems(
-            bookmarks: bookmarks,
-            target: target,
-            isLoading: isLoading,
-            isMutating: isMutating
-        )
-    }
-
-    private static func makeItems(
-        bookmarks: [ReadingBookmark],
-        target: Target,
-        isLoading: Bool,
-        isMutating: Bool
-    ) -> [Item] {
-        if isLoading {
-            return []
-        }
-        return ReadingBookmarkSlot.allCases.map { slot in
-            let placement = target.placement
-            guard let bookmark = bookmarks.first(where: { $0.slot == slot }).flatMap(PlacedReadingBookmark.init) else {
-                return Item(
-                    slot: slot,
-                    subtitle: .text("Not placed yet"),
-                    action: .setHere,
-                    isCurrent: false,
-                    isEnabled: !isMutating
-                )
-            }
-            if bookmark.placement == placement {
-                return Item(
-                    slot: slot,
-                    subtitle: .text("Saved here"),
-                    action: .remove,
-                    isCurrent: true,
-                    isEnabled: !isMutating
-                )
-            }
-            return Item(
-                slot: slot,
-                subtitle: "at \(Self.locationTitle(bookmark.placement))",
-                action: .moveHere,
-                isCurrent: false,
-                isEnabled: !isMutating
-            )
-        }
-    }
-
-    private static func locationTitle(_ placement: PlacedReadingBookmark.Placement) -> MultipartText {
-        switch placement {
-        case .ayah(let ayah):
-            "\(ayah: ayah, decorationHidden: true)"
-        case .page(let page):
-            .text(page.localizedName)
-        }
+        storedBookmarks.first { $0.slot == slot }
     }
 
     private func restore(_ bookmark: PlacedReadingBookmark) async {

--- a/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuViewModel.swift
+++ b/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuViewModel.swift
@@ -99,9 +99,9 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
                 let clearedBookmark = try await service.clearReadingBookmark(in: slot)
                 bookmarks.removeAll { $0.slot == slot }
                 bookmarks.append(clearedBookmark)
-                return ReadingBookmarkUndoToast.removed(bookmark) { [service, target] in
+                return ReadingBookmarkUndoToast.removed(bookmark) {
                     Task { @MainActor in
-                        await Self.undoRemoval(bookmark, service: service, target: target)
+                        await self.restore(bookmark)
                     }
                 }
             }
@@ -114,14 +114,9 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
                 return ReadingBookmarkUndoToast.moved(
                     from: previousBookmark,
                     to: bookmark
-                ) { [service, target] in
+                ) {
                     Task { @MainActor in
-                        await Self.undoMove(
-                            bookmark,
-                            to: previousBookmark,
-                            service: service,
-                            target: target
-                        )
+                        await self.restore(previousBookmark)
                     }
                 }
             }
@@ -203,50 +198,11 @@ final class ReadingBookmarkMenuViewModel: ObservableObject {
         }
     }
 
-    // TODO: Fix
-    private static func currentBookmarks(
-        service: MobileSyncReadingBookmarkService,
-        target: Target
-    ) async throws -> [PlacedReadingBookmark] {
-        for try await bookmarks in service.placedReadingBookmarksSequence(quran: target.quran) {
-            return bookmarks
-        }
-        return []
-    }
-
-    private static func undoRemoval(
-        _ bookmark: PlacedReadingBookmark,
-        service: MobileSyncReadingBookmarkService,
-        target: Target
-    ) async {
+    private func restore(_ bookmark: PlacedReadingBookmark) async {
         do {
-            let bookmarks = try await currentBookmarks(service: service, target: target)
-            guard !bookmarks.contains(where: { $0.slot == bookmark.slot }) else {
-                return
-            }
             try await service.addReadingBookmark(at: bookmark.placement, slot: bookmark.slot)
         } catch {
-            crasher.recordError(error, reason: "Failed to undo reading bookmark removal")
-        }
-    }
-
-    private static func undoMove(
-        _ movedBookmark: PlacedReadingBookmark,
-        to previousBookmark: PlacedReadingBookmark,
-        service: MobileSyncReadingBookmarkService,
-        target: Target
-    ) async {
-        do {
-            let bookmarks = try await currentBookmarks(service: service, target: target)
-            guard bookmarks.first(where: { $0.slot == movedBookmark.slot }) == movedBookmark else {
-                return
-            }
-            try await service.addReadingBookmark(
-                at: previousBookmark.placement,
-                slot: previousBookmark.slot
-            )
-        } catch {
-            crasher.recordError(error, reason: "Failed to undo reading bookmark move")
+            crasher.recordError(error, reason: "Failed to restore reading bookmark")
         }
     }
 }

--- a/Features/ReadingBookmarkMenuFeature/Tests/ReadingBookmarkMenuRowTests.swift
+++ b/Features/ReadingBookmarkMenuFeature/Tests/ReadingBookmarkMenuRowTests.swift
@@ -1,0 +1,67 @@
+#if QURAN_SYNC
+import NoorUI
+import QuranAnnotations
+import QuranKit
+import SwiftUI
+import XCTest
+@testable import ReadingBookmarkMenuFeature
+
+@MainActor
+final class ReadingBookmarkMenuRowTests: XCTestCase {
+    func test_unplacedBookmark_offersSetHere() {
+        let row = makeRow(placement: .unplaced, target: .ayah(ayah(2)))
+
+        XCTAssertEqual(row.action, .setHere)
+        XCTAssertEqual(row.subtitle.accessibilityText, "Not placed yet")
+    }
+
+    func test_bookmarkAtCurrentAyah_offersRemove() {
+        let row = makeRow(placement: .ayah(ayah(2)), target: .ayah(ayah(2)))
+
+        XCTAssertEqual(row.action, .remove)
+        XCTAssertEqual(row.subtitle.accessibilityText, "Saved here")
+    }
+
+    func test_bookmarkAtAnotherAyah_offersMoveHere() {
+        let row = makeRow(placement: .ayah(ayah(3)), target: .ayah(ayah(2)))
+
+        XCTAssertEqual(row.action, .moveHere)
+        XCTAssertEqual(row.subtitle.accessibilityText, "at Al-Fātihah, Ayah 3")
+    }
+
+    func test_bookmarkAtCurrentPage_offersRemove() {
+        let page = Quran.hafsMadani1405.pages[40]
+        let row = makeRow(placement: .page(page), target: .page(page))
+
+        XCTAssertEqual(row.action, .remove)
+        XCTAssertEqual(row.subtitle.accessibilityText, "Saved here")
+    }
+
+    func test_pageBookmarkAtAyahTarget_offersMoveHere() {
+        let page = Quran.hafsMadani1405.pages[0]
+        let row = makeRow(placement: .page(page), target: .ayah(ayah(2)))
+
+        XCTAssertEqual(row.action, .moveHere)
+        XCTAssertEqual(row.subtitle.accessibilityText, "at \(page.localizedName)")
+    }
+
+    private func makeRow(
+        placement: ReadingBookmark.Placement,
+        target: PlacedReadingBookmark.Placement
+    ) -> ReadingBookmarkMenuRow {
+        ReadingBookmarkMenuRow(
+            item: .init(slot: .coral, name: nil, placement: placement),
+            target: target,
+            name: .constant(""),
+            isEnabled: true,
+            editMode: .inactive,
+            save: { true },
+            select: {}
+        )
+    }
+
+    private func ayah(_ number: Int) -> AyahNumber {
+        AyahNumber(quran: .hafsMadani1405, sura: 1, ayah: number)!
+    }
+}
+#endif

--- a/Features/ReadingBookmarkMenuFeature/Tests/ReadingBookmarkMenuViewModelTests.swift
+++ b/Features/ReadingBookmarkMenuFeature/Tests/ReadingBookmarkMenuViewModelTests.swift
@@ -140,6 +140,44 @@ final class ReadingBookmarkMenuViewModelTests: XCTestCase {
         restored.task.cancel()
     }
 
+    func test_removedBookmarkUndo_restoresPreviousLocationAfterSlotChanges() async throws {
+        let previousAyah = ayah(2)
+        try await service.addReadingBookmark(at: .ayah(previousAyah), slot: .coral)
+        let sut = makeSUT(target: .ayah(previousAyah))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+        let toast = await sut.select(.coral)
+        try await service.addReadingBookmark(at: .ayah(ayah(3)), slot: .coral)
+        let restored = bookmarkExpectation(
+            description: "Restores removed bookmark over a later placement",
+            slot: .coral,
+            placement: .ayah(previousAyah)
+        )
+        defer { restored.task.cancel() }
+
+        try XCTUnwrap(toast?.action).handler()
+        await fulfillment(of: [restored.expectation], timeout: 2)
+    }
+
+    func test_movedBookmarkUndo_restoresPreviousLocationAfterSlotChanges() async throws {
+        let previousPage = Quran.hafsMadani1405.pages[40]
+        try await service.addReadingBookmark(at: .page(previousPage), slot: .indigo)
+        let sut = makeSUT(target: .ayah(ayah(2)))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+        let toast = await sut.select(.indigo)
+        try await service.addReadingBookmark(at: .ayah(ayah(3)), slot: .indigo)
+        let restored = bookmarkExpectation(
+            description: "Restores moved bookmark over a later placement",
+            slot: .indigo,
+            placement: .page(previousPage)
+        )
+        defer { restored.task.cancel() }
+
+        try XCTUnwrap(toast?.action).handler()
+        await fulfillment(of: [restored.expectation], timeout: 2)
+    }
+
     func test_start_updatesItemsWhenServicePublishesNewBookmark() async throws {
         let selectedAyah = ayah(2)
         let sut = makeSUT(target: .ayah(selectedAyah))

--- a/Features/ReadingBookmarkMenuFeature/Tests/ReadingBookmarkMenuViewModelTests.swift
+++ b/Features/ReadingBookmarkMenuFeature/Tests/ReadingBookmarkMenuViewModelTests.swift
@@ -24,21 +24,17 @@ final class ReadingBookmarkMenuViewModelTests: XCTestCase {
         try await super.tearDown()
     }
 
-    func test_start_showsUnsetLifecycleForEverySlot() async {
+    func test_start_showsUnplacedBookmarkForEverySlot() async {
         let sut = makeSUT(target: .ayah(ayah(1)))
         let startTask = await start(sut)
         defer { startTask.cancel() }
 
         XCTAssertEqual(sut.items.map(\.slot), ReadingBookmarkSlot.allCases)
-        XCTAssertTrue(sut.items.allSatisfy {
-            $0.subtitle.accessibilityText == "Not placed yet"
-                && $0.action == .setHere
-                && !$0.isCurrent
-                && $0.isEnabled
-        })
+        XCTAssertTrue(sut.items.allSatisfy { $0.placement == .unplaced && $0.name == nil })
+        XCTAssertFalse(sut.isMutating)
     }
 
-    func test_start_describesCurrentAndPlacedElsewhereSlots() async throws {
+    func test_start_exposesStoredPlacementsAndTarget() async throws {
         let selectedAyah = ayah(2)
         try await service.addReadingBookmark(at: .ayah(selectedAyah), slot: .coral)
         try await service.addReadingBookmark(at: .ayah(ayah(3)), slot: .teal)
@@ -47,14 +43,11 @@ final class ReadingBookmarkMenuViewModelTests: XCTestCase {
         defer { startTask.cancel() }
 
         let current = sut.items.first { $0.slot == .coral }
-        XCTAssertEqual(current?.subtitle.accessibilityText, "Saved here")
-        XCTAssertEqual(current?.action, .remove)
-        XCTAssertEqual(current?.isCurrent, true)
+        XCTAssertEqual(current?.placement, .ayah(selectedAyah))
+        XCTAssertEqual(sut.target.placement, .ayah(selectedAyah))
 
         let elsewhere = sut.items.first { $0.slot == .teal }
-        XCTAssertEqual(elsewhere?.subtitle.accessibilityText, "at Al-Fātihah, Ayah 3")
-        XCTAssertEqual(elsewhere?.action, .moveHere)
-        XCTAssertEqual(elsewhere?.isCurrent, false)
+        XCTAssertEqual(elsewhere?.placement, .ayah(ayah(3)))
     }
 
     func test_selectUnsetSlot_persistsBookmarkAtTarget() async throws {
@@ -178,16 +171,17 @@ final class ReadingBookmarkMenuViewModelTests: XCTestCase {
         await fulfillment(of: [restored.expectation], timeout: 2)
     }
 
-    func test_start_updatesItemsWhenServicePublishesNewBookmark() async throws {
+    func test_start_updatesBookmarksWhenServicePublishesNewBookmark() async throws {
         let selectedAyah = ayah(2)
         let sut = makeSUT(target: .ayah(selectedAyah))
         let startTask = await start(sut)
         defer { startTask.cancel() }
         let observed = expectation(description: "Shows externally created reading bookmark")
         var didFulfill = false
-        let observation = sut.$items.sink { items in
+        let observation = sut.objectWillChange.receive(on: RunLoop.main).sink {
+            let bookmarks = sut.items
             guard !didFulfill,
-                  items.first(where: { $0.slot == .indigo })?.isCurrent == true
+                  bookmarks.first(where: { $0.slot == .indigo })?.placement == .ayah(selectedAyah)
             else {
                 return
             }
@@ -214,7 +208,7 @@ final class ReadingBookmarkMenuViewModelTests: XCTestCase {
         XCTAssertEqual(storedBookmark?.placement, .page(firstPage))
     }
 
-    func test_pageTarget_describesBookmarkOnCurrentPage() async throws {
+    func test_pageTarget_exposesBookmarkOnCurrentPage() async throws {
         let page = Quran.hafsMadani1405.pages[40]
         try await service.addReadingBookmark(at: .page(page), slot: .coral)
         let sut = makeSUT(target: .pages(page, [page]))
@@ -222,25 +216,209 @@ final class ReadingBookmarkMenuViewModelTests: XCTestCase {
         defer { startTask.cancel() }
 
         let current = sut.items.first { $0.slot == .coral }
-        XCTAssertEqual(current?.subtitle.accessibilityText, "Saved here")
-        XCTAssertEqual(current?.action, .remove)
+        XCTAssertEqual(current?.placement, .page(page))
+        XCTAssertEqual(sut.target.placement, .page(page))
     }
 
-    func test_clearedPin_showsSetHereAndDoesNotOfferMoveUndo() async throws {
+    func test_clearedPin_isUnplacedAndDoesNotOfferMoveUndo() async throws {
         try await service.addReadingBookmark(at: .ayah(ayah(1)), slot: .coral)
         try await service.clearReadingBookmark(in: .coral)
         let sut = makeSUT(target: .ayah(ayah(2)))
         let startTask = await start(sut)
         defer { startTask.cancel() }
 
-        XCTAssertEqual(sut.items.first?.action, .setHere)
-        XCTAssertEqual(sut.items.first?.subtitle.accessibilityText, "Not placed yet")
+        XCTAssertEqual(sut.items.first?.placement, .unplaced)
 
         let toast = await sut.select(.coral)
         let stored = try await storedBookmark(in: .coral)
         XCTAssertEqual(stored?.placement, .ayah(ayah(2)))
         XCTAssertNotNil(toast)
         XCTAssertNil(toast?.action)
+    }
+
+    func test_beginEditing_clearsDraftsWithoutCopyingSavedNames() async throws {
+        try await service.renameReadingBookmark(in: .teal, name: "Review", quran: .hafsMadani1405)
+        let sut = makeSUT(target: .ayah(ayah(1)))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+
+        sut.draftNames[.coral] = "Discarded draft"
+        sut.beginEditing()
+
+        XCTAssertTrue(sut.draftNames.isEmpty)
+        XCTAssertTrue(sut.editMode.isEditing)
+        XCTAssertEqual(sut.items.first { $0.slot == .teal }?.name, "Review")
+        XCTAssertNil(sut.items.first { $0.slot == .coral }?.name)
+    }
+
+    func test_saveNames_singleSlotSavesTrimmedNameAndLeavesOtherDrafts() async throws {
+        let sut = makeSUT(target: .ayah(ayah(1)))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+        sut.beginEditing()
+        sut.draftNames[.coral] = "  Daily reading \n"
+        sut.draftNames[.teal] = "Review"
+
+        let saved = await sut.saveNames(in: [.coral])
+        let coral = try await storedBookmark(in: .coral)
+        let teal = try await storedBookmark(in: .teal)
+
+        XCTAssertTrue(saved)
+        XCTAssertEqual(coral?.name, "Daily reading")
+        XCTAssertEqual(coral?.placement, .unplaced)
+        XCTAssertNil(teal)
+        XCTAssertNil(sut.draftNames[.coral])
+        XCTAssertEqual(sut.draftNames[.teal], "Review")
+        XCTAssertTrue(sut.editMode.isEditing)
+    }
+
+    func test_finishEditing_savesRemainingNamesAndExitsEditing() async throws {
+        let sut = makeSUT(target: .ayah(ayah(1)))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+        XCTAssertFalse(sut.editMode.isEditing)
+        sut.beginEditing()
+        sut.draftNames[.coral] = "Daily reading"
+        sut.draftNames[.teal] = "Review"
+
+        await sut.finishEditing()
+        let coral = try await storedBookmark(in: .coral)
+        let teal = try await storedBookmark(in: .teal)
+
+        XCTAssertFalse(sut.editMode.isEditing)
+        XCTAssertEqual(coral?.name, "Daily reading")
+        XCTAssertEqual(teal?.name, "Review")
+    }
+
+    func test_finishEditing_whenSaveCannotRunKeepsEditingAndDrafts() async {
+        let sut = makeSUT(target: .ayah(ayah(1)))
+        sut.beginEditing()
+        sut.draftNames[.coral] = "Daily reading"
+
+        await sut.finishEditing()
+
+        XCTAssertTrue(sut.editMode.isEditing)
+        XCTAssertEqual(sut.draftNames[.coral], "Daily reading")
+    }
+
+    func test_editModeBinding_routesEditingAndSavingThroughViewModel() async throws {
+        let sut = makeSUT(target: .ayah(ayah(1)))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+        sut.editModeBinding.wrappedValue = .active
+        XCTAssertTrue(sut.editMode.isEditing)
+        sut.draftNames[.coral] = "Daily reading"
+        let finished = expectation(description: "Exits editing after saving")
+        let observation = sut.$editMode
+            .filter { !$0.isEditing }
+            .prefix(1)
+            .sink { _ in finished.fulfill() }
+        defer { observation.cancel() }
+
+        sut.editModeBinding.wrappedValue = .inactive
+        await fulfillment(of: [finished], timeout: 2)
+        let stored = try await storedBookmark(in: .coral)
+
+        XCTAssertFalse(sut.editMode.isEditing)
+        XCTAssertEqual(stored?.name, "Daily reading")
+    }
+
+    func test_saveNames_allSlotsSavesRemainingChangesWithoutRewritingSubmittedName() async throws {
+        let sut = makeSUT(target: .ayah(ayah(1)))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+        sut.beginEditing()
+        sut.draftNames[.coral] = "Daily reading"
+        sut.draftNames[.teal] = "Review"
+        _ = await sut.saveNames(in: [.coral])
+        let submitted = try await storedBookmark(in: .coral)
+
+        let saved = await sut.saveNames(in: ReadingBookmarkSlot.allCases)
+        let coral = try await storedBookmark(in: .coral)
+        let teal = try await storedBookmark(in: .teal)
+        let indigo = try await storedBookmark(in: .indigo)
+
+        XCTAssertTrue(saved)
+        XCTAssertEqual(coral, submitted)
+        XCTAssertEqual(teal?.name, "Review")
+        XCTAssertNil(indigo)
+    }
+
+    func test_saveNames_blankNameClearsCustomName() async throws {
+        try await service.renameReadingBookmark(in: .coral, name: "Daily reading", quran: .hafsMadani1405)
+        let sut = makeSUT(target: .ayah(ayah(1)))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+        sut.beginEditing()
+        sut.draftNames[.coral] = " \n "
+
+        let saved = await sut.saveNames(in: [.coral])
+        let stored = try await storedBookmark(in: .coral)
+
+        XCTAssertTrue(saved)
+        XCTAssertNotNil(stored)
+        XCTAssertNil(stored?.name)
+        XCTAssertNil(sut.draftNames[.coral])
+    }
+
+    func test_saveNames_publishesSavedNameToMenu() async {
+        let sut = makeSUT(target: .ayah(ayah(1)))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+        sut.beginEditing()
+        sut.draftNames[.coral] = "Daily reading"
+        let observed = expectation(description: "Shows saved custom name")
+        let observation = sut.objectWillChange
+            .receive(on: RunLoop.main)
+            .map { sut.items }
+            .filter { $0.first(where: { $0.slot == .coral })?.name == "Daily reading" }
+            .prefix(1)
+            .sink { _ in observed.fulfill() }
+        defer { observation.cancel() }
+
+        let saved = await sut.saveNames(in: [.coral])
+        await fulfillment(of: [observed], timeout: 2)
+
+        XCTAssertTrue(saved)
+        sut.beginEditing()
+        XCTAssertTrue(sut.draftNames.isEmpty)
+        XCTAssertEqual(sut.items.first { $0.slot == .coral }?.name, "Daily reading")
+    }
+
+    func test_saveNames_untouchedNameDoesNotWriteOrClearIt() async throws {
+        try await service.renameReadingBookmark(in: .coral, name: "Daily reading", quran: .hafsMadani1405)
+        let original = try await storedBookmark(in: .coral)
+        let sut = makeSUT(target: .ayah(ayah(1)))
+        let startTask = await start(sut)
+        defer { startTask.cancel() }
+        sut.beginEditing()
+
+        let saved = await sut.saveNames(in: ReadingBookmarkSlot.allCases)
+        let stored = try await storedBookmark(in: .coral)
+
+        XCTAssertTrue(saved)
+        XCTAssertEqual(stored, original)
+    }
+
+    func test_saveNames_updatesBookmarkWithoutWaitingForObservation() async throws {
+        let sut = makeSUT(target: .ayah(ayah(1)))
+        let startTask = await start(sut)
+        startTask.cancel()
+        await startTask.value
+        sut.beginEditing()
+        sut.draftNames[.coral] = "Daily reading"
+
+        let saved = await sut.saveNames(in: [.coral])
+        let submitted = try await storedBookmark(in: .coral)
+        await sut.finishEditing()
+        let stored = try await storedBookmark(in: .coral)
+
+        XCTAssertTrue(saved)
+        XCTAssertEqual(sut.items.first { $0.slot == .coral }?.name, "Daily reading")
+        XCTAssertEqual(sut.items.map(\.slot), ReadingBookmarkSlot.allCases)
+        XCTAssertEqual(stored, submitted)
+        sut.beginEditing()
+        XCTAssertTrue(sut.draftNames.isEmpty)
     }
 
     private func makeSUT(target: ReadingBookmarkMenuViewModel.Target) -> ReadingBookmarkMenuViewModel {
@@ -250,8 +428,8 @@ final class ReadingBookmarkMenuViewModelTests: XCTestCase {
     private func start(_ sut: ReadingBookmarkMenuViewModel) async -> Task<Void, Never> {
         let observed = expectation(description: "Loads reading bookmarks")
         var didFulfill = false
-        let observation = sut.$items.sink { items in
-            guard !didFulfill, !items.isEmpty, items.allSatisfy(\.isEnabled) else {
+        let observation = sut.objectWillChange.receive(on: RunLoop.main).sink {
+            guard !didFulfill, !sut.items.isEmpty, !sut.isMutating else {
                 return
             }
             didFulfill = true

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quran/mobile-sync-spm.git",
       "state" : {
-        "revision" : "db8a7f2bf6244df3412abaeb42c6053d7e119134",
-        "version" : "0.1.21"
+        "revision" : "6af6f1dda6421416401cdba16b37adc1449cd6ed",
+        "version" : "0.1.22"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let mobileSyncPackageDependency: Package.Dependency = {
     if let localMobileSyncPackagePath, !localMobileSyncPackagePath.isEmpty {
         return .package(path: localMobileSyncPackagePath)
     }
-    return .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.21")
+    return .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.22")
 }()
 
 let mobileSyncPackageDependencies: [Package.Dependency] =


### PR DESCRIPTION
## Summary

- Persist custom pin names through MobileSyncReadingBookmarkService and show them in the bookmark menu and list.
- Save all pending drafts with header Done, or one row with keyboard submit.
- Use color names as placeholders; trimming an empty name restores the default.
- Keep edit mode and sparse drafts in the view model, and derive minimal row items containing only slot, name, and placement.
- Derive row subtitles and actions from placement and the current target.
- Update mobile-sync-spm to v0.1.22 and add service, view-model, and row regression coverage.

## Dependencies

- #1027 is merged; this PR now targets main and includes the resolved merge.
- quran/mobile-sync#261 fixes HTTP 422 errors for unplaced pin mutations. That fix still needs to reach a released mobile-sync-spm dependency; v0.1.22 does not include it.

## Validation

- ReadingBookmarkMenuFeature sync build passed against the released package before local dependency overrides.
- Example app built successfully for iPhone 17 Pro Max Simulator against the local framework containing quran/mobile-sync#261.
- Latest automated tests were not run, per request; runtime validation was left to the user.

Temporary local package paths, sync-default overrides, and local Xcode configuration are excluded from this PR.