### PR TITLE
feat: persist word pointer active state across launches

### DIFF
--- a/Domain/WordTextService/Sources/WordTextPreferences.swift
+++ b/Domain/WordTextService/Sources/WordTextPreferences.swift
@@ -20,8 +20,12 @@ public struct WordTextPreferences {
     @TransformedPreference(wordTextType, transformer: .rawRepresentable(defaultValue: defaultWordTextType))
     public var wordTextType: WordTextType
 
+    @Preference(isWordPointerActive)
+    public var isWordPointerActive: Bool
+
     // MARK: Private
 
     private static let defaultWordTextType = WordTextType.translation
     private static let wordTextType = PreferenceKey<Int>(key: "wordTranslationType", defaultValue: defaultWordTextType.rawValue)
+    private static let isWordPointerActive = PreferenceKey<Bool>(key: "isWordPointerActive", defaultValue: false)
 }

--- a/Domain/WordTextService/Tests/WordTextServiceTests.swift
+++ b/Domain/WordTextService/Tests/WordTextServiceTests.swift
@@ -29,6 +29,18 @@ class WordTextServiceTests: XCTestCase {
         XCTAssertEqual(text, "rabbika")
     }
 
+    func testIsWordPointerActiveDefaultsToFalse() {
+        XCTAssertFalse(preferences.isWordPointerActive)
+    }
+
+    func testIsWordPointerActivePersists() {
+        preferences.isWordPointerActive = true
+        XCTAssertTrue(preferences.isWordPointerActive)
+
+        preferences.isWordPointerActive = false
+        XCTAssertFalse(preferences.isWordPointerActive)
+    }
+
     // MARK: Private
 
     private var service: WordTextService!

--- a/Features/QuranViewFeature/Sources/QuranInteractor.swift
+++ b/Features/QuranViewFeature/Sources/QuranInteractor.swift
@@ -38,6 +38,7 @@ import UIKit
 import UIx
 import VLogging
 import WordPointerFeature
+import WordTextService
 
 @MainActor
 protocol QuranPresentable: UIViewController {
@@ -109,6 +110,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     init(deps: Deps, input: QuranInput) {
         self.deps = deps
         self.input = input
+        isWordPointerActive = WordTextPreferences.shared.isWordPointerActive
         logger.info("Quran: opening quran \(input)")
     }
 
@@ -397,6 +399,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
     func onIsWordPointerActiveUpdated(to isWordPointerActive: Bool) {
         self.isWordPointerActive = isWordPointerActive
+        wordTextPreferences.isWordPointerActive = isWordPointerActive
         if isWordPointerActive {
             if let presenter {
                 showWordPointer(referenceView: presenter.pagesView)
@@ -469,12 +472,13 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     private let readingPreferences = ReadingPreferences.shared
     private let contentStatePreferences = QuranContentStatePreferences.shared
     private let selectedTranslationsPreferences = SelectedTranslationsPreferences.shared
+    private let wordTextPreferences = WordTextPreferences.shared
 
     private var deps: Deps
     private let input: QuranInput
     private var audioBanner: AudioBannerViewModel?
     private var cancellables: Set<AnyCancellable> = []
-    private var isWordPointerActive: Bool = false
+    private var isWordPointerActive: Bool
     private var wordPointer: WordPointerViewController?
 
     private var visiblePageCancellable: AnyCancellable?
@@ -510,6 +514,14 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
         (contentViewController, contentViewModel) = presentQuranContent(with: input)
         presenter?.startHiddenBarsTimer()
+        restoreWordPointerIfNeeded()
+    }
+
+    private func restoreWordPointerIfNeeded() {
+        guard isWordPointerActive, readingPreferences.reading.supportsWordPositions, let presenter else {
+            return
+        }
+        showWordPointer(referenceView: presenter.pagesView)
     }
 
     private func presentTranslationsSelection() {

--- a/Package.swift
+++ b/Package.swift
@@ -810,6 +810,7 @@ private func featuresTargets() -> [[Target]] {
             "NoteEditorFeature",
             "NotesFeature",
             "WordPointerFeature",
+            "WordTextService",
             "TranslationsFeature",
             "TranslationVerseFeature",
             "FeaturesSupport",


### PR DESCRIPTION
Assalamu alaikum wa rahmatuLlahi wa barakatuh,

Fixes #384.

The word pointer toggle in the more menu reset to off on every launch because it only lived in `QuranInteractor`'s in-memory `isWordPointerActive`. This adds an `isWordPointerActive` preference to `WordTextPreferences`, right next to the existing `wordTextType` preference, and has `QuranInteractor` read it at init, write it on every toggle, and restore the pointer overlay on content load when the active reading supports word positions.

| File | Change |
|---|---|
| `Domain/WordTextService/Sources/WordTextPreferences.swift` | Added `isWordPointerActive: Bool` `@Preference`, default `false`, key `"isWordPointerActive"` |
| `Features/QuranViewFeature/Sources/QuranInteractor.swift` | Seed `isWordPointerActive` from the preference in `init`, persist it in `onIsWordPointerActiveUpdated`, and restore the pointer overlay in `loadContent()` via `restoreWordPointerIfNeeded()` (guarded by `readingPreferences.reading.supportsWordPositions`) |
| `Package.swift` | Added `WordTextService` as an explicit dependency of `QuranViewFeature` (previously only reachable transitively through `WordPointerFeature`) |
| `Domain/WordTextService/Tests/WordTextServiceTests.swift` | Added `testIsWordPointerActiveDefaultsToFalse` and `testIsWordPointerActivePersists` |

**Deliberately not done:**
- `TranslationVerseViewController` still builds its `MoreMenuModel` with `isWordPointerActive: false` and `state.wordPointer = .alwaysOff`. That screen never exposes the toggle and its `onIsWordPointerActiveUpdated` is a `fatalError` stub, so there's nothing to restore there.
- No test exercises `QuranInteractor` directly. `QuranViewFeature` does have a `Tests` target, but every existing test in it drives `QuranViewController`/`QuranView`, not the interactor; nothing in the target constructs a `QuranInteractor`, which needs its full `Deps` (audio banner, content, note editor, translations, bookmark, etc. builders). Building that scaffolding just to cover a few lines of preference read/write/restore wiring isn't justified per this repo's testing guidance (fakes only at real boundaries, no protocols introduced solely for testability). The wiring itself is only covered by inspection, not by an automated test.

**Open questions:**
- Should the pointer overlay actually reappear automatically on launch (current behavior), or should persistence only restore the *toggle* state in the more menu, leaving the user to re-enable the overlay explicitly? I went with restoring the overlay since that's what "off by default" in the issue seemed to be complaining about, but it's a product call.

Validation: `make test-no-sync` / `make test-sync` (via fork CI): https://github.com/A-Levin/quran-ios/actions/runs/34450116949 (Package, PackageSync, ExampleApp, ExampleAppSync, SwiftFormat all green).

Mutation testing on the two new preference tests, each reverted after confirming the catch. Clean one-mutation-one-test separation in both cases — each mutant broke only the test guarding that specific behavior, and the other test kept passing:

| Mutation | Result | Test that caught it |
|---|---|---|
| Default value flipped `false` → `true` | `Package` + `PackageSync` fail | `testIsWordPointerActiveDefaultsToFalse` (`XCTAssertFalse failed`); `testIsWordPointerActivePersists` still passed |
| Setter always persists `false`, ignoring the assigned value | `Package` + `PackageSync` fail | `testIsWordPointerActivePersists` (`XCTAssertTrue failed`); `testIsWordPointerActiveDefaultsToFalse` still passed |
