### PR TITLE
feat: append a quran.com link when sharing an ayah

### DIFF
--- a/Domain/QuranTextKit/Sources/ShareableText/ShareableVerseTextRetriever.swift
+++ b/Domain/QuranTextKit/Sources/ShareableText/ShareableVerseTextRetriever.swift
@@ -52,7 +52,7 @@ public struct ShareableVerseTextRetriever {
         async let translationText = translations(for: verses)
 
         let result = try await [arabicText, translationText].flatMap { $0 }
-        return result + ["", versesSummary(verses)]
+        return result + ["", versesSummary(verses), quranComURL(verses)]
     }
 
     // MARK: Private
@@ -68,6 +68,16 @@ public struct ShareableVerseTextRetriever {
             return verses[0].localizedName
         }
         return "\(verses[0].localizedName) - \(verses.last!.localizedName)"
+    }
+
+    private func quranComURL(_ verses: [AyahNumber]) -> String {
+        let first = verses[0]
+        let last = verses.last!
+        let suraNumber = first.sura.suraNumber
+        if verses.count > 1, last.sura.suraNumber == suraNumber {
+            return "https://quran.com/\(suraNumber)/\(first.ayah)-\(last.ayah)"
+        }
+        return "https://quran.com/\(suraNumber)/\(first.ayah)"
     }
 
     private func arabicText(for verse: AyahNumber) async throws -> String {

--- a/Domain/QuranTextKit/Tests/ShareableVerseTextRetrieverTests.swift
+++ b/Domain/QuranTextKit/Tests/ShareableVerseTextRetrieverTests.swift
@@ -54,13 +54,15 @@ final class ShareableVerseTextRetrieverTests: XCTestCase {
                 verses: [quran.suras[0].verses[2]],
                 result: ["\(rightToLeftMark)ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ٣ ﴾\(endMark)",
                          "",
-                         "Al-Fātihah, Ayah 3"]
+                         "Al-Fātihah, Ayah 3",
+                         "https://quran.com/1/3"]
             ),
             (
                 verses: [quran.suras[0].verses[0], quran.suras[0].verses[1], quran.suras[0].verses[2]],
                 result: ["\(rightToLeftMark)بِسۡمِ ٱللَّهِ ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ١ ﴾\(endMark) \(rightToLeftMark)ٱلۡحَمۡدُ لِلَّهِ رَبِّ ٱلۡعَـٰلَمِینَ﴿ ٢ ﴾\(endMark) \(rightToLeftMark)ٱلرَّحۡمَـٰنِ ٱلرَّحِیمِ﴿ ٣ ﴾\(endMark)",
                          "",
-                         "Al-Fātihah, Ayah 1 - Al-Fātihah, Ayah 3"]
+                         "Al-Fātihah, Ayah 1 - Al-Fātihah, Ayah 3",
+                         "https://quran.com/1/1-3"]
             ),
         ]
         for test in tests {
@@ -83,7 +85,8 @@ final class ShareableVerseTextRetrieverTests: XCTestCase {
                          "• Sahih International:",
                          TestData.translationTextAt(translations[1], quran.suras[0].verses[2]),
                          "",
-                         "Al-Fātihah, Ayah 3"]
+                         "Al-Fātihah, Ayah 3",
+                         "https://quran.com/1/3"]
             ),
             (
                 verses: [quran.suras[0].verses[0], quran.suras[0].verses[1], quran.suras[0].verses[2]],
@@ -99,13 +102,22 @@ final class ShareableVerseTextRetrieverTests: XCTestCase {
                          TestData.translationTextAt(translations[1], quran.suras[0].verses[1]),
                          TestData.translationTextAt(translations[1], quran.suras[0].verses[2]),
                          "",
-                         "Al-Fātihah, Ayah 1 - Al-Fātihah, Ayah 3"]
+                         "Al-Fātihah, Ayah 1 - Al-Fātihah, Ayah 3",
+                         "https://quran.com/1/1-3"]
             ),
         ]
         for test in tests {
             let versesText = try await shareableTextRetriever.textForVerses(test.verses)
             XCTAssertEqual(test.result, versesText)
         }
+    }
+
+    func testShareArabicTextAcrossSuras() async throws {
+        statePreferences.quranMode = .arabic
+
+        let verses = [quran.suras[0].verses.last!, quran.suras[1].verses[0]]
+        let versesText = try await shareableTextRetriever.textForVerses(verses)
+        XCTAssertEqual(versesText.last, "https://quran.com/1/7")
     }
 
     func testShareTranslationTextReferenceVerse() async throws {
@@ -119,7 +131,8 @@ final class ShareableVerseTextRetrieverTests: XCTestCase {
                                          "• Khan & Hilai:",
                                          "See ayah 38.",
                                          "",
-                                         "Al-Baqarah, Ayah 50"])
+                                         "Al-Baqarah, Ayah 50",
+                                         "https://quran.com/2/50"])
 
         let verseSavedAsTextReference = try await shareableTextRetriever.textForVerses([quran.suras[1].verses[50]])
         XCTAssertEqual(verseSavedAsTextReference, ["\(rightToLeftMark)وَإِذۡ وَ ٰ⁠عَدۡنَا مُوسَىٰۤ أَرۡبَعِینَ لَیۡلَةࣰ ثُمَّ ٱتَّخَذۡتُمُ ٱلۡعِجۡلَ مِنۢ بَعۡدِهِۦ وَأَنتُمۡ ظَـٰلِمُونَ﴿ ٥١ ﴾\(endMark)",
@@ -127,7 +140,8 @@ final class ShareableVerseTextRetrieverTests: XCTestCase {
                                                    "• Khan & Hilai:",
                                                    "See ayah 38.",
                                                    "",
-                                                   "Al-Baqarah, Ayah 51"])
+                                                   "Al-Baqarah, Ayah 51",
+                                                   "https://quran.com/2/51"])
     }
 
     // MARK: Private

--- a/Features/NotesFeature/Tests/NotesViewModelTests.swift
+++ b/Features/NotesFeature/Tests/NotesViewModelTests.swift
@@ -205,7 +205,8 @@ final class NotesViewModelTests: XCTestCase {
 
         XCTAssertTrue(text.hasPrefix("My note\n\n"))
         XCTAssertTrue(text.contains("﴿ ١ ﴾"))
-        XCTAssertTrue(text.hasSuffix("Al-Fātihah, Ayah 1"))
+        XCTAssertTrue(text.contains("Al-Fātihah, Ayah 1"))
+        XCTAssertTrue(text.hasSuffix("https://quran.com/1/1"))
     }
 
     func test_navigateToNote_navigatesToStartAyah() throws {


### PR DESCRIPTION
Assalamu alaikum wa rahmatuLlahi wa barakatuh,

Fixes #147.

Shared ayah text ended with the verse summary and nothing else, so there was no way back to the verse online. Append a quran.com URL as the final line after the summary.

| What changed | Where |
|---|---|
| Append `quranComURL(verses)` as a new trailing element after `versesSummary(verses)` | `Domain/QuranTextKit/Sources/ShareableText/ShareableVerseTextRetriever.swift` |
| Single-verse and same-sura-range URL forms | `ShareableVerseTextRetriever.quranComURL(_:)` |
| Regression coverage for single verse, same-sura range, and reference-verse cases, plus a new cross-sura case | `Domain/QuranTextKit/Tests/ShareableVerseTextRetrieverTests.swift` |
| Updated an existing NotesFeature test whose assertion depended on the old trailing line | `Features/NotesFeature/Tests/NotesViewModelTests.swift` |

The URL produced for each shape:
- One verse (e.g. Al-Fātihah 3): `https://quran.com/1/3`
- A same-sura range (e.g. Al-Fātihah 1–3): `https://quran.com/1/1-3`
- A selection spanning two suras (e.g. Al-Fātihah 7 through Al-Baqarah 1): `https://quran.com/1/7` — links the first verse only

**What I deliberately did not do**

- Did not build a combined cross-sura URL. quran.com has no single-page URL spanning two suras, so a selection crossing a sura boundary links only the first verse's page.
- Did not add a translation query parameter or reading/edition selector to the URL — kept it to the plain sura/ayah path the maintainer's example showed.
- Did not touch `versesSummary`, the Arabic/translation body formatting, or any caller (`AyahMenuViewModel`, `NotesViewModel`, `HomeViewModel`, `AyahSetViewModel`) — they all just join the returned array, so appending one more line is additive.

**Open questions**

- Is linking only the first verse the right behavior for a cross-sura selection (`https://quran.com/1/7` for Al-Fātihah 7 – Al-Baqarah 1), or would you rather omit the URL entirely in that case?
- Should the URL respect the active reading/mushaf or translation set, or is the plain `sura/ayah` page always correct regardless of app settings?

Validation: `Domain/QuranTextKit/Tests/ShareableVerseTextRetrieverTests.swift`, `Features/NotesFeature/Tests/NotesViewModelTests.swift`. Green fork CI run (Package, PackageSync, ExampleApp, ExampleAppSync, SwiftFormat) on the feature branch: https://github.com/A-Levin/quran-ios/actions/runs/34451506434

**Mutation testing**

Each mutant was pushed to its own throwaway fork PR, run against the same CI, then reverted. The existing share tests assert on the whole output array end-to-end rather than isolating the URL line, so a broken URL trips several tests at once — there is no single dedicated guard test per mutation:

| Mutation | Result | Failing tests |
|---|---|---|
| Single-ayah URL off by one (`first.ayah + 1`) | Killed | `testShareArabicText`, `testShareTranslationText`, `testShareArabicTextAcrossSuras`, `testShareTranslationTextReferenceVerse` |
| Range URL falls back to single-ayah form | Killed | `testShareArabicText`, `testShareTranslationText` only |
| URL omitted entirely | Killed | Same four tests as the off-by-one mutation |

The one meaningful discrimination between mutants: the range→single-ayah mutation leaves `testShareArabicTextAcrossSuras` passing, since that test's expected URL is already the first-verse-only form — consistent with the across-suras case deliberately linking just the first verse.
