### PR TITLE
test: support private ayah marker integration audits

### DIFF
--- a/Data/LinePagePersistence/Sources/GRDBLinePagePersistence.swift
+++ b/Data/LinePagePersistence/Sources/GRDBLinePagePersistence.swift
@@ -10,7 +10,7 @@ import GRDB
 import QuranKit
 import SQLitePersistence
 
-public struct GRDBLinePagePersistence: LinePagePersistence {
+public struct GRDBLinePagePersistence: LinePagePersistence, LinePageAyahMarkerPersistence {
     // MARK: Lifecycle
 
     init(db: DatabaseConnection) {

--- a/Data/LinePagePersistence/Sources/LinePagePersistence.swift
+++ b/Data/LinePagePersistence/Sources/LinePagePersistence.swift
@@ -9,6 +9,10 @@ import QuranKit
 
 public protocol LinePagePersistence {
     func highlightSpans(_ page: Page) async throws -> [LinePageHighlightSpan]
-    func ayahMarkers(_ page: Page) async throws -> [LinePageAyahMarker]
     func suraHeaders(_ page: Page) async throws -> [LinePageSuraHeader]
+}
+
+/// Reads line-relative ayah markers independently of highlight and sura-header data.
+public protocol LinePageAyahMarkerPersistence {
+    func ayahMarkers(_ page: Page) async throws -> [LinePageAyahMarker]
 }

--- a/Data/WordFramePersistence/Sources/GRDBWordFramePersistence.swift
+++ b/Data/WordFramePersistence/Sources/GRDBWordFramePersistence.swift
@@ -11,7 +11,7 @@ import QuranGeometry
 import QuranKit
 import SQLitePersistence
 
-public struct GRDBWordFramePersistence: WordFramePersistence {
+public struct GRDBWordFramePersistence: WordFramePersistence, AyahMarkerPersistence {
     // MARK: Lifecycle
 
     init(db: DatabaseConnection) {
@@ -47,13 +47,36 @@ public struct GRDBWordFramePersistence: WordFramePersistence {
 
     public func ayahNumbers(_ page: Page) async throws -> [AyahNumberLocation] {
         try await db.read { db in
-            let query = GRDBAyahMarker.filter(GRDBAyahMarker.Columns.page == page.pageNumber)
-            let ayahMarkers = try GRDBAyahMarker.fetchAll(db, query)
-            return ayahMarkers.map { $0.toAyahNumberLocation(quran: page.quran) }
+            if try db.tableExists(GRDBAyahMarker.databaseTableName) {
+                let query = GRDBAyahMarker.filter(GRDBAyahMarker.Columns.page == page.pageNumber)
+                let ayahMarkers = try GRDBAyahMarker.fetchAll(db, query)
+                return ayahMarkers.map { $0.toAyahNumberLocation(quran: page.quran) }
+            }
+
+            return try Self.glyphAyahNumbers(page, database: db)
         }
     }
 
     // MARK: Internal
+
+    /// The existing glyph fallback, exposed internally for resource integration checks.
+    static func glyphAyahNumbers(_ page: Page, database db: Database) throws -> [AyahNumberLocation] {
+        let query = GRDBGlyph.filter(GRDBGlyph.Columns.page == page.pageNumber)
+        let glyphs = try GRDBGlyph.fetchAll(db, query)
+        let finalGlyphs = Dictionary(grouping: glyphs) { glyph in
+            AyahNumber(quran: page.quran, sura: glyph.sura, ayah: glyph.ayah)!
+        }
+        .compactMap { ayah, glyphs in
+            // Some resources repeat positions (Hafs 1440, 2:2). Prefer the later line,
+            // then the leftmost rectangle in Arabic reading order. Remaining geometry
+            // makes the choice independent of database row order.
+            glyphs.max {
+                ($0.position, $0.line, -$0.minX, $0.minY, $0.maxY, -$0.maxX)
+                    < ($1.position, $1.line, -$1.minX, $1.minY, $1.maxY, -$1.maxX)
+            }?.toAyahNumberLocation(ayah: ayah)
+        }
+        return finalGlyphs.sorted { $0.ayah < $1.ayah }
+    }
 
     let db: DatabaseConnection
 }
@@ -113,6 +136,14 @@ extension GRDBGlyph {
             maxX: maxX,
             minY: minY,
             maxY: maxY
+        )
+    }
+
+    func toAyahNumberLocation(ayah: AyahNumber) -> AyahNumberLocation {
+        return AyahNumberLocation(
+            ayah: ayah,
+            x: (minX + maxX) / 2,
+            y: (minY + maxY) / 2
         )
     }
 }

--- a/Data/WordFramePersistence/Sources/WordFramePersistence.swift
+++ b/Data/WordFramePersistence/Sources/WordFramePersistence.swift
@@ -11,5 +11,9 @@ import QuranKit
 public protocol WordFramePersistence {
     func wordFrameCollectionForPage(_ page: Page) async throws -> [WordFrame]
     func suraHeaders(_ page: Page) async throws -> [SuraHeaderLocation]
+}
+
+/// Reads ayah marker locations independently of word-frame and sura-header data.
+public protocol AyahMarkerPersistence {
     func ayahNumbers(_ page: Page) async throws -> [AyahNumberLocation]
 }

--- a/Domain/ImageService/Sources/ImageDataService.swift
+++ b/Domain/ImageService/Sources/ImageDataService.swift
@@ -28,9 +28,13 @@ extension ImageDataServiceError: LocalizedError {
 public struct ImageDataService {
     // MARK: Lifecycle
 
-    public init(ayahInfoDatabase: URL, imagesURL: URL) {
+    public init(ayahInfoDatabase: URL, imagesURL: URL, ayahMarkerURL: URL?) {
         self.imagesURL = imagesURL
-        persistence = GRDBWordFramePersistence(fileURL: ayahInfoDatabase)
+        let persistence = GRDBWordFramePersistence(fileURL: ayahInfoDatabase)
+        self.persistence = persistence
+        ayahMarkerPersistence = ayahMarkerURL.map {
+            GRDBWordFramePersistence(fileURL: $0)
+        } ?? persistence
     }
 
     // MARK: Public
@@ -40,7 +44,7 @@ public struct ImageDataService {
     }
 
     public func ayahNumbers(_ page: Page) async throws -> [AyahNumberLocation] {
-        try await persistence.ayahNumbers(page)
+        try await ayahMarkerPersistence.ayahNumbers(page)
     }
 
     public func imageForPage(_ page: Page) async throws -> ImagePage {
@@ -73,6 +77,7 @@ public struct ImageDataService {
 
     private let processor = WordFrameProcessor()
     private let persistence: WordFramePersistence
+    private let ayahMarkerPersistence: AyahMarkerPersistence
     private let imagesURL: URL
 
     private func logFiles(directory: URL) {

--- a/Domain/ImageService/Sources/LinePageAssetService.swift
+++ b/Domain/ImageService/Sources/LinePageAssetService.swift
@@ -52,16 +52,19 @@ public struct LinePageAssets {
         page: Page,
         ayahInfoDatabaseURL: URL,
         lines: [LineImage],
-        sidelines: [SidelineImage]
+        sidelines: [SidelineImage],
+        ayahMarkerURL: URL?
     ) {
         self.page = page
         self.ayahInfoDatabaseURL = ayahInfoDatabaseURL
         self.lines = lines
         self.sidelines = sidelines
+        self.ayahMarkerURL = ayahMarkerURL
     }
 
     public let page: Page
     public let ayahInfoDatabaseURL: URL
+    public let ayahMarkerURL: URL?
     public let lines: [LineImage]
     public let sidelines: [SidelineImage]
 }
@@ -69,11 +72,12 @@ public struct LinePageAssets {
 public struct LinePageAssetService {
     // MARK: Lifecycle
 
-    public init(readingDirectory: URL?, metrics: LinePageMetrics, quran: Quran, fileSystem: FileSystem = DefaultFileSystem()) {
+    public init(readingDirectory: URL?, metrics: LinePageMetrics, quran: Quran, ayahMarkerURL: URL?, fileSystem: FileSystem = DefaultFileSystem()) {
         self.init(
             readingDirectory: readingDirectory,
             metrics: metrics,
             requiredPageNumbers: quran.pages.map(\.pageNumber),
+            ayahMarkerURL: ayahMarkerURL,
             fileSystem: fileSystem
         )
     }
@@ -83,12 +87,14 @@ public struct LinePageAssetService {
             readingDirectory: readingDirectory,
             metrics: .madaniLinePages(widthParameter: widthParameter),
             requiredPageNumbers: Quran.hafsMadani1440.pages.map(\.pageNumber),
+            ayahMarkerURL: nil,
             fileSystem: fileSystem
         )
     }
 
-    init(readingDirectory: URL?, metrics: LinePageMetrics, requiredPageNumbers: [Int], fileSystem: FileSystem) {
+    init(readingDirectory: URL?, metrics: LinePageMetrics, requiredPageNumbers: [Int], ayahMarkerURL: URL?, fileSystem: FileSystem) {
         self.readingDirectory = readingDirectory
+        self.ayahMarkerURL = ayahMarkerURL
         self.metrics = metrics
         self.requiredPageNumbers = requiredPageNumbers
         self.fileSystem = fileSystem
@@ -124,6 +130,7 @@ public struct LinePageAssetService {
     // MARK: Private
 
     private let readingDirectory: URL?
+    private let ayahMarkerURL: URL?
     private let metrics: LinePageMetrics
     private let requiredPageNumbers: [Int]
     private let fileSystem: FileSystem
@@ -155,7 +162,8 @@ public struct LinePageAssetService {
                 page: page,
                 ayahInfoDatabaseURL: ayahInfoDatabaseURL,
                 lines: lines,
-                sidelines: loadSidelines(pageNumber: page.pageNumber, in: readingDirectory)
+                sidelines: loadSidelines(pageNumber: page.pageNumber, in: readingDirectory),
+                ayahMarkerURL: ayahMarkerURL
             )
         )
     }

--- a/Domain/ImageService/Tests/ImageDataServiceTests.swift
+++ b/Domain/ImageService/Tests/ImageDataServiceTests.swift
@@ -22,15 +22,44 @@ class ImageDataServiceTests: XCTestCase {
     override func setUpWithError() throws {
         service = ImageDataService(
             ayahInfoDatabase: TestResources.resourceURL("hafs_1405_ayahinfo.db"),
-            imagesURL: TestResources.testDataURL.appendingPathComponent("images")
+            imagesURL: TestResources.testDataURL.appendingPathComponent("images"),
+            ayahMarkerURL: nil
         )
+    }
+
+    /// A separate marker database supplies markers without replacing the word-frame/header database.
+    func testSeparateAyahMarkerDatabase() async throws {
+        let markerURL = TestResources.resourceURL("hafs_1421_ayahinfo_1120.db")
+        let page = quran.pages[0]
+        let separate = ImageDataService(
+            ayahInfoDatabase: TestResources.resourceURL("hafs_1405_ayahinfo.db"),
+            imagesURL: TestResources.testDataURL.appendingPathComponent("images"),
+            ayahMarkerURL: markerURL
+        )
+        let markerSource = ImageDataService(
+            ayahInfoDatabase: markerURL,
+            imagesURL: TestResources.testDataURL,
+            ayahMarkerURL: nil
+        )
+        let actualMarkers = try await separate.ayahNumbers(page)
+        let expectedMarkers = try await markerSource.ayahNumbers(page)
+        let originalMarkers = try await service.ayahNumbers(page)
+        XCTAssertEqual(actualMarkers, expectedMarkers)
+        XCTAssertNotEqual(actualMarkers, originalMarkers)
+        let actualHeaders = try await separate.suraHeaders(page)
+        let originalHeaders = try await service.suraHeaders(page)
+        XCTAssertEqual(actualHeaders, originalHeaders)
+        let actualImage = try await separate.imageForPage(page)
+        let originalImage = try await service.imageForPage(page)
+        XCTAssertEqual(actualImage.wordFrames.lines[0].frames, originalImage.wordFrames.lines[0].frames)
     }
 
     func testPageMarkers() async throws {
         let quran = Reading.hafs_1421.quran
         service = ImageDataService(
             ayahInfoDatabase: TestResources.resourceURL("hafs_1421_ayahinfo_1120.db"),
-            imagesURL: URL(string: "invalid")!
+            imagesURL: URL(string: "invalid")!,
+            ayahMarkerURL: nil
         )
 
         var surasHeaders = 0
@@ -41,6 +70,13 @@ class ImageDataServiceTests: XCTestCase {
             surasHeaders += pageSuraHeaders.count
         }
         XCTAssertEqual(surasHeaders, quran.suras.count)
+    }
+
+    func testPageMarkersForMushafWithBakedInMarkers() async throws {
+        for page in quran.pages {
+            let ayahNumbers = try await service.ayahNumbers(page)
+            XCTAssertEqual(ayahNumbers.map(\.ayah), page.verses, "Page \(page.pageNumber)")
+        }
     }
 
     func testWordFrameCollection() async throws {
@@ -76,7 +112,8 @@ class ImageDataServiceTests: XCTestCase {
         let page = quran.pages[0]
         service = ImageDataService(
             ayahInfoDatabase: TestResources.resourceURL("hafs_1405_ayahinfo.db"),
-            imagesURL: imagesURL
+            imagesURL: imagesURL,
+            ayahMarkerURL: nil
         )
 
         do {

--- a/Domain/ImageService/Tests/LinePageAssetServiceTests.swift
+++ b/Domain/ImageService/Tests/LinePageAssetServiceTests.swift
@@ -109,6 +109,7 @@ final class LinePageAssetServiceTests: XCTestCase {
             readingDirectory: rootURL,
             metrics: metrics,
             requiredPageNumbers: requiredPageNumbers,
+            ayahMarkerURL: nil,
             fileSystem: DefaultFileSystem()
         )
     }

--- a/Domain/ReadingService/Sources/ReadingRemoteResources.swift
+++ b/Domain/ReadingService/Sources/ReadingRemoteResources.swift
@@ -17,14 +17,18 @@ public protocol ReadingRemoteResources {
 public struct RemoteResource {
     // MARK: Lifecycle
 
-    public init(url: URL, reading: Reading, version: Int) {
+    public init(url: URL, reading: Reading, version: Int, ayahMarkerURL: URL?) {
         self.url = url
         self.reading = reading
         self.version = version
+        self.ayahMarkerURL = ayahMarkerURL
         downloadDestination = Reading.readingsPath.appendingPathComponent(reading.localPath, isDirectory: true)
     }
 
     // MARK: Public
+
+    /// Optional local marker database, independent of downloads and resource cleanup.
+    public let ayahMarkerURL: URL?
 
     public let downloadDestination: RelativeFilePath
 

--- a/Domain/ReadingService/Sources/ReadingResourcesService.swift
+++ b/Domain/ReadingService/Sources/ReadingResourcesService.swift
@@ -18,6 +18,8 @@ import VLogging
 public actor ReadingResourcesService {
     // MARK: Lifecycle
 
+    /// - Parameter removeOtherReadings: Whether loading a reading deletes other readings' downloaded resources.
+    ///   Integration tests pass `false` to retain resources while checking multiple mushafs.
     public init(
         fileManager: FileSystem = DefaultFileSystem(),
         zipper: Zipper = DefaultZipper(),
@@ -26,13 +28,15 @@ public actor ReadingResourcesService {
         preferencesObservingStarted: EventObserver? = nil,
         preferenceLoadingCompleted: EventObserver? = nil,
         downloader: DownloadManager,
-        remoteResources: ReadingRemoteResources?
+        remoteResources: ReadingRemoteResources?,
+        removeOtherReadings: Bool = true
     ) {
         self.zipper = zipper
         self.fileManager = fileManager
         self.preferencesObservingStarted = preferencesObservingStarted
         self.preferenceLoadingCompleted = preferenceLoadingCompleted
         self.remoteResources = remoteResources
+        self.removeOtherReadings = removeOtherReadings
         self.downloader = ReadingResourceDownloader(downloader: downloader, remoteResources: remoteResources)
         self.scheduler = scheduler
         self.throttleInterval = throttleInterval
@@ -65,10 +69,19 @@ public actor ReadingResourcesService {
             }
             await self?.preferencesObservingStarted?()
             for await reading in readings {
+                guard !Task.isCancelled else { return }
                 await self?.loadResourceInAsyncTask(reading)
             }
         }
         .asCancellableTask()
+    }
+
+    /// Stops observing preferences and cancels this service's current loading task.
+    /// Integration tests stop the hosted app's loader before using their own loader with cleanup disabled,
+    /// preventing the app's loader from deleting resources as tests switch readings.
+    public func stopLoadingResources() {
+        readingsTask = nil
+        readingTask = nil
     }
 
     public func retry() async {
@@ -94,9 +107,11 @@ public actor ReadingResourcesService {
     private let fileManager: FileSystem
     private let downloader: ReadingResourceDownloader
     private let remoteResources: ReadingRemoteResources?
+    private let removeOtherReadings: Bool
 
     private func loadResourceInAsyncTask(_ reading: Reading) {
         readingTask = Task {
+            guard !Task.isCancelled else { return }
             let status = await self.loadResource(of: reading)
             self.send(status, from: reading)
             await self.preferenceLoadingCompleted?()
@@ -105,7 +120,9 @@ public actor ReadingResourcesService {
     }
 
     private func loadResource(of reading: Reading) async -> ResourceStatus {
-        removePreviouslyDownloadedResources(exclude: reading)
+        if removeOtherReadings {
+            removePreviouslyDownloadedResources(exclude: reading)
+        }
         await downloader.cancelDownload(exclude: reading)
 
         logger.info("Resources: Start loading reading resources of: \(reading)")

--- a/Domain/ReadingService/Tests/ReadingRemoteResourcesFake.swift
+++ b/Domain/ReadingService/Tests/ReadingRemoteResourcesFake.swift
@@ -35,6 +35,6 @@ final class ReadingRemoteResourcesFake: ReadingRemoteResources {
 
         let url = urls[reading] ?? defaultURL
         let version = versions[reading] ?? 0
-        return url.map { RemoteResource(url: URL(validURL: $0), reading: reading, version: version) }
+        return url.map { RemoteResource(url: URL(validURL: $0), reading: reading, version: version, ayahMarkerURL: nil) }
     }
 }

--- a/Domain/ReadingService/Tests/ReadingResourcesRetentionTests.swift
+++ b/Domain/ReadingService/Tests/ReadingResourcesRetentionTests.swift
@@ -1,0 +1,53 @@
+import AsyncUtilitiesForTesting
+import BatchDownloaderFake
+import CombineSchedulers
+import QuranKit
+import SystemDependenciesFake
+import XCTest
+@testable import ReadingService
+
+final class ReadingResourcesRetentionTests: XCTestCase {
+    func test_preservesDownloadedResourcesAcrossReadingSwitchesWhenCleanupDisabled() async {
+        let originalReading = ReadingPreferences.shared.reading
+        ReadingPreferences.shared.reading = .hafs_1405
+        defer { ReadingPreferences.shared.reading = originalReading }
+
+        let fileManager = FileSystemFake()
+        let remoteResources = ReadingRemoteResourcesFake()
+        let downloadedFiles = Set(Reading.allReadings.compactMap { remoteResources.resource(for: $0) }.flatMap {
+            [$0.downloadDestination.url, $0.successFilePath.url, $0.extractedVersionFileURL]
+        })
+        fileManager.files = downloadedFiles
+        let context = BatchDownloaderFake.makeContext()
+        defer { context.tearDown() }
+        let (downloader, session) = await context.makeDownloader(fileManager: fileManager)
+        let loadingCompleted = AsyncChannelEventObserver()
+        let service = ReadingResourcesService(
+            fileManager: fileManager,
+            scheduler: .immediate,
+            throttleInterval: .zero,
+            preferenceLoadingCompleted: loadingCompleted,
+            downloader: downloader,
+            remoteResources: remoteResources,
+            removeOtherReadings: false
+        )
+        let collector = PublisherCollector(service.publisher)
+
+        await service.startLoadingResources()
+        await loadingCompleted.waitForNextEvent()
+        XCTAssertEqual(collector.items, [.ready])
+        XCTAssertEqual(fileManager.files, downloadedFiles)
+
+        ReadingPreferences.shared.reading = .hafs_1441
+        await loadingCompleted.waitForNextEvent()
+        XCTAssertEqual(collector.items, [.ready, .ready])
+        XCTAssertEqual(fileManager.files, downloadedFiles)
+
+        ReadingPreferences.shared.reading = .hafs_1421
+        await loadingCompleted.waitForNextEvent()
+        XCTAssertEqual(collector.items, [.ready, .ready, .ready])
+        XCTAssertEqual(fileManager.files, downloadedFiles)
+        XCTAssertTrue(session.downloads.isEmpty)
+        await service.stopLoadingResources()
+    }
+}

--- a/Features/QuranImageFeature/Sources/ContentImageBuilder.swift
+++ b/Features/QuranImageFeature/Sources/ContentImageBuilder.swift
@@ -59,7 +59,8 @@ public struct ContentImageBuilder {
         let readingDirectory = Self.readingDirectory(reading, container: container)
         return ImageDataService(
             ayahInfoDatabase: reading.ayahInfoDatabase(in: readingDirectory),
-            imagesURL: reading.imagesDirectory(in: readingDirectory)
+            imagesURL: reading.imagesDirectory(in: readingDirectory),
+            ayahMarkerURL: container.remoteResources?.resource(for: reading)?.ayahMarkerURL
         )
     }
 
@@ -70,22 +71,23 @@ public struct ContentImageBuilder {
         return LinePageAssetService(
             readingDirectory: Self.readingDirectory(reading, container: container),
             metrics: metrics,
-            quran: reading.quran
+            quran: reading.quran,
+            ayahMarkerURL: container.remoteResources?.resource(for: reading)?.ayahMarkerURL
         )
     }
 
-    // MARK: Private
-
-    private let container: AppDependencies
-    private let highlightsService: QuranHighlightsService
-
-    private static func readingDirectory(_ reading: Reading, container: AppDependencies) -> URL {
+    static func readingDirectory(_ reading: Reading, container: AppDependencies) -> URL {
         let remoteResource = container.remoteResources?.resource(for: reading)
         let remotePath = remoteResource?.downloadDestination.url
         let bundlePath = { Bundle.main.url(forResource: reading.localPath, withExtension: nil) }
         logger.info("Images: Use \(remoteResource != nil ? "remote" : "bundle") For reading \(reading)")
         return remotePath ?? bundlePath()!
     }
+
+    // MARK: Private
+
+    private let container: AppDependencies
+    private let highlightsService: QuranHighlightsService
 }
 
 private extension Reading {

--- a/Features/QuranImageFeature/Sources/ContentLineLayoutBuilder.swift
+++ b/Features/QuranImageFeature/Sources/ContentLineLayoutBuilder.swift
@@ -1,0 +1,59 @@
+import ImageService
+import NoorUI
+import QuranGeometry
+import QuranKit
+import UIKit
+
+/// Shared production layout inputs, also used by the resource integration audit.
+@MainActor
+enum ContentLineLayoutBuilder {
+    static func input(
+        page: Page,
+        availableSize: CGSize,
+        data: LinePageGeometryData,
+        showHeaderFooter: Bool,
+        showSidelines: Bool,
+        showLineDividers: Bool,
+        highlightedVerses: Set<AyahNumber> = []
+    ) -> LinePageGeometryInput {
+        LinePageGeometryInput(
+            availableSize: availableSize,
+            orientation: availableSize.height > availableSize.width ? .portrait : .landscape,
+            pageParity: page.pageNumber.isMultiple(of: 2) ? .even : .odd,
+            displaySettings: LinePageDisplaySettings(
+                showHeaderFooter: showHeaderFooter,
+                showSidelines: showSidelines && !data.sidelines.isEmpty,
+                showLineDividers: showLineDividers && page.pageNumber > 3
+            ),
+            data: data,
+            highlights: LinePageHighlightState(highlightedVerses: highlightedVerses),
+            suraHeaderAspectRatio: suraHeaderAspectRatio
+        )
+    }
+
+    private static var suraHeaderAspectRatio: CGFloat {
+        let image = NoorImage.suraHeader.uiImage
+        return image.size.height / image.size.width
+    }
+
+    static func geometrySidelines(from assets: LinePageAssets) -> [LinePageGeometryData.Sideline] {
+        assets.sidelines.map {
+            LinePageGeometryData.Sideline(
+                id: $0.imageURL.lastPathComponent,
+                targetLine: $0.targetLine,
+                direction: $0.direction,
+                intrinsicSize: imagePixelSize($0.image)
+            )
+        }
+    }
+
+    private static func imagePixelSize(_ image: UIImage) -> CGSize {
+        if let cgImage = image.cgImage {
+            return CGSize(width: CGFloat(cgImage.width), height: CGFloat(cgImage.height))
+        }
+        return CGSize(
+            width: image.size.width * image.scale,
+            height: image.size.height * image.scale
+        )
+    }
+}

--- a/Features/QuranImageFeature/Sources/ContentLineViewModel.swift
+++ b/Features/QuranImageFeature/Sources/ContentLineViewModel.swift
@@ -106,6 +106,9 @@ final class ContentLineViewModel: ObservableObject {
         switch result {
         case .available(let assets):
             let persistence = GRDBLinePagePersistence(fileURL: assets.ayahInfoDatabaseURL)
+            let ayahMarkerPersistence: LinePageAyahMarkerPersistence = assets.ayahMarkerURL.map {
+                GRDBLinePagePersistence(fileURL: $0)
+            } ?? persistence
             self.assets = assets
             geometryData = LinePageGeometryData(
                 metrics: linePageMetrics,
@@ -113,12 +116,12 @@ final class ContentLineViewModel: ObservableObject {
                 highlightSpans: [],
                 ayahMarkers: [],
                 suraHeaders: [],
-                sidelines: geometrySidelines(from: assets)
+                sidelines: ContentLineLayoutBuilder.geometrySidelines(from: assets)
             )
 
             do {
                 async let highlightSpans = persistence.highlightSpans(page)
-                async let ayahMarkers = persistence.ayahMarkers(page)
+                async let ayahMarkers = ayahMarkerPersistence.ayahMarkers(page)
                 async let suraHeaders = persistence.suraHeaders(page)
                 let loadedHighlightSpans = try await highlightSpans
                 let loadedAyahMarkers = try await ayahMarkers
@@ -130,7 +133,7 @@ final class ContentLineViewModel: ObservableObject {
                     highlightSpans: loadedHighlightSpans,
                     ayahMarkers: loadedAyahMarkers,
                     suraHeaders: loadedSuraHeaders,
-                    sidelines: geometrySidelines(from: assets)
+                    sidelines: ContentLineLayoutBuilder.geometrySidelines(from: assets)
                 )
             } catch {
                 logger.warning("Quran Line Page: failed to load overlay data for page \(page.pageNumber): \(error)")
@@ -148,17 +151,10 @@ final class ContentLineViewModel: ObservableObject {
             return nil
         }
 
-        let orientation: LinePageOrientation = availableSize.height > availableSize.width ? .portrait : .landscape
         let layout = geometryEngine.layout(
-            LinePageGeometryInput(
+            ContentLineLayoutBuilder.input(
+                page: page,
                 availableSize: availableSize,
-                orientation: orientation,
-                pageParity: page.pageNumber.isMultiple(of: 2) ? .even : .odd,
-                displaySettings: LinePageDisplaySettings(
-                    showHeaderFooter: showHeaderFooter,
-                    showSidelines: showSidelines && !geometryData.sidelines.isEmpty,
-                    showLineDividers: showLineDividers && page.pageNumber > 3
-                ),
                 data: LinePageGeometryData(
                     metrics: linePageMetrics,
                     lineCount: assets.lines.count,
@@ -167,10 +163,10 @@ final class ContentLineViewModel: ObservableObject {
                     suraHeaders: geometryData.suraHeaders,
                     sidelines: geometryData.sidelines
                 ),
-                highlights: LinePageHighlightState(
-                    highlightedVerses: Set(highlightColorsByVerse.keys)
-                ),
-                suraHeaderAspectRatio: suraHeaderAspectRatio
+                showHeaderFooter: showHeaderFooter,
+                showSidelines: showSidelines,
+                showLineDividers: showLineDividers,
+                highlightedVerses: Set(highlightColorsByVerse.keys)
             )
         )
         currentLayout = layout
@@ -212,32 +208,6 @@ final class ContentLineViewModel: ObservableObject {
     private var cancellables: Set<AnyCancellable> = []
     private var currentLayout: LinePageLayout?
     private var contentFrame: CGRect = .zero
-
-    private var suraHeaderAspectRatio: CGFloat {
-        let image = NoorImage.suraHeader.uiImage
-        return image.size.height / image.size.width
-    }
-
-    private func geometrySidelines(from assets: LinePageAssets) -> [LinePageGeometryData.Sideline] {
-        assets.sidelines.map {
-            LinePageGeometryData.Sideline(
-                id: $0.imageURL.lastPathComponent,
-                targetLine: $0.targetLine,
-                direction: $0.direction,
-                intrinsicSize: imagePixelSize($0.image)
-            )
-        }
-    }
-
-    private func imagePixelSize(_ image: UIImage) -> CGSize {
-        if let cgImage = image.cgImage {
-            return CGSize(width: CGFloat(cgImage.width), height: CGFloat(cgImage.height))
-        }
-        return CGSize(
-            width: image.size.width * image.scale,
-            height: image.size.height * image.scale
-        )
-    }
 
     private func scrollToVerseIfNeededSynchronously() {
         let ayah = highlights.firstScrollingVerse()

--- a/Model/QuranKit/Sources/AyahNumber.swift
+++ b/Model/QuranKit/Sources/AyahNumber.swift
@@ -46,6 +46,11 @@ public struct AyahNumber: Navigatable {
         "<AyahNumber sura=\(sura.suraNumber) ayah=\(ayah)>"
     }
 
+    /// Locale-independent sura and ayah numbers for logs and diagnostics, for example "2:255".
+    public var nonLocalizedDescription: String {
+        "\(sura.suraNumber):\(ayah)"
+    }
+
     public var previous: AyahNumber? {
         if self != sura.firstVerse {
             // same sura


### PR DESCRIPTION
Allow integration audits to switch between downloaded readings without deleting resources and use the same layout inputs as production rendering.

Add a resource-retention option and a way to stop the hosted app's resource loader. Support a separate local ayah-marker database, deterministic marker anchors, shared reading paths, and locale-independent ayah identifiers. Extract the line-page layout input builder for reuse by audits.

Validation: includes resource-retention and marker-source regression coverage. Formatting lint passed locally; tests were not rerun when creating this PR.

First PR in a two-PR stack. The follow-up applies the shared ayah description to diagnostic logs.
