### PR TITLE
refactor: use shared ayah descriptions in diagnostics

### DIFF
--- a/Domain/AnnotationsService/Sources/AnalyticsLibrary+Events.swift
+++ b/Domain/AnnotationsService/Sources/AnalyticsLibrary+Events.swift
@@ -11,7 +11,7 @@ import VLogging
 
 extension AnalyticsLibrary {
     private func logVersesEvent(_ name: String, verses: some Collection<AyahNumber>) {
-        let versesDescription = verses.map(\.shortDescription).joined(separator: ", ")
+        let versesDescription = verses.map(\.nonLocalizedDescription).joined(separator: ", ")
         logger.info("AnalyticsVerses=\(name). Verses: [\(versesDescription)]")
         logEvent(name, value: verses.count.description)
     }
@@ -26,11 +26,5 @@ extension AnalyticsLibrary {
 
     public func updateNote(verses: Set<AyahNumber>) {
         logVersesEvent("UpdateNoteVersesNum", verses: verses)
-    }
-}
-
-private extension AyahNumber {
-    var shortDescription: String {
-        "\(sura):\(ayah)"
     }
 }

--- a/Features/AudioBannerFeature/Sources/AudioBannerViewModel.swift
+++ b/Features/AudioBannerFeature/Sources/AudioBannerViewModel.swift
@@ -397,7 +397,7 @@ public final class AudioBannerViewModel: ObservableObject {
     }
 
     private func playing(ayah: AyahNumber) {
-        logger.info("AudioBanner: playing verse \(ayah)")
+        logger.info("AudioBanner: playing verse \(ayah.nonLocalizedDescription)")
         crashContext.setPlayingAyah(sura: ayah.sura.suraNumber, ayah: ayah.ayah)
         listener?.highlightReadingAyah(ayah)
     }

--- a/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
+++ b/Features/AyahMenuFeature/Sources/AyahMenuViewModel.swift
@@ -159,7 +159,7 @@ final class AyahMenuViewModel {
     // MARK: - Items & Actions
 
     func play() {
-        logger.info("AyahMenu: play tapped. Verses: \(deps.verses)")
+        logger.info("AyahMenu: play tapped. Verses: \(deps.verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         listener?.dismissAyahMenu()
 
         let verses = deps.verses
@@ -168,7 +168,7 @@ final class AyahMenuViewModel {
     }
 
     func repeatVerses() {
-        logger.info("AyahMenu: repeat verses tapped. Verses: \(deps.verses)")
+        logger.info("AyahMenu: repeat verses tapped. Verses: \(deps.verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         listener?.dismissAyahMenu()
 
         let verses = deps.verses
@@ -177,13 +177,13 @@ final class AyahMenuViewModel {
 
     #if QURAN_SYNC
     func bookmark() {
-        logger.info("AyahMenu: bookmark tapped. Verses: \(deps.verses)")
+        logger.info("AyahMenu: bookmark tapped. Verses: \(deps.verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         listener?.showCollectionEditor(for: deps.verses)
     }
 
     #else
     func updateHighlight(color: HighlightColor) async {
-        logger.info("AyahMenu: update verse highlights. Verses: \(deps.verses)")
+        logger.info("AyahMenu: update verse highlights. Verses: \(deps.verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         listener?.dismissAyahMenu()
 
         do {
@@ -201,7 +201,7 @@ final class AyahMenuViewModel {
 
     #if QURAN_SYNC
     func showReadingBookmarkMenu(_ viewController: UIViewController) {
-        logger.info("AyahMenu: show reading bookmark menu. Verses: \(deps.verses)")
+        logger.info("AyahMenu: show reading bookmark menu. Verses: \(deps.verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         listener?.showReadingBookmarkMenu(
             viewController,
             in: deps.sourceView,
@@ -211,28 +211,28 @@ final class AyahMenuViewModel {
     #endif
 
     func deleteNotes() async {
-        logger.info("AyahMenu: delete notes. Verses: \(deps.verses)")
+        logger.info("AyahMenu: delete notes. Verses: \(deps.verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         listener?.dismissAyahMenu()
         await listener?.deleteNotes(in: deps.verses)
     }
 
     func editNote() async {
         #if QURAN_SYNC
-        logger.info("AyahMenu: show notes. Verses: \(deps.verses)")
+        logger.info("AyahMenu: show notes. Verses: \(deps.verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         await listener?.showNotes(for: deps.verses, addingNewNote: deps.notes.isEmpty)
         #else
-        logger.info("AyahMenu: edit notes. Verses: \(deps.verses)")
+        logger.info("AyahMenu: edit notes. Verses: \(deps.verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         await listener?.showNoteEditor(for: deps.verses)
         #endif
     }
 
     func showTranslation() {
-        logger.info("AyahMenu: showTranslation. Verses: \(deps.verses)")
+        logger.info("AyahMenu: showTranslation. Verses: \(deps.verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         listener?.showTranslation(deps.verses)
     }
 
     func copy() {
-        logger.info("AyahMenu: copy. Verses: \(deps.verses)")
+        logger.info("AyahMenu: copy. Verses: \(deps.verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         listener?.dismissAyahMenu()
         Task {
             if let lines = try? await retrieveSelectedAyahText() {
@@ -243,7 +243,7 @@ final class AyahMenuViewModel {
     }
 
     func share() {
-        logger.info("AyahMenu: share. Verses: \(deps.verses)")
+        logger.info("AyahMenu: share. Verses: \(deps.verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         Task {
             if let lines = try? await retrieveSelectedAyahText() {
                 let withNewLines = lines.joined(separator: "\n")

--- a/Features/BookmarksFeature/Sources/AyahSetViewModel.swift
+++ b/Features/BookmarksFeature/Sources/AyahSetViewModel.swift
@@ -53,7 +53,7 @@ final class AyahSetViewModel: ObservableObject {
     }
 
     func navigateTo(_ ayah: AyahNumber) {
-        logger.info("Bookmarks: select ayah set entry at \(ayah)")
+        logger.info("Bookmarks: select ayah set entry at \(ayah.nonLocalizedDescription)")
         navigateToAyah(ayah)
     }
 

--- a/Features/NotesFeature/Sources/NotesViewModel.swift
+++ b/Features/NotesFeature/Sources/NotesViewModel.swift
@@ -171,12 +171,12 @@ final class NotesViewModel: ObservableObject {
     #endif
 
     func navigateTo(_ item: NoteItem) {
-        logger.info("Notes: select note at \(item.note.startAyah)")
+        logger.info("Notes: select note at \(item.note.startAyah.nonLocalizedDescription)")
         navigateTo(item.note.startAyah)
     }
 
     func editNote(_ item: NoteItem) {
-        logger.info("Notes: edit note at \(item.note.startAyah)")
+        logger.info("Notes: edit note at \(item.note.startAyah.nonLocalizedDescription)")
         editNoteAction(item.note)
     }
 
@@ -203,7 +203,7 @@ final class NotesViewModel: ObservableObject {
                 self.error = error
             }
             #else
-            logger.info("Notes: delete note at \(item.note.startAyah)")
+            logger.info("Notes: delete note at \(item.note.startAyah.nonLocalizedDescription)")
             do {
                 try await noteService.removeNotes(with: Array(item.note.verses))
             } catch {

--- a/Features/QuranImageFeature/Sources/ContentImageViewModel.swift
+++ b/Features/QuranImageFeature/Sources/ContentImageViewModel.swift
@@ -127,7 +127,7 @@ class ContentImageViewModel: ObservableObject {
         guard let ayah = highlightsService.highlights.firstScrollingVerse() else {
             return
         }
-        logger.info("Quran Image: scrollToVerseIfNeeded \(ayah)")
+        logger.info("Quran Image: scrollToVerseIfNeeded \(ayah.nonLocalizedDescription)")
         scrollToVerse = ayah
     }
 

--- a/Features/QuranImageFeature/Sources/ContentLineViewModel.swift
+++ b/Features/QuranImageFeature/Sources/ContentLineViewModel.swift
@@ -212,7 +212,7 @@ final class ContentLineViewModel: ObservableObject {
     private func scrollToVerseIfNeededSynchronously() {
         let ayah = highlights.firstScrollingVerse()
         if let ayah {
-            logger.info("Quran Line Page: scrollToVerseIfNeeded \(ayah)")
+            logger.info("Quran Line Page: scrollToVerseIfNeeded \(ayah.nonLocalizedDescription)")
         }
         scrollToVerse = ayah
     }

--- a/Features/QuranTranslationFeature/Sources/ContentTranslationViewModel.swift
+++ b/Features/QuranTranslationFeature/Sources/ContentTranslationViewModel.swift
@@ -238,7 +238,7 @@ public final class ContentTranslationViewModel: ObservableObject {
         do {
             let requestedVerses = verses
             let requestedTranslationIds = selectedTranslations
-            logger.info("Loading translations data; selectedTranslations='\(requestedTranslationIds)'; verses='\(requestedVerses)'")
+            logger.info("Loading translations data; selectedTranslations='\(requestedTranslationIds)'; verses='\(requestedVerses.map(\.nonLocalizedDescription).joined(separator: ", "))'")
 
             let localTranslations = try await localTranslationsRetriever.getLocalTranslations()
             try Task.checkCancellation()
@@ -380,7 +380,7 @@ public final class ContentTranslationViewModel: ObservableObject {
         }
         for item in items(quranFont: reading.quranFont) {
             if item.id.ayah == ayah {
-                logger.info("Quran Translation: scrollToVerseIfNeeded \(ayah)")
+                logger.info("Quran Translation: scrollToVerseIfNeeded \(ayah.nonLocalizedDescription)")
                 scrollToItem = item.id
                 break
             }

--- a/Features/QuranViewFeature/Sources/QuranInteractor.swift
+++ b/Features/QuranViewFeature/Sources/QuranInteractor.swift
@@ -204,7 +204,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     }
 
     func highlightReadingAyah(_ ayah: AyahNumber?) {
-        logger.info("Quran: highlight reading verse \(String(describing: ayah))")
+        logger.info("Quran: highlight reading verse \(ayah?.nonLocalizedDescription ?? "nil")")
         contentViewModel?.highlightReadingAyah(ayah)
     }
 
@@ -261,7 +261,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
     #if QURAN_SYNC
     func showNotes(for verses: [AyahNumber], addingNewNote: Bool) async {
-        logger.info("Quran: show ayah notes. Verses: \(verses)")
+        logger.info("Quran: show ayah notes. Verses: \(verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         contentViewModel?.removeAyahMenuHighlight()
         presenter?.dismissPresentedViewController { [weak self] in
             guard let self else {
@@ -293,7 +293,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
 
     #if QURAN_SYNC
     func showCollectionEditor(for verses: [AyahNumber]) {
-        logger.info("Quran: show bookmark editor. Verses: \(verses)")
+        logger.info("Quran: show bookmark editor. Verses: \(verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         contentViewModel?.removeAyahMenuHighlight()
         presenter?.dismissPresentedViewController { [weak self] in
             guard let self else {
@@ -344,7 +344,7 @@ final class QuranInteractor: WordPointerListener, ContentListener, NoteEditorLis
     }
 
     func presentAyahMenu(in sourceView: UIView, at point: CGPoint, verses: [AyahNumber]) {
-        logger.info("Quran: present ayah menu, verses: \(verses)")
+        logger.info("Quran: present ayah menu, verses: \(verses.map(\.nonLocalizedDescription).joined(separator: ", "))")
         #if QURAN_SYNC
         let highlightVerses = deps.highlightsService.highlights.highlightVerses
         let bookmarkedVerses = Set(deps.syncedCollectionsObserver.collections.flatMap { collection in

--- a/Features/TranslationVerseFeature/Sources/TranslationVerseViewModel.swift
+++ b/Features/TranslationVerseFeature/Sources/TranslationVerseViewModel.swift
@@ -57,14 +57,14 @@ class TranslationVerseViewModel: ObservableObject {
     }
 
     func next() {
-        logger.info("Verse Translation: moving to next verse currentVerse:\(currentVerse)")
+        logger.info("Verse Translation: moving to next verse currentVerse:\(currentVerse.nonLocalizedDescription)")
         if let next = currentVerse.next {
             currentVerse = next
         }
     }
 
     func previous() {
-        logger.info("Verse Translation: moving to previous verse currentVerse:\(currentVerse)")
+        logger.info("Verse Translation: moving to previous verse currentVerse:\(currentVerse.nonLocalizedDescription)")
         if let previous = currentVerse.previous {
             currentVerse = previous
         }


### PR DESCRIPTION
Use the shared locale-independent sura:ayah description in analytics and diagnostic logs across audio, ayah menus, bookmarks, notes, images, and translations. Remove the duplicate private shortDescription helper.

Uses AyahNumber.nonLocalizedDescription introduced in the merged #1041. This PR contains only the logging changes.

Validation: formatting lint and diff whitespace checks passed. Tests were not rerun for these logging-only changes.
