### PR TITLE
fix: update reading bookmark pins and sync dependency

### DIFF
--- a/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuRow.swift
+++ b/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuRow.swift
@@ -116,7 +116,7 @@ struct ReadingBookmarkMenuRow: View {
     }
 
     private var pin: some View {
-        ReadingBookmarkPin(style: .filled)
+        ReadingBookmarkPin(style: item.placement == .unplaced ? .outline : .filled)
             .foregroundColor(isEnabled ? item.slot.swiftUIColor : .tertiaryLabel)
             .accessibilityHidden(true)
     }

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/quran/mobile-sync-spm.git",
       "state" : {
-        "revision" : "6af6f1dda6421416401cdba16b37adc1449cd6ed",
-        "version" : "0.1.22"
+        "revision" : "71d10ea8730ebcdb90fcc44be96ccc24a8d7a7b3",
+        "version" : "0.1.23"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let mobileSyncPackageDependency: Package.Dependency = {
     if let localMobileSyncPackagePath, !localMobileSyncPackagePath.isEmpty {
         return .package(path: localMobileSyncPackagePath)
     }
-    return .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.22")
+    return .package(url: "https://github.com/quran/mobile-sync-spm.git", from: "0.1.23")
 }()
 
 let mobileSyncPackageDependencies: [Package.Dependency] =


### PR DESCRIPTION
Unplaced reading bookmarks now use the outline pin in both normal and edit modes; placed bookmarks keep the filled pin. Update mobile-sync-spm from v0.1.22 to v0.1.23.

Validation: SwiftFormat passed, and ReadingBookmarkMenuFeature built successfully with sync enabled and disabled on an arm64 iPhone 17 Pro Max simulator. Test runs were stopped at the owner's request; verification is build-only.

<img src="https://github.com/user-attachments/assets/378845f0-820e-4a7e-bf11-138193e6048d" alt="Reading bookmarks with an outline pin for the unset bookmark and filled pins for set bookmarks" width="300" />
