### PR TITLE
fix: use custom reading bookmark display names

### DIFF
--- a/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
@@ -124,7 +124,7 @@ final class AyahMenuViewModel {
         guard selectedAyah != nil else {
             return .disabled(message: l("ayah.menu.reading-bookmark.single-ayah-only"))
         }
-        return .available(slot: deps.readingBookmark?.slot)
+        return .available(bookmark: deps.readingBookmark)
     }
     #endif
 

--- a/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
+++ b/Features/AyahMenuFeature/Tests/AyahMenuViewModelTests.swift
@@ -87,18 +87,19 @@ final class AyahMenuViewModelTests: XCTestCase {
         let selectedAyah = verses[0]
         let sut = makeSUT(verses: [selectedAyah])
 
-        XCTAssertEqual(sut.readingBookmarkState, .available(slot: nil))
+        XCTAssertEqual(sut.readingBookmarkState, .available(bookmark: nil))
         XCTAssertEqual(sut.selectedAyah, selectedAyah)
     }
 
-    func test_readingBookmarkState_showsSelectedSlotForSingleAyah() {
+    func test_readingBookmarkState_showsSelectedBookmarkForSingleAyah() {
         let selectedAyah = verses[0]
+        let bookmark = readingBookmark(slot: .indigo, at: selectedAyah)
         let sut = makeSUT(
             verses: [selectedAyah],
-            readingBookmark: readingBookmark(slot: .indigo, at: selectedAyah)
+            readingBookmark: bookmark
         )
 
-        XCTAssertEqual(sut.readingBookmarkState, .available(slot: .indigo))
+        XCTAssertEqual(sut.readingBookmarkState, .available(bookmark: bookmark))
     }
 
     func test_editNote_requestsNotesListAndNewNoteWhenSelectionHasNoNotes() async {

--- a/Features/FeaturesSupport/Sources/ReadingBookmarkListItem.swift
+++ b/Features/FeaturesSupport/Sources/ReadingBookmarkListItem.swift
@@ -30,7 +30,7 @@ public struct ReadingBookmarkListItem: View {
                 Image(uiImage: ReadingBookmarkPin.image(style: .filled)),
                 color: bookmark.slot.swiftUIColor
             ),
-            title: "\(bookmark.name ?? bookmark.slot.displayName) · \(sura: bookmark.sura)",
+            title: "\(bookmark.displayName) · \(sura: bookmark.sura)",
             subtitle: .init(
                 text: "\(locationTitle) · \(bookmark.modifiedOn.timeAgo())",
                 location: .bottom

--- a/Features/QuranViewFeature/Sources/QuranInteractor.swift
+++ b/Features/QuranViewFeature/Sources/QuranInteractor.swift
@@ -49,7 +49,7 @@ protocol QuranPresentable: UIViewController {
 
     func setVisiblePages(_ pages: [Page])
     #if QURAN_SYNC
-    func updateReadingBookmark(_ slot: ReadingBookmarkSlot?)
+    func updateReadingBookmark(_ bookmark: PlacedReadingBookmark?)
     #else
     func updateBookmark(_ isBookmarked: Bool)
     #endif
@@ -600,7 +600,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
         #if QURAN_SYNC
         let placements = pages.map(PlacedReadingBookmark.Placement.page)
         let bookmark = deps.readingBookmarksObserver.latest(at: placements)
-        presenter?.updateReadingBookmark(bookmark?.slot)
+        presenter?.updateReadingBookmark(bookmark)
         #else
         presenter?.updateBookmark(bookmarked(pages))
         #endif

--- a/Features/QuranViewFeature/Sources/QuranViewController.swift
+++ b/Features/QuranViewFeature/Sources/QuranViewController.swift
@@ -276,14 +276,14 @@ class QuranViewController: BaseViewController, QuranViewDelegate,
     }
 
     #if QURAN_SYNC
-    func updateReadingBookmark(_ slot: ReadingBookmarkSlot?) {
-        let style: ReadingBookmarkPin.Style = slot == nil ? .outline : .filled
+    func updateReadingBookmark(_ bookmark: PlacedReadingBookmark?) {
+        let style: ReadingBookmarkPin.Style = bookmark == nil ? .outline : .filled
         readingBookmarkMenuNavigationButton.image = ReadingBookmarkPin.image(
             style: style,
             badge: .ellipsis
         )
-        readingBookmarkMenuNavigationButton.tintColor = slot?.color
-        readingBookmarkMenuNavigationButton.accessibilityValue = slot?.displayName
+        readingBookmarkMenuNavigationButton.tintColor = bookmark?.slot.color
+        readingBookmarkMenuNavigationButton.accessibilityValue = bookmark?.displayName
         quranView?.navigationItem.setRightBarButtonItems(
             [moreNavigationButton, readingBookmarkMenuNavigationButton],
             animated: false

--- a/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuRow.swift
+++ b/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuRow.swift
@@ -96,7 +96,7 @@ struct ReadingBookmarkMenuRow: View {
             HStack {
                 pin
                 VStack(alignment: .leading, spacing: 1) {
-                    Text(item.name ?? item.slot.displayName)
+                    Text(item.displayName)
                         .fontWeight(.semibold)
                         .foregroundColor(isEnabled ? .label : .tertiaryLabel)
                     subtitle.view(ofSize: .footnote)

--- a/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuViewModel.swift
+++ b/Features/ReadingBookmarkMenuFeature/Sources/ReadingBookmarkMenuViewModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 @MainActor
 final class ReadingBookmarkMenuViewModel: ObservableObject {
-    struct Item: Identifiable {
+    struct Item: Identifiable, ReadingBookmarkDisplayable {
         let slot: ReadingBookmarkSlot
         let name: String?
         let placement: ReadingBookmark.Placement

--- a/UI/NoorUI/Sources/Components/ReadingBookmarkDisplayable.swift
+++ b/UI/NoorUI/Sources/Components/ReadingBookmarkDisplayable.swift
@@ -1,0 +1,18 @@
+#if QURAN_SYNC
+import QuranAnnotations
+
+public protocol ReadingBookmarkDisplayable {
+    var slot: ReadingBookmarkSlot { get }
+    var name: String? { get }
+}
+
+public extension ReadingBookmarkDisplayable {
+    var displayName: String {
+        name ?? slot.displayName
+    }
+}
+
+extension ReadingBookmark: ReadingBookmarkDisplayable { }
+extension PlacedReadingBookmark: ReadingBookmarkDisplayable { }
+
+#endif

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuUI.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuUI.swift
@@ -159,7 +159,7 @@ public enum AyahMenuUI {
 
     public enum ReadingBookmarkState: Equatable {
         case disabled(message: String)
-        case available(slot: ReadingBookmarkSlot?)
+        case available(bookmark: PlacedReadingBookmark?)
     }
     #endif
 }

--- a/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
+++ b/UI/NoorUI/Sources/Features/AyahMenu/AyahMenuView.swift
@@ -255,18 +255,18 @@ private struct AyahMenuViewList: View {
             ) {
                 Image(uiImage: ReadingBookmarkPin.image(style: .outline, badge: .ellipsis))
             }
-        case .available(let slot):
+        case .available(let bookmark):
             Row(
                 title: l("ayah.menu.reading-bookmark.title"),
-                subtitle: .text(slot?.displayName ?? "Move here"),
+                subtitle: .text(bookmark?.displayName ?? "Move here"),
                 subtitlePlacement: .below,
                 action: dataObject.actions.showReadingBookmarkMenu
             ) {
                 Image(uiImage: ReadingBookmarkPin.image(
-                    style: slot == nil ? .outline : .filled,
+                    style: bookmark == nil ? .outline : .filled,
                     badge: .ellipsis
                 ))
-                .foregroundColor(slot?.swiftUIColor ?? .label)
+                .foregroundColor(bookmark?.slot.swiftUIColor ?? .label)
             }
         }
     }
@@ -563,7 +563,7 @@ private func previewDataObject(
         repeatSubtitle: "selected verses",
         actions: previewActions,
         isTranslationView: isTranslationView,
-        readingBookmarkState: .available(slot: nil)
+        readingBookmarkState: .available(bookmark: nil)
     )
     #else
     return AyahMenuUI.DataObject(

--- a/UI/NoorUI/Tests/ReadingBookmarkDisplayNameTests.swift
+++ b/UI/NoorUI/Tests/ReadingBookmarkDisplayNameTests.swift
@@ -1,0 +1,20 @@
+#if QURAN_SYNC
+import QuranAnnotations
+import QuranKit
+import XCTest
+@testable import NoorUI
+
+final class ReadingBookmarkDisplayNameTests: XCTestCase {
+    func test_displayName_usesCustomNameAndFallsBackToSlot() {
+        let ayah = Quran.hafsMadani1405.suras[1].verses[4]
+        for name in ["Hifz", nil] as [String?] {
+            let bookmark = PlacedReadingBookmark(
+                id: "coral", slot: .coral, placement: .ayah(ayah), modifiedOn: .distantPast, name: name
+            )
+
+            XCTAssertEqual(bookmark.displayName, name ?? ReadingBookmarkSlot.coral.displayName)
+            XCTAssertEqual(ReadingBookmark(bookmark).displayName, bookmark.displayName)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Reading bookmark menus and the reader toolbar now use a bookmark’s custom name, falling back to its color name when no custom name is set. A shared `displayName` property keeps the ayah menu, bookmark list, and bookmark picker consistent.

The ayah annotation feature is excluded from this PR.

Validation: built the sync Example app and the full no-sync package from an isolated checkout containing only this PR; SwiftFormat passed. Updated regression coverage; tests were not run, as requested.
