### PR TITLE
feat: navigate to sura and ayah deep links

### DIFF
--- a/Example/QuranEngineApp/Classes/SceneDelegate.swift
+++ b/Example/QuranEngineApp/Classes/SceneDelegate.swift
@@ -27,6 +27,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         launchStartup?.launch(from: window)
 
         self.launchStartup = launchStartup
+
+        // A link that launches the app arrives here, not in `scene(_:openURLContexts:)`.
+        if let urlContext = connectionOptions.urlContexts.first {
+            launchStartup?.handleIncomingUrl(urlContext: urlContext)
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {
@@ -61,7 +66,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let urlContext: UIOpenURLContext = URLContexts.first else {
             return
         }
-        launchBuilder?.handleIncomingUrl(urlContext: urlContext)
+        launchStartup?.handleIncomingUrl(urlContext: urlContext)
     }
 
     // MARK: Private

--- a/Features/AppStructureFeature/Sources/App/AppBuilder.swift
+++ b/Features/AppStructureFeature/Sources/App/AppBuilder.swift
@@ -13,7 +13,7 @@ import UIKit
 struct AppBuilder {
     let container: AppDependencies
 
-    func build() -> UIViewController {
+    func build() -> AppViewController {
         let interactor = AppInteractor(
             supportsCloudKit: container.supportsCloudKit,
             analytics: container.analytics,
@@ -26,10 +26,9 @@ struct AppBuilder {
                 SettingsTabBuilder(container: container),
             ]
         )
-        let viewController = AppViewController(
+        return AppViewController(
             analytics: container.analytics,
             interactor: interactor
         )
-        return viewController
     }
 }

--- a/Features/AppStructureFeature/Sources/App/AppViewController.swift
+++ b/Features/AppStructureFeature/Sources/App/AppViewController.swift
@@ -20,6 +20,8 @@
 
 import Analytics
 import Crashing
+import FeaturesSupport
+import QuranKit
 import UIKit
 import VLogging
 import WhatsNewFeature
@@ -59,6 +61,25 @@ class AppViewController: UITabBarController, UITabBarControllerDelegate, AppPres
         super.viewDidLoad()
         delegate = self
         updateCrashContext(selectedIndex: selectedIndex)
+    }
+
+    /// Opens the Quran on the deep linked sura or ayah, replacing whatever the home tab
+    /// currently shows so links never stack Quran screens on top of each other.
+    func navigate(to deepLink: QuranDeepLink) {
+        guard let homeTab = viewControllers?.first as? TabViewController else {
+            logger.error("Deep link: home tab is unavailable")
+            return
+        }
+        presentedViewController?.dismiss(animated: false)
+        selectedIndex = 0
+        homeTab.popToRootViewController(animated: false)
+
+        switch deepLink {
+        case .sura(let sura):
+            homeTab.quranNavigator.navigateTo(page: sura.page, lastPage: nil)
+        case .ayah(let ayah):
+            homeTab.quranNavigator.navigateTo(ayah: ayah, lastPage: nil)
+        }
     }
 
     func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {

--- a/Features/AppStructureFeature/Sources/Common/TabViewController.swift
+++ b/Features/AppStructureFeature/Sources/Common/TabViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Quran.com. All rights reserved.
 //
 
+import FeaturesSupport
 import NoorUI
 import UIKit
 
@@ -27,6 +28,8 @@ class TabViewController: BaseNavigationController, TabPresenter {
     }
 
     // MARK: Internal
+
+    var quranNavigator: QuranNavigator { interactor }
 
     func getTabBarItem() -> UITabBarItem {
         fatalError("\(#function) should be subclassed")

--- a/Features/AppStructureFeature/Sources/Launch/LaunchBuilder.swift
+++ b/Features/AppStructureFeature/Sources/Launch/LaunchBuilder.swift
@@ -38,27 +38,7 @@ public struct LaunchBuilder {
         )
     }
 
-    public func handleIncomingUrl(urlContext: UIOpenURLContext) {
-        let url = urlContext.url
-
-        if url.scheme == "quran" || url.scheme == "quran-ios" {
-            let path: String = if #available(iOS 16.0, *) {
-                url.path(percentEncoded: true)
-            } else {
-                url.path
-            }
-            _ = navigateTo(path: path)
-        }
-    }
-
     // MARK: Internal
 
     let container: AppDependencies
-
-    // MARK: Public
-
-    private func navigateTo(path: String) -> Bool {
-        // TODO: Implement the actual navigation
-        return true
-    }
 }

--- a/Features/AppStructureFeature/Sources/Launch/LaunchStartup.swift
+++ b/Features/AppStructureFeature/Sources/Launch/LaunchStartup.swift
@@ -10,6 +10,8 @@ import AppMigrationFeature
 import AppMigrator
 import AudioUpdater
 import Crashing
+import QuranKit
+import ReadingService
 import SettingsService
 import UIKit
 import VLogging
@@ -57,6 +59,16 @@ public final class LaunchStartup {
         )
     }
 
+    public func handleIncomingUrl(urlContext: UIOpenURLContext) {
+        let url = urlContext.url
+        guard let deepLink = QuranDeepLink(url: url, quran: ReadingPreferences.shared.reading.quran) else {
+            logger.notice("Deep link: ignoring unsupported url \(url)")
+            return
+        }
+        logger.info("Deep link: handling \(url)")
+        navigate(to: deepLink)
+    }
+
     // MARK: Private
 
     private let fileSystemMigrator: FileSystemMigrator
@@ -68,7 +80,8 @@ public final class LaunchStartup {
     private let notificationCenter = NotificationCenter.default
 
     private let appMigrator = AppMigrator()
-    private var appViewController: UIViewController?
+    private var appViewController: AppViewController?
+    private var pendingDeepLink: QuranDeepLink?
     private var protectedDataObserver: NSObjectProtocol?
     private var protectedDataStartupState = ProtectedDataStartupState()
 
@@ -160,6 +173,21 @@ public final class LaunchStartup {
         }
         crashContext.setStartupPhase("ready")
         logger.info("Crash context: startup phase ready")
+
+        if let pendingDeepLink {
+            self.pendingDeepLink = nil
+            appViewController.navigate(to: pendingDeepLink)
+        }
+    }
+
+    /// Links can arrive while the app is still migrating or waiting for protected data,
+    /// so they are replayed once the app UI exists.
+    private func navigate(to deepLink: QuranDeepLink) {
+        guard let appViewController else {
+            pendingDeepLink = deepLink
+            return
+        }
+        appViewController.navigate(to: deepLink)
     }
 
     private func registerMigrators() {

--- a/Features/AppStructureFeature/Sources/Launch/QuranDeepLink.swift
+++ b/Features/AppStructureFeature/Sources/Launch/QuranDeepLink.swift
@@ -1,0 +1,56 @@
+//
+//  QuranDeepLink.swift
+//  Quran
+//
+//  Created by Abdullah Levin on 2026-09-06.
+//
+
+import Foundation
+import QuranKit
+
+enum QuranDeepLink: Equatable {
+    case sura(Sura)
+    case ayah(AyahNumber)
+}
+
+extension QuranDeepLink {
+    // MARK: Lifecycle
+
+    /// Parses links of the form `quran://sura` and `quran://sura/ayah`, matching the
+    /// format handled by `QuranForwarderActivity` on Android. Non numeric segments are
+    /// skipped, so `quran://sura/2/255` resolves the same way `quran://2/255` does.
+    init?(url: URL, quran: Quran) {
+        guard let scheme = url.scheme?.lowercased(), Self.supportedSchemes.contains(scheme) else {
+            return nil
+        }
+
+        let numbers = Self.segments(of: url).compactMap { Int($0) }
+        guard let suraNumber = numbers.first, let sura = Sura(quran: quran, suraNumber: suraNumber) else {
+            return nil
+        }
+
+        guard numbers.count > 1 else {
+            self = .sura(sura)
+            return
+        }
+        guard let ayah = AyahNumber(sura: sura, ayah: numbers[1]) else {
+            return nil
+        }
+        self = .ayah(ayah)
+    }
+
+    // MARK: Private
+
+    private static let supportedSchemes: Set<String> = ["quran", "quran-ios"]
+
+    /// The authority of `quran://2/255` is the sura, so it is read from the host and
+    /// not from the path.
+    private static func segments(of url: URL) -> [String] {
+        var segments: [String] = []
+        if let host = url.host, !host.isEmpty {
+            segments.append(host)
+        }
+        segments.append(contentsOf: url.pathComponents.filter { $0 != "/" })
+        return segments
+    }
+}

--- a/Features/AppStructureFeature/Tests/QuranDeepLinkTests.swift
+++ b/Features/AppStructureFeature/Tests/QuranDeepLinkTests.swift
@@ -1,0 +1,93 @@
+//
+//  QuranDeepLinkTests.swift
+//  Quran
+//
+//  Created by Abdullah Levin on 2026-09-06.
+//
+
+import QuranKit
+import XCTest
+@testable import AppStructureFeature
+
+final class QuranDeepLinkTests: XCTestCase {
+    // MARK: Internal
+
+    func testSuraOnlyLink() {
+        XCTAssertEqual(deepLink("quran://2"), .sura(sura(2)))
+    }
+
+    func testSuraAndAyahLink() {
+        XCTAssertEqual(deepLink("quran://2/255"), .ayah(ayah(sura: 2, ayah: 255)))
+    }
+
+    func testLegacySchemeIsSupported() {
+        XCTAssertEqual(deepLink("quran-ios://114/6"), .ayah(ayah(sura: 114, ayah: 6)))
+    }
+
+    func testSchemeIsCaseInsensitive() {
+        XCTAssertEqual(deepLink("QURAN://1/1"), .ayah(ayah(sura: 1, ayah: 1)))
+    }
+
+    func testTrailingSlashIsIgnored() {
+        XCTAssertEqual(deepLink("quran://18/"), .sura(sura(18)))
+    }
+
+    func testNonNumericSegmentsAreSkipped() {
+        XCTAssertEqual(deepLink("quran://sura/2/255"), .ayah(ayah(sura: 2, ayah: 255)))
+    }
+
+    func testExtraSegmentsAreIgnored() {
+        XCTAssertEqual(deepLink("quran://2/255/anything"), .ayah(ayah(sura: 2, ayah: 255)))
+    }
+
+    func testFirstAndLastAyahOfTheQuran() {
+        XCTAssertEqual(deepLink("quran://1/1"), .ayah(quran.firstVerse))
+        XCTAssertEqual(deepLink("quran://114/6"), .ayah(quran.lastVerse))
+    }
+
+    func testUnsupportedSchemeIsRejected() {
+        XCTAssertNil(deepLink("https://quran.com/2/255"))
+        XCTAssertNil(deepLink("quranx://2/255"))
+    }
+
+    func testLinkWithoutSuraIsRejected() {
+        XCTAssertNil(deepLink("quran://"))
+        XCTAssertNil(deepLink("quran://home"))
+    }
+
+    func testSuraOutOfRangeIsRejected() {
+        XCTAssertNil(deepLink("quran://0"))
+        XCTAssertNil(deepLink("quran://115"))
+        XCTAssertNil(deepLink("quran://999"))
+    }
+
+    func testAyahOutOfRangeIsRejected() {
+        XCTAssertNil(deepLink("quran://2/0"))
+        XCTAssertNil(deepLink("quran://2/287"))
+        XCTAssertNil(deepLink("quran://1/8"))
+    }
+
+    func testLastAyahOfSuraIsAccepted() {
+        XCTAssertEqual(deepLink("quran://2/286"), .ayah(ayah(sura: 2, ayah: 286)))
+    }
+
+    // MARK: Private
+
+    private let quran = Quran.hafsMadani1405
+
+    private func deepLink(_ string: String) -> QuranDeepLink? {
+        guard let url = URL(string: string) else {
+            XCTFail("Couldn't create a URL out of \(string)")
+            return nil
+        }
+        return QuranDeepLink(url: url, quran: quran)
+    }
+
+    private func sura(_ suraNumber: Int) -> Sura {
+        Sura(quran: quran, suraNumber: suraNumber)!
+    }
+
+    private func ayah(sura suraNumber: Int, ayah ayahNumber: Int) -> AyahNumber {
+        AyahNumber(quran: quran, sura: suraNumber, ayah: ayahNumber)!
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -851,6 +851,9 @@ private func featuresTargets() -> [[Target]] {
 
         target(type, name: "AppStructureFeature", dependencies: [
             "Crashing",
+            "FeaturesSupport",
+            "QuranKit",
+            "ReadingService",
             "HomeFeature",
             "BookmarksFeature",
             "NotesFeature",


### PR DESCRIPTION
Closes #348. Part of #195.

### What

`quran://` and `quran-ios://` were registered in #657, but `LaunchBuilder.navigateTo(path:)` was left as `// TODO: Implement the actual navigation`, so a link opened the app and stopped on whatever screen was last shown. This implements the navigation.

Supported links follow the format `QuranForwarderActivity` already handles in Quran for Android:

- `quran://2` opens sura 2
- `quran://2/255` opens ayah 2:255 and highlights it
- `quran-ios://` keeps working as an alias

### Parsing

`QuranDeepLink` maps a `URL` to either a sura or an ayah:

- the sura is read from the URL host, since `quran://2/255` parses as host `2` and path `/255`. The previous stub read `url.path` only, so the sura number was dropped
- non numeric segments are skipped, matching Android, so `quran://sura/2/255` resolves like `quran://2/255`
- the scheme is matched case insensitively
- validation goes through `Sura` and `AyahNumber` against the reading currently selected in `ReadingPreferences`. Anything out of range returns `nil` and the link is ignored rather than clamped to a nearby verse

Unit tests cover valid links, both schemes, trailing slashes, extra segments, `1:1` and `114:6`, the last ayah of a sura, and the rejected cases: sura `0`, `115`, `999`, ayah `0`, `2:287`, `1:8`, foreign schemes, and links with no sura at all.

### Navigation

- the entry point moves from `LaunchBuilder` to `LaunchStartup`. `LaunchBuilder` is a stateless struct, while `LaunchStartup` owns the built view controller hierarchy, which is what navigation needs. This is a source breaking change for anyone calling `LaunchBuilder.handleIncomingUrl(urlContext:)`; happy to keep a deprecated forwarding method instead if you prefer
- a link that arrives before the UI exists, for example during a migration or while waiting for protected data, is stored and replayed once `showApp` finishes
- `AppViewController.navigate(to:)` dismisses any presented modal, selects the home tab, pops it to its root, then pushes the Quran view. Popping first keeps repeated links from stacking Quran screens
- `Example` now also reads `connectionOptions.urlContexts` in `scene(_:willConnectTo:options:)`. A link that launches the app is delivered there and not to `scene(_:openURLContexts:)`, which is likely why #348 reports that nothing happens when the app is not already running

### Notes

- audio is out of scope here. As a follow up I would like to carry an optional playback range and repeat counts in the link, for example `quran://2/255?to=2:257&play=true&verse_repeat=3&range_repeat=infinite`, so a memoriser can open the app already looping a range. The engine already has `AdvancedAudioOptions` and the `audioBanner?.play(from:to:repeatVerses:)` seam, so it would mostly be threading an optional request through `QuranInput`. Let me know if you would take that
- universal links are not addressed. `https://quran.com/apple-app-site-association` currently returns 404, so `quran.com` links cannot be claimed yet
- the shipped app is not in this repository. If its target does not register these schemes and forward to `handleIncomingUrl`, this will work in `QuranEngineApp` but not in the App Store build

### Testing

`make test-no-sync`, `make test-sync`, `make build-example-no-sync`, `make build-example-sync` and SwiftFormat all pass on CI.

Verified the new tests actually fail when the logic breaks, by running CI against three deliberately broken copies of the parser: one with the scheme check removed, one with the ayah range check removed, one reading the path without the host.
