### PR TITLE
fix: normalize search input from Urdu, Farsi and Pashto keyboards

### DIFF
--- a/Domain/QuranTextKit/Sources/Search/Searchers/CompositeSearcher.swift
+++ b/Domain/QuranTextKit/Sources/Search/Searchers/CompositeSearcher.swift
@@ -51,7 +51,7 @@ public struct CompositeSearcher {
     // MARK: Public
 
     public func autocomplete(term: String, quran: Quran) async -> [SearchText] {
-        guard let term = SearchTerm(term) else {
+        guard let term = SearchTerm(term, normalizeUnicode: false) else {
             return []
         }
         logger.info("Autocompleting term: \(term.compactQuery)")

--- a/Domain/QuranTextKit/Sources/Search/Searchers/SearchTerm.swift
+++ b/Domain/QuranTextKit/Sources/Search/Searchers/SearchTerm.swift
@@ -47,9 +47,9 @@ private enum SearchRegex {
         // match: ئﻯي
         "\u{0626}": "\u{0626}\u{0649}\u{064a}",
 
-        // The letters below are typed on Urdu, Farsi and Pashto keyboards in place of
-        // the Arabic letters used by the mushaf, so a search from those keyboards has
-        // to reach the Arabic spelling.
+        // Tolerant keyboard substitutions for Urdu, Farsi and Pashto input.
+        // These are search approximations, not linguistic equivalences. Keep the
+        // original letter in each class so it can still match translation text.
 
         // given: ک
         // match: كک
@@ -62,6 +62,10 @@ private enum SearchRegex {
         // given: ے
         // match: يﻯے
         "\u{06d2}": "\u{064a}\u{0649}\u{06d2}",
+
+        // given: ۓ
+        // match: ئيىۓ (same tolerance as Arabic yeh with hamza)
+        "\u{06d3}": "\u{0626}\u{064a}\u{0649}\u{06d3}",
 
         // given: ې
         // match: يﻯې
@@ -99,12 +103,13 @@ private enum SearchRegex {
 struct SearchTerm {
     // MARK: Lifecycle
 
-    init?(_ value: String) {
+    init?(_ value: String, normalizeUnicode: Bool = true) {
         compactQuery = value.trimmedWords()
         if compactQuery.isEmpty {
             return nil
         }
-        persistenceQuery = compactQuery.removeInvalidSearchCharacters()
+        let query = normalizeUnicode ? compactQuery.precomposedStringWithCanonicalMapping : compactQuery
+        persistenceQuery = query.removeInvalidSearchCharacters()
         guard let resultRegex = Self.regexForArabicSimilarityCharacters(persistenceQuery) else {
             return nil
         }
@@ -188,7 +193,7 @@ struct SearchTerm {
     ) -> [SearchResult] {
         var results: [SearchResult] = []
         for verse in verses {
-            for text in [verse.text, verse.text.decomposedStringWithCompatibilityMapping] {
+            for text in [verse.text, verse.text.precomposedStringWithCanonicalMapping, verse.text.decomposedStringWithCompatibilityMapping] {
                 let ranges = text.split(separatedBy: queryRegex)
                 if !ranges.isEmpty {
                     let result = SearchResult(text: transform(text), ranges: ranges, ayah: verse.verse)

--- a/Domain/QuranTextKit/Sources/Search/Searchers/SearchTerm.swift
+++ b/Domain/QuranTextKit/Sources/Search/Searchers/SearchTerm.swift
@@ -14,7 +14,6 @@ private enum SearchRegex {
     static let spaceRegex = "\\p{Z}+"
     /// Match unicode categories Marks (M), Punctuation (P), Symbols (S), Control (C) and Arabic Tatweel character.
     static let invalidSearchRegex = "[\\p{M}\\p{P}\\p{S}\\p{C}\u{0640}]"
-    static let arabicSimilarityRegex = "[\u{0627}\u{0623}\u{0621}\u{062a}\u{0629}\u{0647}\u{0649}\u{0626}]"
     static let arabicSimilarityReplacements: [Character: String] = [
         // given: ا
         // match: آأإاﻯ
@@ -47,7 +46,54 @@ private enum SearchRegex {
         // given: ئ
         // match: ئﻯي
         "\u{0626}": "\u{0626}\u{0649}\u{064a}",
+
+        // The letters below are typed on Urdu, Farsi and Pashto keyboards in place of
+        // the Arabic letters used by the mushaf, so a search from those keyboards has
+        // to reach the Arabic spelling.
+
+        // given: ک
+        // match: كک
+        "\u{06a9}": "\u{0643}\u{06a9}",
+
+        // given: ی
+        // match: يﻯی
+        "\u{06cc}": "\u{064a}\u{0649}\u{06cc}",
+
+        // given: ے
+        // match: يﻯے
+        "\u{06d2}": "\u{064a}\u{0649}\u{06d2}",
+
+        // given: ې
+        // match: يﻯې
+        "\u{06d0}": "\u{064a}\u{0649}\u{06d0}",
+
+        // given: ۍ
+        // match: يﻯۍ
+        "\u{06cd}": "\u{064a}\u{0649}\u{06cd}",
+
+        // given: ہ
+        // match: هةہ
+        "\u{06c1}": "\u{0647}\u{0629}\u{06c1}",
+
+        // given: ھ
+        // match: هھ
+        "\u{06be}": "\u{0647}\u{06be}",
+
+        // given: ۃ
+        // match: ةۃ
+        "\u{06c3}": "\u{0629}\u{06c3}",
+
+        // given: ۀ
+        // match: ةهۀ
+        "\u{06c0}": "\u{0629}\u{0647}\u{06c0}",
+
+        // given: ۂ
+        // match: ةهۂ
+        "\u{06c2}": "\u{0629}\u{0647}\u{06c2}",
     ]
+
+    /// Derived from the replacements so a letter cannot be added to one and forgotten in the other.
+    static let arabicSimilarityRegex = "[" + String(arabicSimilarityReplacements.keys) + "]"
 }
 
 struct SearchTerm {

--- a/Domain/QuranTextKit/Tests/CompositeSearcherTests.swift
+++ b/Domain/QuranTextKit/Tests/CompositeSearcherTests.swift
@@ -105,6 +105,14 @@ class CompositeSearcherTests: XCTestCase {
         XCTAssertTrue(results.map(\.text).contains(where: \.isQuranText))
     }
 
+    func testUrduKeyboardFindsTheSameVersesAsArabicKeyboard() async throws {
+        let arabic = try await searcher.search(for: "كتاب", quran: quran)
+        let urdu = try await searcher.search(for: "کتاب", quran: quran)
+
+        XCTAssertFalse(arabic.isEmpty)
+        XCTAssertEqual(urdu, arabic)
+    }
+
     func testMatchTranslation() async throws {
         await testAutocomplete(term: "All")
         try await testSearch(term: "All")

--- a/Domain/QuranTextKit/Tests/CompositeSearcherTests.swift
+++ b/Domain/QuranTextKit/Tests/CompositeSearcherTests.swift
@@ -113,6 +113,15 @@ class CompositeSearcherTests: XCTestCase {
         XCTAssertEqual(urdu, arabic)
     }
 
+    func testCanonicalKeyboardEncodingsFindTheSameVerses() async throws {
+        for input in ["رحمۀ", "رحمۂ", "علۓ"] {
+            let composed = try await searcher.search(for: input, quran: quran)
+            let decomposed = try await searcher.search(for: input.decomposedStringWithCanonicalMapping, quran: quran)
+            XCTAssertFalse(composed.isEmpty, input)
+            XCTAssertEqual(decomposed, composed, input)
+        }
+    }
+
     func testMatchTranslation() async throws {
         await testAutocomplete(term: "All")
         try await testSearch(term: "All")

--- a/Domain/QuranTextKit/Tests/SearchTermTests.swift
+++ b/Domain/QuranTextKit/Tests/SearchTermTests.swift
@@ -1,0 +1,62 @@
+//
+//  SearchTermTests.swift
+//
+//
+//  Created by Abdullah Levin on 2026-09-07.
+//
+
+import QuranKit
+import XCTest
+@testable import QuranTextKit
+
+final class SearchTermTests: XCTestCase {
+    // MARK: Internal
+
+    func testKehehMatchesArabicKaf() {
+        XCTAssertTrue(matches("کتاب", in: "ذلك الكتاب لا ريب فيه"))
+    }
+
+    func testYehVariantsMatchArabicYeh() {
+        for yeh in ["ی", "ے", "ې", "ۍ"] {
+            XCTAssertTrue(matches("الذ" + yeh, in: "الذي خلق"), "\(yeh) doesn't match Arabic yeh")
+        }
+    }
+
+    func testHehVariantsMatchArabicHeh() {
+        for heh in ["ہ", "ھ"] {
+            XCTAssertTrue(matches("من" + heh, in: "منه آيات"), "\(heh) doesn't match Arabic heh")
+        }
+    }
+
+    func testTehMarbutaVariantsMatchArabicTehMarbuta() {
+        for tehMarbuta in ["ۃ", "ۀ", "ۂ"] {
+            XCTAssertTrue(matches("رحم" + tehMarbuta, in: "رحمة من ربك"), "\(tehMarbuta) doesn't match Arabic teh marbuta")
+        }
+    }
+
+    func testArabicKeyboardStillMatches() {
+        XCTAssertTrue(matches("الكتاب", in: "ذلك الكتاب لا ريب فيه"))
+        XCTAssertTrue(matches("الذي", in: "الذي خلق"))
+    }
+
+    func testUnrelatedTermDoesNotMatch() {
+        XCTAssertFalse(matches("کتاب", in: "الحمد لله رب العالمين"))
+    }
+
+    func testPersoArabicLettersBecomeWildcardsInThePersistenceQuery() {
+        let term = SearchTerm("کتاب")
+        XCTAssertEqual(term?.persistenceQueryReplacingArabicSimilarityCharactersWithUnderscore(), "___ب")
+    }
+
+    // MARK: Private
+
+    private let verse = Quran.hafsMadani1405.firstVerse
+
+    private func matches(_ term: String, in text: String) -> Bool {
+        guard let searchTerm = SearchTerm(term) else {
+            return false
+        }
+        let results = searchTerm.buildSearchResults(verses: [(verse: verse, text: text)])
+        return !results.isEmpty
+    }
+}

--- a/Domain/QuranTextKit/Tests/SearchTermTests.swift
+++ b/Domain/QuranTextKit/Tests/SearchTermTests.swift
@@ -17,7 +17,7 @@ final class SearchTermTests: XCTestCase {
     }
 
     func testYehVariantsMatchArabicYeh() {
-        for yeh in ["ی", "ے", "ې", "ۍ"] {
+        for yeh in ["ی", "ے", "ې", "ۍ", "ۓ"] {
             XCTAssertTrue(matches("الذ" + yeh, in: "الذي خلق"), "\(yeh) doesn't match Arabic yeh")
         }
     }
@@ -28,7 +28,7 @@ final class SearchTermTests: XCTestCase {
         }
     }
 
-    func testTehMarbutaVariantsMatchArabicTehMarbuta() {
+    func testHehAndTehMarbutaFormsMatchArabicTehMarbuta() {
         for tehMarbuta in ["ۃ", "ۀ", "ۂ"] {
             XCTAssertTrue(matches("رحم" + tehMarbuta, in: "رحمة من ربك"), "\(tehMarbuta) doesn't match Arabic teh marbuta")
         }
@@ -46,6 +46,48 @@ final class SearchTermTests: XCTestCase {
     func testPersoArabicLettersBecomeWildcardsInThePersistenceQuery() {
         let term = SearchTerm("کتاب")
         XCTAssertEqual(term?.persistenceQueryReplacingArabicSimilarityCharactersWithUnderscore(), "___ب")
+    }
+
+    func testCanonicalEncodingsProduceTheSameSearchQuery() throws {
+        for suffix in ["\u{06c0}", "\u{06c2}", "\u{06d3}"] {
+            let composed = try XCTUnwrap(SearchTerm("رحم" + suffix))
+            let decomposed = try XCTUnwrap(SearchTerm("رحم" + suffix.decomposedStringWithCanonicalMapping))
+            XCTAssertEqual(Array(composed.persistenceQuery.unicodeScalars), Array(decomposed.persistenceQuery.unicodeScalars))
+            XCTAssertEqual(composed.persistenceQueryReplacingArabicSimilarityCharactersWithUnderscore(), decomposed.persistenceQueryReplacingArabicSimilarityCharactersWithUnderscore())
+        }
+        XCTAssertTrue(matches("رحم\u{06d5}\u{0654}", in: "رحمة"))
+        XCTAssertTrue(matches("رحم\u{06c1}\u{0654}", in: "رحمة"))
+        XCTAssertTrue(matches("عل\u{06d2}\u{0654}", in: "علي"))
+        XCTAssertTrue(matches("علۓ", in: "علئ"))
+    }
+
+    func testCanonicalNormalizationPreservesOriginalQuery() throws {
+        let input = "cafe\u{0301}"
+        let term = try XCTUnwrap(SearchTerm(input))
+        XCTAssertEqual(Array(term.compactQuery.unicodeScalars), Array(input.unicodeScalars))
+        XCTAssertEqual(Array(term.persistenceQuery.unicodeScalars), Array("café".unicodeScalars))
+        XCTAssertTrue(matches(input, in: "café"))
+        XCTAssertTrue(matches("café", in: input))
+    }
+
+    func testAutocompleteCanRetainItsExistingNormalization() throws {
+        let input = "رحم\u{06d5}\u{0654}"
+        let term = try XCTUnwrap(SearchTerm(input, normalizeUnicode: false))
+        XCTAssertEqual(Array(term.persistenceQuery.unicodeScalars), Array("رحم\u{06d5}".unicodeScalars))
+    }
+
+    func testMappedLettersStillMatchOriginalTranslationLetters() {
+        for letter in ["ک", "ی", "ے", "ې", "ۍ", "ۓ", "ہ", "ھ", "ۃ", "ۀ", "ۂ"] {
+            XCTAssertTrue(matches(letter, in: "لفظ " + letter), letter)
+            XCTAssertFalse(matches(letter, in: "ب"), letter)
+        }
+    }
+
+    func testDistinctConsonantsAreNotMappedToArabicLookalikes() {
+        for (input, text) in [("پ", "ب"), ("چ", "ج"), ("ژ", "ز"), ("گ", "ك")] {
+            XCTAssertFalse(matches(input, in: text))
+            XCTAssertTrue(matches(input, in: input))
+        }
     }
 
     // MARK: Private


### PR DESCRIPTION
Fixes #841. Urdu, Farsi, and Pashto keyboards can produce letters such as `ک` and `ی` where Quran text uses `ك` and `ي`, causing submitted searches to miss matching verses.

The shared search similarity table now covers the relevant keheh, yeh, heh, and ta marbuta forms, including Urdu yeh barree with hamza (`ۓ`). These mappings are tolerant search substitutions, not linguistic equivalences. Each mapping retains the original character so it can still match translation text. Unrelated consonants such as `پ`, `چ`, `ژ`, and `گ` are not mapped to Arabic lookalikes. The SQL wildcard character class is derived from the mapping keys to keep candidate retrieval and regex matching consistent.

Submitted searches now apply canonical Unicode composition before removing marks. This makes composed and decomposed spellings of the same character behave consistently, while preserving the original query for display. Result matching also tries canonically composed text. Autocomplete retains its existing query normalization and database lookup behavior; extending its keyboard support is outside this change. Translation-search routing is unchanged.

Validation:
- All 39 `QuranTextKitTests` passed with sync disabled and enabled, run sequentially to avoid interference through the shared translation fixture directory.
- Regression tests cover equivalent Unicode encodings, accented Latin input, original translation letters, unrelated consonants, and end-to-end Quran search results.
- Existing autocomplete snapshots and the explicit autocomplete-normalization regression test passed.
- `make format-lint` and `git diff --check` passed.
