### PR TITLE
Fix translation options and navigation button order

### DIFF
--- a/Features/TranslationVerseFeature/Sources/TranslationVerseViewController.swift
+++ b/Features/TranslationVerseFeature/Sources/TranslationVerseViewController.swift
@@ -91,13 +91,23 @@ class TranslationVerseViewController: UIHostingController<TranslationVerseView> 
             self?.viewModel.previous()
         }
 
+        let arrows: [UIBarButtonItem]
         switch view.effectiveUserInterfaceLayoutDirection {
         case .leftToRight:
-            navigationItem.rightBarButtonItems = [overflow, previous, next]
+            arrows = [next, previous]
         case .rightToLeft:
-            navigationItem.rightBarButtonItems = [overflow, next, previous]
+            arrows = [previous, next]
         @unknown default:
             fatalError("Unhandled case")
+        }
+
+        if #available(iOS 16.0, *) {
+            navigationItem.trailingItemGroups = [
+                UIBarButtonItemGroup(barButtonItems: arrows, representativeItem: nil),
+                UIBarButtonItemGroup(barButtonItems: [overflow], representativeItem: nil),
+            ]
+        } else {
+            navigationItem.rightBarButtonItems = [overflow] + arrows.reversed()
         }
 
         moreButton = overflow

--- a/Features/TranslationVerseFeature/Sources/TranslationVerseViewController.swift
+++ b/Features/TranslationVerseFeature/Sources/TranslationVerseViewController.swift
@@ -69,6 +69,7 @@ class TranslationVerseViewController: UIHostingController<TranslationVerseView> 
     private let viewModel: TranslationVerseViewModel
     private var cancellables: Set<AnyCancellable> = []
 
+    private var moreButton: UIBarButtonItem?
     private var nextButton: UIBarButtonItem?
     private var previousButton: UIBarButtonItem?
 
@@ -99,12 +100,14 @@ class TranslationVerseViewController: UIHostingController<TranslationVerseView> 
             fatalError("Unhandled case")
         }
 
+        moreButton = overflow
         nextButton = next
         previousButton = previous
     }
 
     private func settingsTapped() {
-        guard let item = navigationItem.rightBarButtonItems?.first else {
+        // UIHostingController can move navigation items into trailingItemGroups on iOS 18.
+        guard let item = moreButton else {
             return
         }
         logger.info("Verse Translation: Settings button tapped")


### PR DESCRIPTION
Fix the verse translation sheet’s More button on iOS 18 and keep the navigation controls ordered consistently: adjacent verse arrows followed by More at the trailing edge.

On iOS 18, UIHostingController moves the buttons into `trailingItemGroups`, leaving `rightBarButtonItems` nil. The settings action previously returned before presenting its menu. Retain the More button directly as the popover anchor and configure explicit trailing groups for the arrows and More. Keep the legacy ordering on iOS 15.

Validation:
- Reproduced the original More-button failure on iOS 18.6 and confirmed the nil array in LLDB.
- Verified button order, ayah 12 → 13 → 12 navigation, and opening More on iOS 18.6 and iOS 26.5 simulators.
- Final example-app build and SwiftFormat lint passed. Temporary reproduction code was removed.

Screenshots use an isolated launch of the production translation sheet, without downloaded translations.

| Verified behavior | iOS 18.6 | iOS 26.5 |
| --- | --- | --- |
| Button order | <img src="https://github.com/user-attachments/assets/74dce844-1c96-403e-bf17-27c87a90ce6c" width="300" alt="Button order on iOS 18"> | <img src="https://github.com/user-attachments/assets/117a3e29-3930-49e1-b1e6-55ad805d9496" width="300" alt="Button order on iOS 26"> |
| More opens its menu | <img src="https://github.com/user-attachments/assets/488d4440-6d0f-41ce-8533-049bdc91a9f2" width="300" alt="More opens its menu on iOS 18"> | <img src="https://github.com/user-attachments/assets/61deb9a8-a051-449e-bfd1-ae9eda1d86a2" width="300" alt="More opens its menu on iOS 26"> |
