### PR TITLE
fix: use available simulator runtimes for tests and example launches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BUILD_TOOLS_DIR=./BuildTools
 
 PACKAGE_SCHEME ?= QuranEngine-Package
 PACKAGE_SDK ?= iphonesimulator
-PACKAGE_DESTINATION ?= name=iPhone 17e,OS=26.5
+PACKAGE_DESTINATION ?= name=iPhone 17e,OS=latest
 EXAMPLE_PROJECT ?= Example/QuranEngineApp.xcodeproj
 EXAMPLE_SCHEME ?= QuranEngineApp
 EXAMPLE_SDK ?= iphonesimulator

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ EXAMPLE_SCHEME ?= QuranEngineApp
 EXAMPLE_SDK ?= iphonesimulator
 EXAMPLE_DESTINATION ?= generic/platform=iOS
 EXAMPLE_BUNDLE_IDENTIFIER ?= com.quran.QuranEngineApp
-EXAMPLE_NO_SYNC_SIMULATOR ?= iPhone 17e,26.5
-EXAMPLE_SYNC_SIMULATOR ?= iPhone 17 Pro Max,26.5
+# simctl needs a concrete runtime version when locating the device to launch.
+LATEST_IOS_SIMULATOR_OS = $(shell xcrun simctl list runtimes | sed -nE 's/^iOS ([0-9.]+) .* - com\.apple\.CoreSimulator\.SimRuntime\.iOS-[0-9-]+$$/\1/p' | sort -V | tail -n 1)
+EXAMPLE_NO_SYNC_SIMULATOR ?= iPhone 17e,$(LATEST_IOS_SIMULATOR_OS)
+EXAMPLE_SYNC_SIMULATOR ?= iPhone 17 Pro Max,$(LATEST_IOS_SIMULATOR_OS)
 DERIVED_DATA_DIR ?= .build/DerivedData
 GIT_COMMON_DIR := $(shell git rev-parse --path-format=absolute --git-common-dir)
 QURAN_WORKSPACE_DIR := $(abspath $(GIT_COMMON_DIR)/../..)


### PR DESCRIPTION
Fixes #1037: package CI can fail before building when a runner image does not have the pinned iOS 26.5 simulator runtime.

Package builds and tests now use `name=iPhone 17e,OS=latest`. Example launch targets also default to the newest available installed iOS runtime, keeping the existing iPhone 17e and iPhone 17 Pro Max device choices. Since `simctl` requires a concrete version for device lookup, the example defaults resolve that version from installed runtimes and pass it to both the build destination and launcher. Explicit simulator and destination overrides remain supported.

Validation:
- Checked all five example launch command expansions, including local sync and What's New flows.
- Verified numeric version ordering (26.10 after 26.5), exclusion of unavailable and non-iOS runtimes, and explicit version overrides using a temporary `xcrun` fixture.
- Verified both default example launch commands resolve to iOS 26.5 on a machine with iOS 18.6, 26.0, and 26.5 installed.

The original failure depends on which runner image CI receives. A green run alone does not verify behavior on the older image; the evidence and affected runs are documented in #1037.
