### PR TITLE
feat: parse audio parameters in quran deep links

### DIFF
--- a/Features/AppStructureFeature/Sources/App/AppViewController.swift
+++ b/Features/AppStructureFeature/Sources/App/AppViewController.swift
@@ -74,7 +74,7 @@ class AppViewController: UITabBarController, UITabBarControllerDelegate, AppPres
         selectedIndex = 0
         homeTab.popToRootViewController(animated: false)
 
-        switch deepLink {
+        switch deepLink.target {
         case .sura(let sura):
             homeTab.quranNavigator.navigateTo(page: sura.page, lastPage: nil)
         case .ayah(let ayah):

--- a/Features/AppStructureFeature/Sources/Launch/QuranDeepLink.swift
+++ b/Features/AppStructureFeature/Sources/Launch/QuranDeepLink.swift
@@ -6,11 +6,25 @@
 //
 
 import Foundation
+import QuranAudio
 import QuranKit
 
-enum QuranDeepLink: Equatable {
+enum QuranDeepLinkTarget: Equatable {
     case sura(Sura)
     case ayah(AyahNumber)
+}
+
+struct QuranDeepLinkAudio: Equatable {
+    let end: AyahNumber?
+    let verseRuns: Runs
+    let listRuns: Runs
+    let reciterId: Int?
+    let playbackRate: Float?
+}
+
+struct QuranDeepLink: Equatable {
+    let target: QuranDeepLinkTarget
+    let audio: QuranDeepLinkAudio?
 }
 
 extension QuranDeepLink {
@@ -19,6 +33,10 @@ extension QuranDeepLink {
     /// Parses links of the form `quran://sura` and `quran://sura/ayah`, matching the
     /// format handled by `QuranForwarderActivity` on Android. Non numeric segments are
     /// skipped, so `quran://sura/2/255` resolves the same way `quran://2/255` does.
+    ///
+    /// Audio playback query parameters (`play`, `to`, `verse_repeat`, `range_repeat`,
+    /// `reciter`, `speed`) are only parsed when `play` is present and truthy; otherwise
+    /// they are ignored entirely and `audio` is `nil`.
     init?(url: URL, quran: Quran) {
         guard let scheme = url.scheme?.lowercased(), Self.supportedSchemes.contains(scheme) else {
             return nil
@@ -29,19 +47,35 @@ extension QuranDeepLink {
             return nil
         }
 
-        guard numbers.count > 1 else {
-            self = .sura(sura)
+        let target: QuranDeepLinkTarget
+        if numbers.count > 1 {
+            guard let ayah = AyahNumber(sura: sura, ayah: numbers[1]) else {
+                return nil
+            }
+            target = .ayah(ayah)
+        } else {
+            target = .sura(sura)
+        }
+
+        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        guard Self.isPlayEnabled(queryItems) else {
+            self.target = target
+            audio = nil
             return
         }
-        guard let ayah = AyahNumber(sura: sura, ayah: numbers[1]) else {
+
+        guard let audio = Self.audio(for: target, queryItems: queryItems) else {
             return nil
         }
-        self = .ayah(ayah)
+        self.target = target
+        self.audio = audio
     }
 
     // MARK: Private
 
     private static let supportedSchemes: Set<String> = ["quran", "quran-ios"]
+    private static let repeatRange = 1 ... 100
+    private static let playbackRateRange: ClosedRange<Float> = 0.25 ... 2.0
 
     /// The authority of `quran://2/255` is the sura, so it is read from the host and
     /// not from the path.
@@ -52,5 +86,107 @@ extension QuranDeepLink {
         }
         segments.append(contentsOf: url.pathComponents.filter { $0 != "/" })
         return segments
+    }
+
+    private static func value(_ name: String, in queryItems: [URLQueryItem]) -> String? {
+        queryItems.first { $0.name == name }?.value
+    }
+
+    private static func isPlayEnabled(_ queryItems: [URLQueryItem]) -> Bool {
+        guard let play = value("play", in: queryItems)?.lowercased() else {
+            return false
+        }
+        return play == "true" || play == "1"
+    }
+
+    private static func audio(for target: QuranDeepLinkTarget, queryItems: [URLQueryItem]) -> QuranDeepLinkAudio? {
+        guard let verseRuns = runs(named: "verse_repeat", in: queryItems) else {
+            return nil
+        }
+        guard let listRuns = runs(named: "range_repeat", in: queryItems) else {
+            return nil
+        }
+        guard let end = end(for: target, queryItems: queryItems) else {
+            return nil
+        }
+        guard let reciterId = reciterId(in: queryItems) else {
+            return nil
+        }
+        guard let playbackRate = playbackRate(in: queryItems) else {
+            return nil
+        }
+        return QuranDeepLinkAudio(
+            end: end,
+            verseRuns: verseRuns,
+            listRuns: listRuns,
+            reciterId: reciterId,
+            playbackRate: playbackRate
+        )
+    }
+
+    private static func runs(named name: String, in queryItems: [URLQueryItem]) -> Runs? {
+        guard let rawValue = value(name, in: queryItems) else {
+            return .finite(1)
+        }
+        if rawValue.lowercased() == "infinite" {
+            return .indefinite
+        }
+        guard let count = Int(rawValue), repeatRange.contains(count) else {
+            return nil
+        }
+        return .finite(count)
+    }
+
+    private static func end(for target: QuranDeepLinkTarget, queryItems: [URLQueryItem]) -> AyahNumber?? {
+        guard let rawValue = value("to", in: queryItems) else {
+            return .some(nil)
+        }
+
+        let components = rawValue.split(separator: ":", omittingEmptySubsequences: false)
+        guard components.count == 2,
+              let suraNumber = Int(components[0]),
+              let ayahNumber = Int(components[1])
+        else {
+            return nil
+        }
+
+        let quran: Quran
+        let start: AyahNumber
+        switch target {
+        case .sura(let sura):
+            quran = sura.quran
+            start = sura.firstVerse
+        case .ayah(let ayah):
+            quran = ayah.quran
+            start = ayah
+        }
+
+        guard let sura = Sura(quran: quran, suraNumber: suraNumber),
+              let endAyah = AyahNumber(sura: sura, ayah: ayahNumber),
+              endAyah >= start
+        else {
+            return nil
+        }
+        return .some(endAyah)
+    }
+
+    private static func reciterId(in queryItems: [URLQueryItem]) -> Int?? {
+        guard let rawValue = value("reciter", in: queryItems) else {
+            return .some(nil)
+        }
+        guard let reciterId = Int(rawValue), reciterId >= 1 else {
+            return nil
+        }
+        return .some(reciterId)
+    }
+
+    private static func playbackRate(in queryItems: [URLQueryItem]) -> Float?? {
+        guard let rawValue = value("speed", in: queryItems) else {
+            return .some(nil)
+        }
+        guard let playbackRate = Float(rawValue), playbackRateRange.contains(playbackRate) else {
+            return nil
+        }
+        return .some(playbackRate)
     }
 }

--- a/Features/AppStructureFeature/Sources/Launch/QuranDeepLink.swift
+++ b/Features/AppStructureFeature/Sources/Launch/QuranDeepLink.swift
@@ -100,31 +100,22 @@ extension QuranDeepLink {
     }
 
     private static func audio(for target: QuranDeepLinkTarget, queryItems: [URLQueryItem]) -> QuranDeepLinkAudio? {
-        guard let verseRuns = runs(named: "verse_repeat", in: queryItems) else {
-            return nil
-        }
-        guard let listRuns = runs(named: "range_repeat", in: queryItems) else {
-            return nil
-        }
-        guard let end = end(for: target, queryItems: queryItems) else {
-            return nil
-        }
-        guard let reciterId = reciterId(in: queryItems) else {
-            return nil
-        }
-        guard let playbackRate = playbackRate(in: queryItems) else {
-            return nil
-        }
-        return QuranDeepLinkAudio(
-            end: end,
-            verseRuns: verseRuns,
-            listRuns: listRuns,
-            reciterId: reciterId,
-            playbackRate: playbackRate
+        try? parseAudio(for: target, queryItems: queryItems)
+    }
+
+    private static func parseAudio(
+        for target: QuranDeepLinkTarget, queryItems: [URLQueryItem]
+    ) throws -> QuranDeepLinkAudio {
+        QuranDeepLinkAudio(
+            end: try end(for: target, queryItems: queryItems),
+            verseRuns: try runs(named: "verse_repeat", in: queryItems),
+            listRuns: try runs(named: "range_repeat", in: queryItems),
+            reciterId: try reciterId(in: queryItems),
+            playbackRate: try playbackRate(in: queryItems)
         )
     }
 
-    private static func runs(named name: String, in queryItems: [URLQueryItem]) -> Runs? {
+    private static func runs(named name: String, in queryItems: [URLQueryItem]) throws -> Runs {
         guard let rawValue = value(name, in: queryItems) else {
             return .finite(1)
         }
@@ -132,14 +123,14 @@ extension QuranDeepLink {
             return .indefinite
         }
         guard let count = Int(rawValue), repeatRange.contains(count) else {
-            return nil
+            throw AudioParameterError.invalid
         }
         return .finite(count)
     }
 
-    private static func end(for target: QuranDeepLinkTarget, queryItems: [URLQueryItem]) -> AyahNumber?? {
+    private static func end(for target: QuranDeepLinkTarget, queryItems: [URLQueryItem]) throws -> AyahNumber? {
         guard let rawValue = value("to", in: queryItems) else {
-            return .some(nil)
+            return nil
         }
 
         let components = rawValue.split(separator: ":", omittingEmptySubsequences: false)
@@ -147,7 +138,7 @@ extension QuranDeepLink {
               let suraNumber = Int(components[0]),
               let ayahNumber = Int(components[1])
         else {
-            return nil
+            throw AudioParameterError.invalid
         }
 
         let quran: Quran
@@ -165,28 +156,32 @@ extension QuranDeepLink {
               let endAyah = AyahNumber(sura: sura, ayah: ayahNumber),
               endAyah >= start
         else {
-            return nil
+            throw AudioParameterError.invalid
         }
-        return .some(endAyah)
+        return endAyah
     }
 
-    private static func reciterId(in queryItems: [URLQueryItem]) -> Int?? {
+    private static func reciterId(in queryItems: [URLQueryItem]) throws -> Int? {
         guard let rawValue = value("reciter", in: queryItems) else {
-            return .some(nil)
+            return nil
         }
         guard let reciterId = Int(rawValue), reciterId >= 1 else {
-            return nil
+            throw AudioParameterError.invalid
         }
-        return .some(reciterId)
+        return reciterId
     }
 
-    private static func playbackRate(in queryItems: [URLQueryItem]) -> Float?? {
+    private static func playbackRate(in queryItems: [URLQueryItem]) throws -> Float? {
         guard let rawValue = value("speed", in: queryItems) else {
-            return .some(nil)
-        }
-        guard let playbackRate = Float(rawValue), playbackRateRange.contains(playbackRate) else {
             return nil
         }
-        return .some(playbackRate)
+        guard let playbackRate = Float(rawValue), playbackRateRange.contains(playbackRate) else {
+            throw AudioParameterError.invalid
+        }
+        return playbackRate
     }
+}
+
+private enum AudioParameterError: Error {
+    case invalid
 }

--- a/Features/AppStructureFeature/Tests/QuranDeepLinkTests.swift
+++ b/Features/AppStructureFeature/Tests/QuranDeepLinkTests.swift
@@ -5,6 +5,7 @@
 //  Created by Abdullah Levin on 2026-09-06.
 //
 
+import QuranAudio
 import QuranKit
 import XCTest
 @testable import AppStructureFeature
@@ -12,37 +13,41 @@ import XCTest
 final class QuranDeepLinkTests: XCTestCase {
     // MARK: Internal
 
+    // MARK: - Target parsing (no audio)
+
     func testSuraOnlyLink() {
-        XCTAssertEqual(deepLink("quran://2"), .sura(sura(2)))
+        XCTAssertEqual(deepLink("quran://2")?.target, .sura(sura(2)))
+        XCTAssertNil(deepLink("quran://2")?.audio)
     }
 
     func testSuraAndAyahLink() {
-        XCTAssertEqual(deepLink("quran://2/255"), .ayah(ayah(sura: 2, ayah: 255)))
+        XCTAssertEqual(deepLink("quran://2/255")?.target, .ayah(ayah(sura: 2, ayah: 255)))
+        XCTAssertNil(deepLink("quran://2/255")?.audio)
     }
 
     func testLegacySchemeIsSupported() {
-        XCTAssertEqual(deepLink("quran-ios://114/6"), .ayah(ayah(sura: 114, ayah: 6)))
+        XCTAssertEqual(deepLink("quran-ios://114/6")?.target, .ayah(ayah(sura: 114, ayah: 6)))
     }
 
     func testSchemeIsCaseInsensitive() {
-        XCTAssertEqual(deepLink("QURAN://1/1"), .ayah(ayah(sura: 1, ayah: 1)))
+        XCTAssertEqual(deepLink("QURAN://1/1")?.target, .ayah(ayah(sura: 1, ayah: 1)))
     }
 
     func testTrailingSlashIsIgnored() {
-        XCTAssertEqual(deepLink("quran://18/"), .sura(sura(18)))
+        XCTAssertEqual(deepLink("quran://18/")?.target, .sura(sura(18)))
     }
 
     func testNonNumericSegmentsAreSkipped() {
-        XCTAssertEqual(deepLink("quran://sura/2/255"), .ayah(ayah(sura: 2, ayah: 255)))
+        XCTAssertEqual(deepLink("quran://sura/2/255")?.target, .ayah(ayah(sura: 2, ayah: 255)))
     }
 
     func testExtraSegmentsAreIgnored() {
-        XCTAssertEqual(deepLink("quran://2/255/anything"), .ayah(ayah(sura: 2, ayah: 255)))
+        XCTAssertEqual(deepLink("quran://2/255/anything")?.target, .ayah(ayah(sura: 2, ayah: 255)))
     }
 
     func testFirstAndLastAyahOfTheQuran() {
-        XCTAssertEqual(deepLink("quran://1/1"), .ayah(quran.firstVerse))
-        XCTAssertEqual(deepLink("quran://114/6"), .ayah(quran.lastVerse))
+        XCTAssertEqual(deepLink("quran://1/1")?.target, .ayah(quran.firstVerse))
+        XCTAssertEqual(deepLink("quran://114/6")?.target, .ayah(quran.lastVerse))
     }
 
     func testUnsupportedSchemeIsRejected() {
@@ -68,7 +73,256 @@ final class QuranDeepLinkTests: XCTestCase {
     }
 
     func testLastAyahOfSuraIsAccepted() {
-        XCTAssertEqual(deepLink("quran://2/286"), .ayah(ayah(sura: 2, ayah: 286)))
+        XCTAssertEqual(deepLink("quran://2/286")?.target, .ayah(ayah(sura: 2, ayah: 286)))
+    }
+
+    // MARK: - play flag
+
+    func testPlayTrueEnablesAudio() {
+        let audio = deepLink("quran://2/255?play=true")?.audio
+        XCTAssertEqual(audio, defaultAudio())
+    }
+
+    func testPlayOneEnablesAudio() {
+        let audio = deepLink("quran://2/255?play=1")?.audio
+        XCTAssertEqual(audio, defaultAudio())
+    }
+
+    func testPlayIsCaseInsensitive() {
+        let audio = deepLink("quran://2/255?play=TRUE")?.audio
+        XCTAssertEqual(audio, defaultAudio())
+    }
+
+    func testPlayFalseValueDoesNotEnableAudio() {
+        XCTAssertNil(deepLink("quran://2/255?play=false")?.audio)
+        XCTAssertNil(deepLink("quran://2/255?play=0")?.audio)
+    }
+
+    func testMissingPlayLeavesAudioNil() {
+        XCTAssertNil(deepLink("quran://2/255")?.audio)
+    }
+
+    func testAudioParametersAreIgnoredWithoutPlay() {
+        let link = deepLink("quran://2/255?to=2:257&verse_repeat=3&range_repeat=infinite&reciter=5&speed=1.5")
+        XCTAssertEqual(link?.target, .ayah(ayah(sura: 2, ayah: 255)))
+        XCTAssertNil(link?.audio)
+    }
+
+    func testInvalidAudioParametersAreIgnoredWithoutPlay() {
+        let link = deepLink("quran://2/255?to=garbage&verse_repeat=abc&reciter=-1&speed=fast")
+        XCTAssertEqual(link?.target, .ayah(ayah(sura: 2, ayah: 255)))
+        XCTAssertNil(link?.audio)
+    }
+
+    func testPlaySuraOnlyLink() {
+        let link = deepLink("quran://2?play=true")
+        XCTAssertEqual(link?.target, .sura(sura(2)))
+        XCTAssertEqual(link?.audio, defaultAudio())
+    }
+
+    // MARK: - verse_repeat
+
+    func testRepeatCountsDefaultToOneWhenPlayIsPresent() {
+        let audio = deepLink("quran://2/255?play=true")?.audio
+        XCTAssertEqual(audio?.verseRuns, .finite(1))
+        XCTAssertEqual(audio?.listRuns, .finite(1))
+    }
+
+    func testVerseRepeatCountSetsFiniteRuns() {
+        let audio = deepLink("quran://2/255?play=true&verse_repeat=3")?.audio
+        XCTAssertEqual(audio?.verseRuns, .finite(3))
+    }
+
+    func testVerseRepeatInfiniteIsIndefinite() {
+        let audio = deepLink("quran://2/255?play=true&verse_repeat=infinite")?.audio
+        XCTAssertEqual(audio?.verseRuns, .indefinite)
+    }
+
+    func testVerseRepeatInfiniteIsCaseInsensitive() {
+        let audio = deepLink("quran://2/255?play=true&verse_repeat=INFINITE")?.audio
+        XCTAssertEqual(audio?.verseRuns, .indefinite)
+    }
+
+    func testVerseRepeatLowerBoundIsAccepted() {
+        let audio = deepLink("quran://2/255?play=true&verse_repeat=1")?.audio
+        XCTAssertEqual(audio?.verseRuns, .finite(1))
+    }
+
+    func testVerseRepeatUpperBoundIsAccepted() {
+        let audio = deepLink("quran://2/255?play=true&verse_repeat=100")?.audio
+        XCTAssertEqual(audio?.verseRuns, .finite(100))
+    }
+
+    func testVerseRepeatZeroIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&verse_repeat=0"))
+    }
+
+    func testVerseRepeatAboveUpperBoundIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&verse_repeat=101"))
+    }
+
+    func testVerseRepeatNegativeIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&verse_repeat=-1"))
+    }
+
+    func testVerseRepeatNonNumericIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&verse_repeat=abc"))
+    }
+
+    // MARK: - range_repeat
+
+    func testRangeRepeatCountSetsFiniteRuns() {
+        let audio = deepLink("quran://2/255?play=true&range_repeat=5")?.audio
+        XCTAssertEqual(audio?.listRuns, .finite(5))
+    }
+
+    func testRangeRepeatInfiniteIsIndefinite() {
+        let audio = deepLink("quran://2/255?play=true&range_repeat=infinite")?.audio
+        XCTAssertEqual(audio?.listRuns, .indefinite)
+    }
+
+    func testRangeRepeatZeroIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&range_repeat=0"))
+    }
+
+    func testRangeRepeatAboveUpperBoundIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&range_repeat=101"))
+    }
+
+    func testRangeRepeatNonNumericIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&range_repeat=abc"))
+    }
+
+    func testVerseAndRangeRepeatAreIndependent() {
+        let audio = deepLink("quran://2/255?play=true&verse_repeat=3&range_repeat=infinite")?.audio
+        XCTAssertEqual(audio?.verseRuns, .finite(3))
+        XCTAssertEqual(audio?.listRuns, .indefinite)
+    }
+
+    // MARK: - to (end of range)
+
+    func testToSetsEndAyah() {
+        let audio = deepLink("quran://2/255?play=true&to=2:257")?.audio
+        XCTAssertEqual(audio?.end, ayah(sura: 2, ayah: 257))
+    }
+
+    func testToAbsentLeavesEndNil() {
+        let audio = deepLink("quran://2/255?play=true")?.audio
+        XCTAssertNil(audio?.end)
+    }
+
+    func testToInLaterSuraIsAccepted() {
+        let audio = deepLink("quran://2/255?play=true&to=3:5")?.audio
+        XCTAssertEqual(audio?.end, ayah(sura: 3, ayah: 5))
+    }
+
+    func testToEqualToStartIsAccepted() {
+        let audio = deepLink("quran://2/255?play=true&to=2:255")?.audio
+        XCTAssertEqual(audio?.end, ayah(sura: 2, ayah: 255))
+    }
+
+    func testToBeforeStartIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&to=2:100"))
+    }
+
+    func testToInEarlierSuraIsRejected() {
+        XCTAssertNil(deepLink("quran://3/5?play=true&to=2:255"))
+    }
+
+    func testMalformedToIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&to=notasuraayah"))
+        XCTAssertNil(deepLink("quran://2/255?play=true&to=2"))
+        XCTAssertNil(deepLink("quran://2/255?play=true&to=2:"))
+        XCTAssertNil(deepLink("quran://2/255?play=true&to=:5"))
+        XCTAssertNil(deepLink("quran://2/255?play=true&to=2:255:3"))
+    }
+
+    func testToWithOutOfRangeSuraIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&to=200:5"))
+    }
+
+    func testToWithOutOfRangeAyahIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&to=2:999"))
+    }
+
+    // MARK: - reciter
+
+    func testReciterIdIsParsed() {
+        let audio = deepLink("quran://2/255?play=true&reciter=5")?.audio
+        XCTAssertEqual(audio?.reciterId, 5)
+    }
+
+    func testReciterIdAbsentIsNil() {
+        let audio = deepLink("quran://2/255?play=true")?.audio
+        XCTAssertNil(audio?.reciterId)
+    }
+
+    func testReciterIdZeroIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&reciter=0"))
+    }
+
+    func testReciterIdNegativeIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&reciter=-3"))
+    }
+
+    func testReciterIdNonNumericIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&reciter=abc"))
+    }
+
+    // MARK: - speed
+
+    func testPlaybackRateIsParsed() {
+        let audio = deepLink("quran://2/255?play=true&speed=1.5")?.audio
+        XCTAssertEqual(audio?.playbackRate, 1.5)
+    }
+
+    func testPlaybackRateAbsentIsNil() {
+        let audio = deepLink("quran://2/255?play=true")?.audio
+        XCTAssertNil(audio?.playbackRate)
+    }
+
+    func testPlaybackRateLowerBoundIsAccepted() {
+        let audio = deepLink("quran://2/255?play=true&speed=0.25")?.audio
+        XCTAssertEqual(audio?.playbackRate, 0.25)
+    }
+
+    func testPlaybackRateUpperBoundIsAccepted() {
+        let audio = deepLink("quran://2/255?play=true&speed=2.0")?.audio
+        XCTAssertEqual(audio?.playbackRate, 2.0)
+    }
+
+    func testPlaybackRateBelowLowerBoundIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&speed=0.2"))
+    }
+
+    func testPlaybackRateAboveUpperBoundIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&speed=2.5"))
+    }
+
+    func testPlaybackRateNonNumericIsRejected() {
+        XCTAssertNil(deepLink("quran://2/255?play=true&speed=fast"))
+    }
+
+    // MARK: - unknown parameters
+
+    func testUnknownQueryParameterIsIgnored() {
+        let link = deepLink("quran://2/255?foo=bar&play=true")
+        XCTAssertEqual(link?.target, .ayah(ayah(sura: 2, ayah: 255)))
+        XCTAssertEqual(link?.audio, defaultAudio())
+    }
+
+    // MARK: - full example
+
+    func testFullExampleFromIssue() {
+        let link = deepLink("quran://2/255?play=true&to=2:257&verse_repeat=3&range_repeat=infinite")
+        XCTAssertEqual(link?.target, .ayah(ayah(sura: 2, ayah: 255)))
+        XCTAssertEqual(link?.audio, QuranDeepLinkAudio(
+            end: ayah(sura: 2, ayah: 257),
+            verseRuns: .finite(3),
+            listRuns: .indefinite,
+            reciterId: nil,
+            playbackRate: nil
+        ))
     }
 
     // MARK: Private
@@ -89,5 +343,15 @@ final class QuranDeepLinkTests: XCTestCase {
 
     private func ayah(sura suraNumber: Int, ayah ayahNumber: Int) -> AyahNumber {
         AyahNumber(quran: quran, sura: suraNumber, ayah: ayahNumber)!
+    }
+
+    private func defaultAudio() -> QuranDeepLinkAudio {
+        QuranDeepLinkAudio(
+            end: nil,
+            verseRuns: .finite(1),
+            listRuns: .finite(1),
+            reciterId: nil,
+            playbackRate: nil
+        )
     }
 }

--- a/Features/AppStructureFeature/Tests/QuranDeepLinkTests.swift
+++ b/Features/AppStructureFeature/Tests/QuranDeepLinkTests.swift
@@ -245,6 +245,20 @@ final class QuranDeepLinkTests: XCTestCase {
         XCTAssertNil(deepLink("quran://2/255?play=true&to=2:999"))
     }
 
+    func testToOnSuraOnlyLinkUsesFirstAyahAsStart() {
+        let audio = deepLink("quran://2?play=true&to=2:10")?.audio
+        XCTAssertEqual(audio?.end, ayah(sura: 2, ayah: 10))
+    }
+
+    func testToOnSuraOnlyLinkEqualToFirstAyahIsAccepted() {
+        let audio = deepLink("quran://2?play=true&to=2:1")?.audio
+        XCTAssertEqual(audio?.end, ayah(sura: 2, ayah: 1))
+    }
+
+    func testToOnSuraOnlyLinkInEarlierSuraIsRejected() {
+        XCTAssertNil(deepLink("quran://3?play=true&to=2:255"))
+    }
+
     // MARK: - reciter
 
     func testReciterIdIsParsed() {

--- a/Package.swift
+++ b/Package.swift
@@ -870,6 +870,8 @@ private func featuresTargets() -> [[Target]] {
             "WhatsNewFeature",
             "AudioUpdater",
             "AppMigrationFeature",
+        ], testDependencies: [
+            "QuranAudio",
         ]),
     ]
 }

--- a/Package.swift
+++ b/Package.swift
@@ -860,6 +860,7 @@ private func featuresTargets() -> [[Target]] {
             "Crashing",
             "FeaturesSupport",
             "QuranKit",
+            "QuranAudio",
             "ReadingService",
             "HomeFeature",
             "BookmarksFeature",
@@ -870,8 +871,6 @@ private func featuresTargets() -> [[Target]] {
             "WhatsNewFeature",
             "AudioUpdater",
             "AppMigrationFeature",
-        ], testDependencies: [
-            "QuranAudio",
         ]),
     ]
 }


### PR DESCRIPTION
Assalamu alaikum wa rahmatuLlahi wa barakatuh,

First layer of #1033. Opening it as code rather than waiting on the open questions there, so the shape of the feature is something concrete to react to — nothing here plays audio, so it is safe to take or reject on its own.

## What this layer does

`QuranDeepLink` becomes a struct with a `target` (`.sura` or `.ayah`, unchanged
behavior from before) and an optional `audio: QuranDeepLinkAudio`. The query
string is parsed with `URLComponents` instead of manual string splitting.

`QuranDeepLinkAudio` carries the parsed intent only:

- `end: AyahNumber?` — the end of the playback range, from `to`
- `verseRuns: Runs` — from `verse_repeat`
- `listRuns: Runs` — from `range_repeat`
- `reciterId: Int?` — from `reciter`
- `playbackRate: Float?` — from `speed`

## What this layer explicitly does NOT do

- It does not play any audio.
- It does not touch `QuranInput`, `QuranInteractor`, or `AudioBannerViewModel`.
- It does not resolve a reciter id to a `Reciter`, and does not snap
  `playbackRate` to `PlaybackSpeed.supportedRates`. Both are deferred to
  whichever layer wires the parsed `audio` into actual playback.
- Nothing about existing navigation behavior changed: `AppViewController` and
  `LaunchStartup` still navigate exactly as before, now switching on
  `deepLink.target` instead of the deep link itself.

## URL contract

| Parameter      | Meaning                                   | Accepted values                                        | Default when `play` present | Behavior when invalid                                  |
|-----------------|--------------------------------------------|---------------------------------------------------------|------------------------------|----------------------------------------------------------|
| `play`         | Enables audio parsing                     | `true`/`1` (case-insensitive) enable; anything else, or absent, does not | n/a | Audio params are ignored entirely; `audio` is `nil`      |
| `to`           | End of playback range                     | `sura:ayah`, both numeric, sura/ayah in range, `to >= start` | `nil` (single ayah/sura start) | Whole link rejected (`nil`)                              |
| `verse_repeat` | Per-verse repeat count                    | `1...100` or `infinite` (case-insensitive)              | `.finite(1)`                 | Whole link rejected (`nil`)                              |
| `range_repeat` | Whole-range repeat count                  | `1...100` or `infinite` (case-insensitive)              | `.finite(1)`                 | Whole link rejected (`nil`)                              |
| `reciter`      | Reciter id                                | Integer `>= 1`                                          | `nil`                        | Whole link rejected (`nil`)                              |
| `speed`        | Playback rate                             | `0.25...2.0`                                            | `nil`                        | Whole link rejected (`nil`)                              |

An unknown query parameter is ignored. When `play` is absent (or not
truthy), every other audio parameter is ignored too — even a malformed one —
and the link still resolves to its `target` with `audio == nil`.

## Decisions where issue #1033 left questions open

- **Repeat-count cap**: `verse_repeat` and `range_repeat` accept `1...100`,
  matching the picker in `AdvancedAudioOptionsView`, which offers `infinite`
  plus `1 ... 100`. Android's playback UI caps at 25, so a link written on one
  platform can ask for a count the other cannot honour. I went with matching
  the iOS UI rather than the Android cap, so a link can express anything a
  user can already set by hand here — happy to lower it to 25 for strict
  parity if you would rather the format stay identical across platforms.
- **Playback rate**: accepted as the continuous range `0.25...2.0` rather
  than validating against `PlaybackSpeed.supportedRates`. Snapping an
  arbitrary rate to the nearest supported step is a decision for the layer
  that actually starts playback, not for parsing.
- **Audio parameters without `play`**: entirely ignored, including malformed
  ones (`to=garbage`, `speed=fast`, etc.) — a deep link without `play` is a
  pure navigation link, so nothing after it is validated as audio input.

## Verification

All five checks green on the branch: https://github.com/A-Levin/quran-ios/actions/runs/34595164865

The tests were written first, against the contract in #1033, and committed before any implementation existed — the first CI run on this branch failed to compile with `cannot find type 'QuranDeepLinkAudio' in scope`, which is the red this work started from.

## Mutation testing

Each mutation was applied on top of the green commit as its own branch and run
through the same CI. Every one was caught, and each failed only the tests that
guard it — no mutation tripped an unrelated test:

| Mutation | Failing tests |
|---|---|
| Remove the `1...100` bound check | `testVerseRepeatZeroIsRejected`, `testVerseRepeatNegativeIsRejected`, `testVerseRepeatAboveUpperBoundIsRejected`, `testRangeRepeatZeroIsRejected`, `testRangeRepeatAboveUpperBoundIsRejected` |
| Parse `infinite` as a finite value | `testVerseRepeatInfiniteIsIndefinite`, `testVerseRepeatInfiniteIsCaseInsensitive`, `testRangeRepeatInfiniteIsIndefinite`, `testVerseAndRangeRepeatAreIndependent`, `testFullExampleFromIssue` |
| Remove the `to`-before-start check | `testToBeforeStartIsRejected`, `testToInEarlierSuraIsRejected`, `testToOnSuraOnlyLinkInEarlierSuraIsRejected` |

The contract questions in #1033 are still open — the cap above, and whether the number should mean times heard or times repeated. This PR takes a position so there is something concrete to argue with; say the word and I will change it.
